### PR TITLE
Fix permission denied when opening service.json

### DIFF
--- a/docker/serverless/gcloud_build_image
+++ b/docker/serverless/gcloud_build_image
@@ -49,8 +49,11 @@ gcloud endpoints configs describe "${CONFIG_ID}" --project="${PROJECT}" \
 cat <<EOF > Dockerfile
 FROM ${BASE_IMAGE}
 
+USER root
 ENV ENDPOINTS_SERVICE_PATH /etc/endpoints/service.json
 COPY service.json \${ENDPOINTS_SERVICE_PATH}
+RUN chown -R envoy:envoy \${ENDPOINTS_SERVICE_PATH} && chmod -R 755 \${ENDPOINTS_SERVICE_PATH}
+USER envoy
 
 ENTRYPOINT ["/env_start_proxy.py"]
 EOF


### PR DESCRIPTION
Fixes permission denied in Config Manager when reading `/etc/endpoints/service.json`.

Tested manually and internally with our CI/CD.