### PR TITLE
Remove gcc

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,7 +1,7 @@
 # Developer Documentation
 
 ESPv2 is based on Envoy Proxy and Config Manager. Envoy written in C++ is
-built using bazel with clang(gcc also works but is unrecommended), and Config Manager written in go is built using go build.
+built using bazel with clang and Config Manager written in go is built using go build.
 
 See the [architecture overview](doc/architecture.md) before getting started.
 

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ integration-test-run-parallel:
 
 integration-test: build  build-envoy build-grpc-interop build-grpc-echo integration-test-run-sequential
 
-integration-debug: build build-envoy build-grpc-interop build-grpc-echo
+integration-debug: build build-envoy-debug build-grpc-interop build-grpc-echo
 	@echo "--> running integration tests and showing debug logs"
 	@go test -timeout 20m ./tests/endpoints/...
 	@go test -v -timeout 20m ./tests/env/... --logtostderr

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ GODIRS	= $(shell go list -f '{{.Dir}}' ./... \
 $(BINDIR):
 	@mkdir -p $(BINDIR)
 
-.PHONY: build build-envoy build-envoy-gcc build-envoy-release build-envoy-debug build-grpc-echo build-grpc-bookstore build-grpc-interop upload-e2e-client-binaries
+.PHONY: build build-envoy build-envoy build-envoy-debug build-grpc-echo build-grpc-bookstore build-grpc-interop upload-e2e-client-binaries
 build: format
 	@echo "--> building"
 	@go build ./src/go/...
@@ -60,21 +60,15 @@ build-envoy-tsan:
 	@CC=clang-8 CXX=clang++-8 bazel build --config=clang-tsan  //src/envoy:envoy
 	@cp -f bazel-bin/src/envoy/envoy bin/
 
-build-envoy-gcc:
-	@echo "--> building envoy (compilation_mode=fastbuild)"
-	@CC=gcc CXX=g++ bazel build --config=release //src/envoy:envoy
-	@cp -f bazel-bin/src/envoy/envoy bin/
 
-build-envoy-release:
+build-envoy:
 	@echo "--> building envoy (compilation_mode=release)"
 	@CC=clang-8 CXX=clang++-8 bazel build --config=clang-release //src/envoy:envoy
 	@cp -f bazel-bin/src/envoy/envoy bin/
 
-build-envoy:build-envoy-release
-
 build-envoy-debug:
 	@echo "--> building envoy (compilation_mode=debug)"
-	@bazel build --config=debug //src/envoy:envoy
+	@CC=clang-8 CXX=clang++-8 bazel build --config=debug //src/envoy:envoy
 	@cp -f bazel-bin/src/envoy/envoy bin/
 
 build-grpc-echo:
@@ -168,9 +162,9 @@ integration-test-run-parallel:
 	@go test -timeout 20m ./tests/utils/... --logtostderr
 	@go test -timeout 20m ./tests/integration_test/... --logtostderr
 
-integration-test: build  build-envoy-gcc build-grpc-interop build-grpc-echo integration-test-run-sequential
+integration-test: build  build-envoy build-grpc-interop build-grpc-echo integration-test-run-sequential
 
-integration-debug: build build-envoy-gcc build-grpc-interop build-grpc-echo
+integration-debug: build build-envoy build-grpc-interop build-grpc-echo
 	@echo "--> running integration tests and showing debug logs"
 	@go test -timeout 20m ./tests/endpoints/...
 	@go test -v -timeout 20m ./tests/env/... --logtostderr

--- a/prow/gcpproxy-build.sh
+++ b/prow/gcpproxy-build.sh
@@ -31,12 +31,11 @@ cd "${ROOT}"
 . ${ROOT}/scripts/all-utilities.sh || { echo 'Cannot load Bash utilities';
 exit 1; }
 
-if [ ! ${USE_RELEASE_BINARY} ]; then
-  echo '======================================================='
-  echo '===================== Setup Cache ====================='
-  echo '======================================================='
-  try_setup_bazel_remote_cache "${PROW_JOB_ID}" "${IMAGE}" "${ROOT}" ""
-fi
+
+echo '======================================================='
+echo '===================== Setup Cache ====================='
+echo '======================================================='
+try_setup_bazel_remote_cache "${PROW_JOB_ID}" "${IMAGE}" "${ROOT}" ""
 
 
 if [ ! -d "$GOPATH/bin" ]; then

--- a/prow/utils/prow_test_utils.sh
+++ b/prow/utils/prow_test_utils.sh
@@ -16,4 +16,3 @@
 
 LONG_RUN_DURATION_IN_HOUR=3
 LONG_RUN_BUCKET="apiproxy-continuous-long-run"
-export USE_RELEASE_BINARY=1

--- a/scripts/all-utilities.sh
+++ b/scripts/all-utilities.sh
@@ -320,11 +320,6 @@ function get_serverless_image_release_name() {
 
 function get_tag_name() {
   local tag_format="%H"
-  if [ ${USE_RELEASE_BINARY} ]; then
-    tag_format="rel-${tag_format}"
-  else
-    tag_format="dev-${tag_format}"
-  fi
   tag_name="$(git show -q HEAD --pretty=format:"${tag_format}")"
   echo -n ${tag_name}
 }

--- a/scripts/release/release-publish.sh
+++ b/scripts/release/release-publish.sh
@@ -25,8 +25,6 @@
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 . ${ROOT}/scripts/all-utilities.sh || { echo "Cannot load Bash utilities"; exit 1; }
 
-# get_[proxy|serverless]_image_name_with_sha will use this environment variable
-USE_RELEASE_BINARY=1
 
 function usage() {
   [[ -n "${1}" ]] && echo "${1}"

--- a/scripts/robot-release.sh
+++ b/scripts/robot-release.sh
@@ -46,11 +46,7 @@ echo '======================================================='
 echo '===================== Build Envoy ====================='
 echo '======================================================='
 
-if [ ${USE_RELEASE_BINARY} ]; then
-  make build-envoy-release
-else
-  make build-envoy-gcc
-fi
+make build-envoy
 
 echo "Checking if docker image $(get_envoy_image_name_with_sha) and image $(get_proxy_image_name_with_sha) exists.."
 


### PR DESCRIPTION
After servicecontrol proto build rule is updated, clang works without bazel cache conflict so remove gcc to build envoy during tests.