### PR TITLE
b/149491061: [Refactor 2/3] Decouple TokenSubscriber platform logic from TokenInfo for IAM and IMDS

### DIFF
--- a/src/envoy/token/BUILD
+++ b/src/envoy/token/BUILD
@@ -1,0 +1,181 @@
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_fuzz_test",
+    "envoy_cc_library",
+    "envoy_cc_test",
+)
+
+package(
+    default_visibility = [
+        "//src/envoy:__subpackages__",
+    ],
+)
+
+envoy_cc_library(
+    name = "iam_token_info_lib",
+    srcs = ["iam_token_info.cc"],
+    hdrs = ["iam_token_info.h"],
+    repository = "@envoy",
+    deps = [
+        ":token_info_lib",
+        "//external:protobuf",
+        "//src/envoy/utils:json_struct_lib",
+        "@envoy//source/common/http:headers_lib",
+        "@envoy//source/common/http:message_lib",
+        "@envoy//source/common/http:utility_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "imds_token_info_lib",
+    srcs = ["imds_token_info.cc"],
+    hdrs = ["imds_token_info.h"],
+    repository = "@envoy",
+    deps = [
+        ":token_info_lib",
+        "//src/envoy/utils:json_struct_lib",
+        "@envoy//source/common/http:headers_lib",
+        "@envoy//source/common/http:message_lib",
+        "@envoy//source/common/http:utility_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "token_subscriber_lib",
+    srcs = ["token_subscriber.cc"],
+    hdrs = ["token_subscriber.h"],
+    repository = "@envoy",
+    deps = [
+        ":token_info_lib",
+        "@envoy//include/envoy/common:time_interface",
+        "@envoy//include/envoy/event:dispatcher_interface",
+        "@envoy//include/envoy/server:filter_config_interface",
+        "@envoy//include/envoy/upstream:cluster_manager_interface",
+        "@envoy//source/common/common:enum_to_int",
+        "@envoy//source/common/http:headers_lib",
+        "@envoy//source/common/http:message_lib",
+        "@envoy//source/common/http:utility_lib",
+        "@envoy//source/common/init:target_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "token_info_lib",
+    hdrs = ["token_info.h"],
+    repository = "@envoy",
+    deps = [
+        "@envoy//source/common/http:message_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "token_subscriber_factory_interface",
+    hdrs = ["token_subscriber_factory.h"],
+    repository = "@envoy",
+    deps = [
+        ":sa_token_generator_lib",
+        ":token_subscriber_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "mocks_lib",
+    hdrs = ["mocks.h"],
+    repository = "@envoy",
+    deps = [
+        ":token_info_lib",
+        ":token_subscriber_factory_interface",
+    ],
+)
+
+envoy_cc_library(
+    name = "token_subscriber_factory_lib",
+    hdrs = ["token_subscriber_factory_impl.h"],
+    repository = "@envoy",
+    deps = [
+        ":iam_token_info_lib",
+        ":imds_token_info_lib",
+        ":token_subscriber_factory_interface",
+        ":token_subscriber_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "sa_token_generator_lib",
+    srcs = ["sa_token_generator.cc"],
+    hdrs = ["sa_token_generator.h"],
+    repository = "@envoy",
+    deps = [
+        "//api/envoy/http/common:base_proto_cc_proto",
+        "//src/api_proxy/auth:lib",
+        "//src/envoy/utils:json_struct_lib",
+        "@envoy//include/envoy/event:dispatcher_interface",
+        "@envoy//include/envoy/server:filter_config_interface",
+        "@envoy//include/envoy/upstream:cluster_manager_interface",
+        "@envoy//source/common/init:target_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "imds_token_info_test",
+    size = "small",
+    srcs = ["imds_token_info_test.cc"],
+    repository = "@envoy",
+    deps = [
+        ":imds_token_info_lib",
+    ],
+)
+
+envoy_cc_fuzz_test(
+    name = "iam_token_subscriber_fuzz_test",
+    srcs = ["iam_token_subscriber_fuzz_test.cc"],
+    corpus = "//tests/fuzz/corpus:iam_token_subscriber_corpus",
+    repository = "@envoy",
+    deps = [
+        ":iam_token_info_lib",
+        ":token_subscriber_lib",
+        "//tests/fuzz/structured_inputs:iam_token_subscriber_proto_cc_proto",
+        "@envoy//test/fuzz:utility_lib",
+        "@envoy//test/mocks/init:init_mocks",
+        "@envoy//test/mocks/server:server_mocks",
+        "@envoy//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "iam_token_info_test",
+    size = "small",
+    srcs = ["iam_token_info_test.cc"],
+    repository = "@envoy",
+    deps = [
+        ":iam_token_info_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "token_subscriber_test",
+    size = "small",
+    srcs = ["token_subscriber_test.cc"],
+    repository = "@envoy",
+    deps = [
+        ":mocks_lib",
+        ":token_subscriber_lib",
+        "@envoy//test/mocks/init:init_mocks",
+        "@envoy//test/mocks/server:server_mocks",
+        "@envoy//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "service_account_token_test",
+    size = "small",
+    srcs = ["sa_token_generator_test.cc"],
+    repository = "@envoy",
+    deps = [
+        ":sa_token_generator_lib",
+        "@envoy//source/common/tracing:http_tracer_lib",
+        "@envoy//test/mocks/init:init_mocks",
+        "@envoy//test/mocks/server:server_mocks",
+        "@envoy//test/test_common:utility_lib",
+    ],
+)

--- a/src/envoy/token/BUILD
+++ b/src/envoy/token/BUILD
@@ -73,6 +73,8 @@ envoy_cc_library(
     hdrs = ["token_subscriber_factory.h"],
     repository = "@envoy",
     deps = [
+        ":iam_token_info_lib",
+        ":imds_token_info_lib",
         ":sa_token_generator_lib",
         ":token_subscriber_lib",
     ],

--- a/src/envoy/token/iam_token_info.cc
+++ b/src/envoy/token/iam_token_info.cc
@@ -1,0 +1,181 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/envoy/token/iam_token_info.h"
+#include "absl/strings/str_cat.h"
+#include "common/http/headers.h"
+#include "common/http/message_impl.h"
+#include "src/envoy/utils/json_struct.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Token {
+
+using Utils::JsonStruct;
+
+// Body field for the sequence of service accounts in a delegation chain.
+constexpr char kDelegatesField[]("delegates");
+
+// The prefix for delegates body field. They must have the following format:
+// projects/-/serviceAccounts/{ACCOUNT_EMAIL_OR_UNIQUEID}, by
+// https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateIdToken.
+constexpr char kDelegatePrefix[]("projects/-/serviceAccounts/");
+
+// Body field to identify the scopes to be included in the OAuth 2.0 access
+// token
+constexpr char kScopesField[]("scope");
+
+// Required header when fetching from the IAM server.
+const Envoy::Http::LowerCaseString kAuthorizationKey("Authorization");
+
+IamTokenInfo::IamTokenInfo(
+    const ::google::protobuf::RepeatedPtrField<std::string>& delegates,
+    const ::google::protobuf::RepeatedPtrField<std::string>& scopes,
+    const GetTokenFunc access_token_fn)
+    : delegates_(delegates),
+      scopes_(scopes),
+      access_token_fn_(access_token_fn) {}
+
+Envoy::Http::MessagePtr IamTokenInfo::prepareRequest(
+    absl::string_view token_url) const {
+  const std::string access_token = access_token_fn_();
+  // Wait the access token to be set.
+  if (access_token.empty()) {
+    // This codes depends on access_token. This periodical pulling is not ideal.
+    // But when both imds_token_subscriber and iam_token_subscriber register to
+    // init_manager,  it will trigger both at the same time. For
+    // easy implementation,  just using periodical pulling for now
+    return nullptr;
+  }
+
+  absl::string_view host, path;
+  Http::Utility::extractHostPathFromUri(token_url, host, path);
+  Envoy::Http::HeaderMapImplPtr headers{new Envoy::Http::HeaderMapImpl{
+      {Envoy::Http::Headers::get().Method, "POST"},
+      {Envoy::Http::Headers::get().Host, std::string(host)},
+      {Envoy::Http::Headers::get().Path, std::string(path)},
+      {kAuthorizationKey, "Bearer " + access_token}}};
+
+  Envoy::Http::MessagePtr message(
+      new Envoy::Http::RequestMessageImpl(std::move(headers)));
+
+  Envoy::ProtobufWkt::Value body;
+  if (!delegates_.empty()) {
+    insertStrListToProto(body, kDelegatesField, delegates_, kDelegatePrefix);
+  }
+
+  if (!scopes_.empty()) {
+    insertStrListToProto(body, kScopesField, scopes_, "");
+  }
+
+  if (!delegates_.empty() || !scopes_.empty()) {
+    std::string bodyStr =
+        MessageUtil::getJsonStringFromMessage(body, false, false);
+    message->body() =
+        std::make_unique<Buffer::OwnedImpl>(bodyStr.data(), bodyStr.size());
+  }
+  return message;
+}
+
+// Access token response is a JSON payload in the format:
+// {
+//   "accessToken": "string",
+//   "expireTime": "Timestamp"
+// }
+bool IamTokenInfo::parseAccessToken(absl::string_view response,
+                                    TokenResult* ret) const {
+  // Parse the JSON into a proto.
+  ::google::protobuf::Struct response_pb;
+  ::google::protobuf::util::Status parse_status =
+      ::google::protobuf::util::JsonStringToMessage(std::string(response),
+                                                    &response_pb);
+  if (!parse_status.ok()) {
+    ENVOY_LOG(error, "Parsing response failed: {}", parse_status.ToString());
+    return false;
+  }
+  JsonStruct json_struct(response_pb);
+
+  // Parse the token.
+  std::string token;
+  parse_status = json_struct.getString("accessToken", &token);
+  if (!parse_status.ok()) {
+    ENVOY_LOG(error, "Parsing response failed for field `accessToken`: {}",
+              parse_status.ToString());
+    return false;
+  }
+
+  // Parse the expiry timestamp.
+  ::google::protobuf::Timestamp expireTime;
+  parse_status = json_struct.getTimestamp("expireTime", &expireTime);
+
+  if (!parse_status.ok()) {
+    ENVOY_LOG(error, "Parsing response failed for field `expireTime`: {}",
+              parse_status.ToString());
+    return false;
+  }
+
+  const std::chrono::seconds& expires_in = std::chrono::seconds(
+      (expireTime - ::google::protobuf::util::TimeUtil::GetCurrentTime())
+          .seconds());
+  ret->token = token;
+  ret->expiry_duration = expires_in;
+  return true;
+}
+
+// Identity token response is a JSON payload in the format:
+// {
+//   "token": "string",
+// }
+bool IamTokenInfo::parseIdentityToken(absl::string_view response,
+                                      TokenResult* ret) const {
+  // Parse the JSON into a proto.
+  ::google::protobuf::Struct response_pb;
+  ::google::protobuf::util::Status parse_status =
+      ::google::protobuf::util::JsonStringToMessage(std::string(response),
+                                                    &response_pb);
+  if (!parse_status.ok()) {
+    ENVOY_LOG(error, "Parsing response failed: {}", parse_status.ToString());
+    return false;
+  }
+  JsonStruct json_struct(response_pb);
+
+  // Parse the token.
+  std::string token;
+  parse_status = json_struct.getString("token", &token);
+  if (!parse_status.ok()) {
+    ENVOY_LOG(error, "Parsing response failed for field `token`: {}",
+              parse_status.ToString());
+    return false;
+  }
+
+  ret->token = token;
+  ret->expiry_duration = kDefaultTokenExpiry;
+  return true;
+}
+
+void IamTokenInfo::insertStrListToProto(
+    Envoy::ProtobufWkt::Value& body, const std::string& key,
+    const ::google::protobuf::RepeatedPtrField<std::string>& val_list,
+    const absl::string_view& val_prefix) const {
+  Envoy::ProtobufWkt::Value vals;
+  for (const auto& val : val_list) {
+    vals.mutable_list_value()->add_values()->set_string_value(
+        absl::StrCat(val_prefix, val));
+  }
+  (*body.mutable_struct_value()->mutable_fields())[key].Swap(&vals);
+}
+
+}  // namespace Token
+}  // namespace Extensions
+}  // namespace Envoy

--- a/src/envoy/token/iam_token_info.cc
+++ b/src/envoy/token/iam_token_info.cc
@@ -50,7 +50,7 @@ IamTokenInfo::IamTokenInfo(
 Envoy::Http::MessagePtr IamTokenInfo::prepareRequest(
     absl::string_view token_url) const {
   const std::string access_token = access_token_fn_();
-  // Wait the access token to be set.
+  // Wait for the access token to be set.
   if (access_token.empty()) {
     // This codes depends on access_token. This periodical pulling is not ideal.
     // But when both imds_token_subscriber and iam_token_subscriber register to

--- a/src/envoy/token/iam_token_info.cc
+++ b/src/envoy/token/iam_token_info.cc
@@ -39,6 +39,9 @@ constexpr char kScopesField[]("scope");
 // Required header when fetching from the IAM server.
 const Envoy::Http::LowerCaseString kAuthorizationKey("Authorization");
 
+// Default token expiry time for ID tokens.
+constexpr std::chrono::seconds kDefaultTokenExpiry(3599);
+
 IamTokenInfo::IamTokenInfo(
     const ::google::protobuf::RepeatedPtrField<std::string>& delegates,
     const ::google::protobuf::RepeatedPtrField<std::string>& scopes,

--- a/src/envoy/token/iam_token_info.h
+++ b/src/envoy/token/iam_token_info.h
@@ -22,6 +22,8 @@ namespace Envoy {
 namespace Extensions {
 namespace Token {
 
+typedef std::function<std::string()> GetTokenFunc;
+
 // `IamTokenInfo` is a bridge `TokenInfo` for parsing
 // identity and access tokens from the IAM server.
 class IamTokenInfo : public TokenInfo {

--- a/src/envoy/token/iam_token_info.h
+++ b/src/envoy/token/iam_token_info.h
@@ -1,0 +1,54 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "common/http/utility.h"
+#include "google/protobuf/repeated_field.h"
+#include "src/envoy/token/token_info.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Token {
+
+// `ImdsTokenInfo` is a bridge `TokenInfo` for parsing
+// identity and access tokens from the Instance Metadata Server.
+class IamTokenInfo : public TokenInfo {
+ public:
+  IamTokenInfo(
+      const ::google::protobuf::RepeatedPtrField<std::string>& delegates,
+      const ::google::protobuf::RepeatedPtrField<std::string>& scopes,
+      const GetTokenFunc access_token_fn);
+
+  Envoy::Http::MessagePtr prepareRequest(
+      absl::string_view token_url) const override;
+  bool parseAccessToken(absl::string_view response,
+                        TokenResult* ret) const override;
+  bool parseIdentityToken(absl::string_view response,
+                          TokenResult* ret) const override;
+
+ private:
+  void insertStrListToProto(
+      Envoy::ProtobufWkt::Value& body, const std::string& key,
+      const ::google::protobuf::RepeatedPtrField<std::string>& val_list,
+      const absl::string_view& val_prefix) const;
+
+  const ::google::protobuf::RepeatedPtrField<std::string>& delegates_;
+  const ::google::protobuf::RepeatedPtrField<std::string> scopes_;
+  const GetTokenFunc access_token_fn_;
+};
+
+}  // namespace Token
+}  // namespace Extensions
+}  // namespace Envoy

--- a/src/envoy/token/iam_token_info.h
+++ b/src/envoy/token/iam_token_info.h
@@ -22,8 +22,8 @@ namespace Envoy {
 namespace Extensions {
 namespace Token {
 
-// `ImdsTokenInfo` is a bridge `TokenInfo` for parsing
-// identity and access tokens from the Instance Metadata Server.
+// `IamTokenInfo` is a bridge `TokenInfo` for parsing
+// identity and access tokens from the IAM server.
 class IamTokenInfo : public TokenInfo {
  public:
   IamTokenInfo(

--- a/src/envoy/token/iam_token_info_test.cc
+++ b/src/envoy/token/iam_token_info_test.cc
@@ -23,6 +23,10 @@ namespace Extensions {
 namespace Token {
 namespace Test {
 
+// Default token expiry time for ID tokens.
+// Should match the value in `iam_token_info.cc`
+constexpr std::chrono::seconds kDefaultTokenExpiry(3599);
+
 class IamTokenInfoTest : public testing::Test {
  protected:
   void SetUp() override {}

--- a/src/envoy/token/iam_token_info_test.cc
+++ b/src/envoy/token/iam_token_info_test.cc
@@ -1,0 +1,215 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/envoy/token/iam_token_info.h"
+
+#include "absl/strings/str_cat.h"
+#include "common/http/message_impl.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Token {
+namespace Test {
+
+class IamTokenInfoTest : public testing::Test {
+ protected:
+  void SetUp() override {}
+
+  TokenInfoPtr info_;
+};
+
+TEST_F(IamTokenInfoTest, FailPreconditions) {
+  // Create info that fails preconditions.
+  ::google::protobuf::RepeatedPtrField<std::string> delegates;
+  ::google::protobuf::RepeatedPtrField<std::string> scopes;
+  Token::GetTokenFunc access_token_fn = []() { return ""; };
+  info_ = std::make_unique<IamTokenInfo>(delegates, scopes, access_token_fn);
+
+  // Call function under test.
+  Envoy::Http::MessagePtr got_msg = info_->prepareRequest("iam-url");
+
+  // Assert preconditions failed.
+  EXPECT_EQ(got_msg, nullptr);
+}
+
+TEST_F(IamTokenInfoTest, SimpleSuccess) {
+  // Create info that fails preconditions.
+  ::google::protobuf::RepeatedPtrField<std::string> delegates;
+  ::google::protobuf::RepeatedPtrField<std::string> scopes;
+  Token::GetTokenFunc access_token_fn = []() { return "valid-access-token"; };
+  info_ = std::make_unique<IamTokenInfo>(delegates, scopes, access_token_fn);
+
+  // Call function under test.
+  Envoy::Http::MessagePtr got_msg =
+      info_->prepareRequest("https://iam-url.com/path1");
+
+  // Assert success.
+  EXPECT_NE(got_msg, nullptr);
+  EXPECT_EQ(got_msg->bodyAsString(), R"()");
+  EXPECT_EQ(got_msg->headers()
+                .get(Envoy::Http::Headers::get().Method)
+                ->value()
+                .getStringView(),
+            "POST");
+  EXPECT_EQ(got_msg->headers()
+                .get(Envoy::Http::Headers::get().Host)
+                ->value()
+                .getStringView(),
+            "iam-url.com");
+  EXPECT_EQ(got_msg->headers()
+                .get(Envoy::Http::Headers::get().Path)
+                ->value()
+                .getStringView(),
+            "/path1");
+  EXPECT_EQ(got_msg->headers()
+                .get(Envoy::Http::Headers::get().Authorization)
+                ->value()
+                .getStringView(),
+            "Bearer valid-access-token");
+}
+
+TEST_F(IamTokenInfoTest, SetDelegatesAndScopes) {
+  // Create info that fails preconditions.
+  ::google::protobuf::RepeatedPtrField<std::string> delegates;
+  delegates.Add("delegate_foo");
+  delegates.Add("delegate_bar");
+  ::google::protobuf::RepeatedPtrField<std::string> scopes;
+  scopes.Add("scope_foo");
+  scopes.Add("scope_bar");
+  Token::GetTokenFunc access_token_fn = []() { return "valid-access-token"; };
+  info_ = std::make_unique<IamTokenInfo>(delegates, scopes, access_token_fn);
+
+  // Call function under test.
+  Envoy::Http::MessagePtr got_msg = info_->prepareRequest("iam-url");
+
+  // Assert success.
+  EXPECT_NE(got_msg, nullptr);
+  EXPECT_EQ(
+      got_msg->bodyAsString(),
+      R"({"scope":["scope_foo","scope_bar"],"delegates":["projects/-/serviceAccounts/delegate_foo","projects/-/serviceAccounts/delegate_bar"]})");
+}
+
+TEST_F(IamTokenInfoTest, OnlySetDelegates) {
+  // Create info that fails preconditions.
+  ::google::protobuf::RepeatedPtrField<std::string> delegates;
+  delegates.Add("delegate_foo");
+  delegates.Add("delegate_bar");
+  ::google::protobuf::RepeatedPtrField<std::string> scopes;
+  Token::GetTokenFunc access_token_fn = []() { return "valid-access-token"; };
+  info_ = std::make_unique<IamTokenInfo>(delegates, scopes, access_token_fn);
+
+  // Call function under test.
+  Envoy::Http::MessagePtr got_msg = info_->prepareRequest("iam-url");
+
+  // Assert success.
+  EXPECT_NE(got_msg, nullptr);
+  EXPECT_EQ(
+      got_msg->bodyAsString(),
+      R"({"delegates":["projects/-/serviceAccounts/delegate_foo","projects/-/serviceAccounts/delegate_bar"]})");
+}
+
+TEST_F(IamTokenInfoTest, OnlySetScopes) {
+  // Create info that fails preconditions.
+  ::google::protobuf::RepeatedPtrField<std::string> delegates;
+  ::google::protobuf::RepeatedPtrField<std::string> scopes;
+  scopes.Add("scope_foo");
+  scopes.Add("scope_bar");
+  Token::GetTokenFunc access_token_fn = []() { return "valid-access-token"; };
+  info_ = std::make_unique<IamTokenInfo>(delegates, scopes, access_token_fn);
+
+  // Call function under test.
+  Envoy::Http::MessagePtr got_msg = info_->prepareRequest("iam-url");
+
+  // Assert success.
+  EXPECT_NE(got_msg, nullptr);
+  EXPECT_EQ(got_msg->bodyAsString(), R"({"scope":["scope_foo","scope_bar"]})");
+}
+
+class IamParseTokenTest : public IamTokenInfoTest {
+ protected:
+  void SetUp() override {
+    // None of these fields matter for parsing the token.
+    ::google::protobuf::RepeatedPtrField<std::string> delegates;
+    ::google::protobuf::RepeatedPtrField<std::string> scopes;
+    Token::GetTokenFunc access_token_fn = []() { return "fake-access-token"; };
+    info_ = std::make_unique<IamTokenInfo>(delegates, scopes, access_token_fn);
+  }
+};
+
+TEST_F(IamParseTokenTest, NonJsonResponse) {
+  // Input.
+  std::string response = R"({ non-json-response })";
+  TokenResult result{};
+
+  // Test access token.
+  bool success = info_->parseAccessToken(response, &result);
+  EXPECT_FALSE(success);
+
+  // Test identity token.
+  success = info_->parseIdentityToken(response, &result);
+  EXPECT_FALSE(success);
+}
+
+TEST_F(IamParseTokenTest, InvalidJsonResponse) {
+  // Input.
+  std::string response = R"({ "key": "value" })";
+  TokenResult result{};
+
+  // Test access token.
+  bool success = info_->parseAccessToken(response, &result);
+  EXPECT_FALSE(success);
+
+  // Test identity token.
+  success = info_->parseIdentityToken(response, &result);
+  EXPECT_FALSE(success);
+}
+
+TEST_F(IamParseTokenTest, IdentityTokenSuccess) {
+  // Input.
+  std::string response = R"({ "token": "fake-identity-token" })";
+  TokenResult result{};
+
+  // Test access token.
+  bool success = info_->parseIdentityToken(response, &result);
+  EXPECT_TRUE(success);
+  EXPECT_EQ(result.token, "fake-identity-token");
+  EXPECT_EQ(result.expiry_duration, kDefaultTokenExpiry);
+
+  // Test identity token.
+  success = info_->parseAccessToken(response, &result);
+  EXPECT_FALSE(success);
+}
+
+TEST_F(IamParseTokenTest, AccessTokenSuccess) {
+  // Input.
+  std::string response =
+      R"({ "accessToken": "fake-access-token", "expireTime": "2020-02-20T23:15:34-08:00" })";
+  TokenResult result{};
+
+  // Test access token.
+  bool success = info_->parseAccessToken(response, &result);
+  EXPECT_TRUE(success);
+  EXPECT_EQ(result.token, "fake-access-token");
+  EXPECT_NE(result.expiry_duration, kDefaultTokenExpiry);
+
+  // Test identity token.
+  success = info_->parseIdentityToken(response, &result);
+  EXPECT_FALSE(success);
+}
+
+}  // namespace Test
+}  // namespace Token
+}  // namespace Extensions
+}  // namespace Envoy

--- a/src/envoy/token/iam_token_subscriber_fuzz_test.cc
+++ b/src/envoy/token/iam_token_subscriber_fuzz_test.cc
@@ -1,0 +1,110 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "test/fuzz/fuzz_runner.h"
+#include "test/fuzz/utility.h"
+#include "test/mocks/init/mocks.h"
+#include "test/mocks/server/mocks.h"
+
+#include "src/envoy/token/iam_token_info.h"
+#include "src/envoy/token/token_subscriber.h"
+#include "tests/fuzz/structured_inputs/iam_token_subscriber.pb.validate.h"
+
+#include "gmock/gmock.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Token {
+namespace Test {
+
+using ::Envoy::Server::Configuration::MockFactoryContext;
+
+using ::testing::MockFunction;
+
+DEFINE_PROTO_FUZZER(const tests::fuzz::protos::IamTokenSubscriberInput& input) {
+  ENVOY_LOG_MISC(trace, "{}", input.DebugString());
+
+  try {
+    TestUtility::validate(input);
+
+    Envoy::Event::TimerCb onReadyCallback;
+
+    // Setup mocks
+    NiceMock<MockFactoryContext> context;
+    NiceMock<Http::MockAsyncClientRequest> request(
+        &context.cluster_manager_.async_client_);
+    EXPECT_CALL(context.cluster_manager_.async_client_, send_(_, _, _))
+        .WillRepeatedly(
+            Invoke([&input, &request](
+                       const Envoy::Http::MessagePtr&,
+                       Envoy::Http::AsyncClient::Callbacks& callback,
+                       const Envoy::Http::AsyncClient::RequestOptions&) {
+              ENVOY_LOG_MISC(trace, "Mocking async client send");
+
+              // Generate upstream response
+              auto headers = Envoy::Fuzz::fromHeaders(
+                  input.async_client_response().headers());
+              auto headers_ptr =
+                  std::make_unique<Envoy::Http::TestHeaderMapImpl>(headers);
+              auto trailers = Envoy::Fuzz::fromHeaders(
+                  input.async_client_response().trailers());
+              auto trailers_ptr =
+                  std::make_unique<Envoy::Http::TestHeaderMapImpl>(trailers);
+
+              auto msg = std::make_unique<Envoy::Http::ResponseMessageImpl>(
+                  std::move(headers_ptr));
+              msg->trailers(std::move(trailers_ptr));
+              msg->body() = std::make_unique<Buffer::OwnedImpl>(
+                  input.async_client_response().data());
+
+              // Callback
+              callback.onSuccess(std::move(msg));
+              return &request;
+            }));
+
+    EXPECT_CALL(context.dispatcher_, createTimer_(_))
+        .WillRepeatedly(
+            Invoke([&onReadyCallback](const Envoy::Event::TimerCb& cb) {
+              ENVOY_LOG_MISC(trace, "Mocking dispatcher createTimer");
+              onReadyCallback = cb;
+              return new NiceMock<Event::MockTimer>();
+            }));
+
+    // Setup fakes
+    Token::GetTokenFunc access_token_fn = [&input]() {
+      return input.access_token();
+    };
+    Token::UpdateTokenCallback id_token_callback = [](absl::string_view) {};
+
+    // Class under test
+    ::google::protobuf::RepeatedPtrField<std::string> delegates;
+    ::google::protobuf::RepeatedPtrField<std::string> scopes;
+    TokenInfoPtr info =
+        std::make_unique<IamTokenInfo>(delegates, scopes, access_token_fn);
+    TokenSubscriber subscriber(context, TokenType::IdentityToken,
+                               "token_cluster", "http://iam/uri_suffix",
+                               id_token_callback, std::move(info));
+    subscriber.init();
+
+    onReadyCallback();
+
+  } catch (const ProtoValidationException& e) {
+    ENVOY_LOG_MISC(debug, "Controlled proto validation failure: {}", e.what());
+  }
+}
+
+}  // namespace Test
+}  // namespace Token
+}  // namespace Extensions
+}  // namespace Envoy

--- a/src/envoy/token/imds_token_info.cc
+++ b/src/envoy/token/imds_token_info.cc
@@ -1,0 +1,104 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/envoy/token/imds_token_info.h"
+#include "absl/strings/str_cat.h"
+#include "common/http/headers.h"
+#include "common/http/message_impl.h"
+#include "common/http/utility.h"
+#include "src/envoy/utils/json_struct.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Token {
+
+using Utils::JsonStruct;
+
+// Required header when fetching from IMDS.
+const Envoy::Http::LowerCaseString kMetadataFlavorKey("Metadata-Flavor");
+constexpr char kMetadataFlavor[]{"Google"};
+
+ImdsTokenInfo::ImdsTokenInfo() {}
+
+Envoy::Http::MessagePtr ImdsTokenInfo::prepareRequest(
+    absl::string_view token_url) const {
+  absl::string_view host, path;
+  Http::Utility::extractHostPathFromUri(token_url, host, path);
+
+  Envoy::Http::HeaderMapImplPtr headers{new Envoy::Http::HeaderMapImpl{
+      {Envoy::Http::Headers::get().Method, "GET"},
+      {Envoy::Http::Headers::get().Host, std::string(host)},
+      {Envoy::Http::Headers::get().Path, std::string(path)},
+      {kMetadataFlavorKey, kMetadataFlavor}}};
+
+  Envoy::Http::MessagePtr message(
+      new Envoy::Http::RequestMessageImpl(std::move(headers)));
+
+  return message;
+}
+
+// Access token response is a JSON payload in the format:
+// {
+//   "access_token": "string",
+//   "expires_in": uint
+// }
+bool ImdsTokenInfo::parseAccessToken(absl::string_view response,
+                                     TokenResult* ret) const {
+  // Parse the JSON into a proto.
+  ::google::protobuf::Struct response_pb;
+  ::google::protobuf::util::Status parse_status =
+      ::google::protobuf::util::JsonStringToMessage(std::string(response),
+                                                    &response_pb);
+  if (!parse_status.ok()) {
+    ENVOY_LOG(error, "Parsing response failed: {}", parse_status.ToString());
+    return false;
+  }
+  JsonStruct json_struct(response_pb);
+
+  // Parse the token.
+  std::string token;
+  parse_status = json_struct.getString("access_token", &token);
+  if (!parse_status.ok()) {
+    ENVOY_LOG(error, "Parsing response failed for field `access_token`: {}",
+              parse_status.ToString());
+    return false;
+  }
+
+  // Parse the expiry duration.
+  int expires_seconds;
+  parse_status = json_struct.getInteger("expires_in", &expires_seconds);
+  if (!parse_status.ok()) {
+    ENVOY_LOG(error, "Parsing response failed for field `expires_in`: {}",
+              parse_status.ToString());
+    return false;
+  }
+
+  const std::chrono::seconds& expires_in =
+      std::chrono::seconds(expires_seconds);
+  ret->token = token;
+  ret->expiry_duration = expires_in;
+  return true;
+}
+
+// Identity token response is just the raw string, no JSON to parse.
+bool ImdsTokenInfo::parseIdentityToken(absl::string_view response,
+                                       TokenResult* ret) const {
+  ret->token = std::string(response);
+  ret->expiry_duration = kDefaultTokenExpiry;
+  return true;
+}
+
+}  // namespace Token
+}  // namespace Extensions
+}  // namespace Envoy

--- a/src/envoy/token/imds_token_info.cc
+++ b/src/envoy/token/imds_token_info.cc
@@ -29,6 +29,9 @@ using Utils::JsonStruct;
 const Envoy::Http::LowerCaseString kMetadataFlavorKey("Metadata-Flavor");
 constexpr char kMetadataFlavor[]{"Google"};
 
+// Default token expiry time for ID tokens.
+constexpr std::chrono::seconds kDefaultTokenExpiry(3599);
+
 ImdsTokenInfo::ImdsTokenInfo() {}
 
 Envoy::Http::MessagePtr ImdsTokenInfo::prepareRequest(

--- a/src/envoy/token/imds_token_info.h
+++ b/src/envoy/token/imds_token_info.h
@@ -1,0 +1,39 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "src/envoy/token/token_info.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Token {
+
+// `ImdsTokenInfo` is a bridge `TokenInfo` for parsing
+// identity and access tokens from the Instance Metadata Server.
+class ImdsTokenInfo : public TokenInfo {
+ public:
+  ImdsTokenInfo();
+
+  Envoy::Http::MessagePtr prepareRequest(
+      absl::string_view token_url) const override;
+  bool parseAccessToken(absl::string_view response,
+                        TokenResult* ret) const override;
+  bool parseIdentityToken(absl::string_view response,
+                          TokenResult* ret) const override;
+};
+
+}  // namespace Token
+}  // namespace Extensions
+}  // namespace Envoy

--- a/src/envoy/token/imds_token_info_test.cc
+++ b/src/envoy/token/imds_token_info_test.cc
@@ -22,6 +22,10 @@ namespace Extensions {
 namespace Token {
 namespace Test {
 
+// Default token expiry time for ID tokens.
+// Should match the value in `imds_token_info.cc`.
+constexpr std::chrono::seconds kDefaultTokenExpiry(3599);
+
 class ImdsTokenInfoTest : public testing::Test {
  protected:
   void SetUp() override { info_ = std::make_unique<ImdsTokenInfo>(); }

--- a/src/envoy/token/imds_token_info_test.cc
+++ b/src/envoy/token/imds_token_info_test.cc
@@ -1,0 +1,102 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/envoy/token/imds_token_info.h"
+
+#include "common/http/message_impl.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Token {
+namespace Test {
+
+class ImdsTokenInfoTest : public testing::Test {
+ protected:
+  void SetUp() override { info_ = std::make_unique<ImdsTokenInfo>(); }
+
+  TokenInfoPtr info_;
+};
+
+TEST_F(ImdsTokenInfoTest, SimpleSuccess) {
+  // Call function under test.
+  Envoy::Http::MessagePtr got_msg =
+      info_->prepareRequest("https://imds-url.com/path2");
+
+  // Assert success.
+  EXPECT_NE(got_msg, nullptr);
+  EXPECT_EQ(got_msg->bodyAsString(), R"()");
+  EXPECT_EQ(got_msg->headers()
+                .get(Envoy::Http::Headers::get().Method)
+                ->value()
+                .getStringView(),
+            "GET");
+  EXPECT_EQ(got_msg->headers()
+                .get(Envoy::Http::Headers::get().Host)
+                ->value()
+                .getStringView(),
+            "imds-url.com");
+  EXPECT_EQ(got_msg->headers()
+                .get(Envoy::Http::Headers::get().Path)
+                ->value()
+                .getStringView(),
+            "/path2");
+  Envoy::Http::LowerCaseString metadata_key("Metadata-Flavor");
+  EXPECT_EQ(got_msg->headers().get(metadata_key)->value().getStringView(),
+            "Google");
+}
+
+TEST_F(ImdsTokenInfoTest, IdentityTokenSuccess) {
+  // Input.
+  std::string response = R"(non-json-response)";
+  TokenResult result{};
+
+  // Test access token.
+  bool success = info_->parseAccessToken(response, &result);
+  EXPECT_FALSE(success);
+
+  // Test identity token.
+  success = info_->parseIdentityToken(response, &result);
+  EXPECT_TRUE(success);
+  EXPECT_EQ(result.token, "non-json-response");
+  EXPECT_EQ(result.expiry_duration, kDefaultTokenExpiry);
+}
+
+TEST_F(ImdsTokenInfoTest, InvalidJsonResponse) {
+  // Input.
+  std::string response = R"({ "key": "value" })";
+  TokenResult result{};
+
+  // Test access token.
+  bool success = info_->parseAccessToken(response, &result);
+  EXPECT_FALSE(success);
+}
+
+TEST_F(ImdsTokenInfoTest, AccessTokenSuccess) {
+  // Input.
+  std::string response =
+      R"({ "access_token": "fake-access-token", "expires_in": 434432 })";
+  TokenResult result{};
+
+  // Test access token.
+  bool success = info_->parseAccessToken(response, &result);
+  EXPECT_TRUE(success);
+  EXPECT_EQ(result.token, "fake-access-token");
+  EXPECT_NE(result.expiry_duration, kDefaultTokenExpiry);
+}
+
+}  // namespace Test
+}  // namespace Token
+}  // namespace Extensions
+}  // namespace Envoy

--- a/src/envoy/token/mocks.h
+++ b/src/envoy/token/mocks.h
@@ -1,0 +1,67 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include "gmock/gmock.h"
+#include "src/envoy/token/token_info.h"
+#include "src/envoy/token/token_subscriber_factory.h"
+
+using ::testing::NiceMock;
+
+namespace Envoy {
+namespace Extensions {
+namespace Token {
+namespace Test {
+
+class MockTokenSubscriberFactory : public TokenSubscriberFactory {
+ public:
+  MOCK_METHOD(TokenSubscriberPtr, createImdsTokenSubscriber,
+              (const TokenType& token_type, const std::string& token_cluster,
+               const std::string& token_url, UpdateTokenCallback callback),
+              (const));
+
+  MOCK_METHOD(
+      TokenSubscriberPtr, createIamTokenSubscriber,
+      (const TokenType& token_type, const std::string& token_cluster,
+       const std::string& token_url, UpdateTokenCallback callback,
+       const ::google::protobuf::RepeatedPtrField<std::string>& delegates,
+       const ::google::protobuf::RepeatedPtrField<std::string>& scopes,
+       GetTokenFunc access_token_fn),
+      (const));
+
+  MOCK_METHOD(ServiceAccountTokenPtr, createServiceAccountTokenGenerator,
+              (const std::string& service_account_key,
+               const std::string& audience,
+               ServiceAccountTokenGenerator::TokenUpdateFunc callback),
+              (const));
+};
+
+class MockTokenInfo : public TokenInfo {
+ public:
+  MOCK_METHOD(Envoy::Http::MessagePtr, prepareRequest,
+              (absl::string_view token_url), (const));
+
+  MOCK_METHOD(bool, parseAccessToken,
+              (absl::string_view response, TokenResult* ret), (const));
+
+  MOCK_METHOD(bool, parseIdentityToken,
+              (absl::string_view response, TokenResult* ret), (const));
+};
+
+typedef std::unique_ptr<NiceMock<MockTokenInfo>> MockTokenInfoPtr;
+
+}  // namespace Test
+}  // namespace Token
+}  // namespace Extensions
+}  // namespace Envoy

--- a/src/envoy/token/sa_token_generator.cc
+++ b/src/envoy/token/sa_token_generator.cc
@@ -1,0 +1,54 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/envoy/token/sa_token_generator.h"
+#include "src/api_proxy/auth/auth_token.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Token {
+namespace {
+// Token expired in 1 hour, reduce 5 seconds for grace buffer.
+const std::chrono::seconds kRefresherDefaultTokenExpiry(3600 - 5);
+
+}  // namespace
+
+ServiceAccountTokenGenerator::ServiceAccountTokenGenerator(
+    Envoy::Server::Configuration::FactoryContext& context,
+    const std::string& service_account_key, const std::string& audience,
+    TokenUpdateFunc callback)
+    : service_account_key_(service_account_key),
+      audience_(audience),
+      callback_(callback) {
+  refresh_timer_ =
+      context.dispatcher().createTimer([this]() -> void { refresh(); });
+  // call this in a delayed fashion so that the callback is ready to accept new
+  // token.
+  context.dispatcher().post([this]() -> void { refresh(); });
+}
+
+void ServiceAccountTokenGenerator::refresh() {
+  char* token = ::google::api_proxy::auth::get_auth_token(
+      service_account_key_.c_str(), audience_.c_str());
+  callback_(token);
+  ENVOY_LOG(debug, "Generated token: {}", token);
+  ::google::api_proxy::auth::grpc_free(token);
+
+  // Update the token every 1 hour.
+  refresh_timer_->enableTimer(kRefresherDefaultTokenExpiry);
+}
+
+}  // namespace Token
+}  // namespace Extensions
+}  // namespace Envoy

--- a/src/envoy/token/sa_token_generator.h
+++ b/src/envoy/token/sa_token_generator.h
@@ -1,0 +1,51 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "common/common/logger.h"
+#include "common/init/target_impl.h"
+#include "envoy/event/dispatcher.h"
+#include "envoy/server/filter_config.h"
+#include "envoy/upstream/cluster_manager.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Token {
+
+// The class generates an access_token with 1 hour expiration from a service
+// account json for an audience and re-generating it before it is expired.
+class ServiceAccountTokenGenerator
+    : public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
+ public:
+  using TokenUpdateFunc = std::function<void(const std::string& token)>;
+  ServiceAccountTokenGenerator(
+      Envoy::Server::Configuration::FactoryContext& context,
+      const std::string& service_account_key, const std::string& audience,
+      TokenUpdateFunc callback);
+
+ private:
+  void refresh();
+
+  const std::string& service_account_key_;
+  const std::string audience_;
+
+  TokenUpdateFunc callback_;
+  Envoy::Event::TimerPtr refresh_timer_;
+};
+typedef std::unique_ptr<ServiceAccountTokenGenerator> ServiceAccountTokenPtr;
+
+}  // namespace Token
+}  // namespace Extensions
+}  // namespace Envoy

--- a/src/envoy/token/sa_token_generator_test.cc
+++ b/src/envoy/token/sa_token_generator_test.cc
@@ -1,0 +1,68 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+
+#include "src/envoy/token/sa_token_generator.h"
+#include "src/envoy/utils/json_struct.h"
+
+#include "test/mocks/init/mocks.h"
+#include "test/mocks/server/mocks.h"
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock-generated-function-mockers.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Token {
+namespace {
+
+using ::Envoy::Server::Configuration::MockFactoryContext;
+
+using ::testing::_;
+using ::testing::MockFunction;
+
+const std::string kTestServiceAccountKey = R"({
+  "type": "service_account",
+  "project_id": "cloudesf-dummy",
+  "private_key_id": "dcb3a004c6c21f45e3b65625979b11e9e96fc0f6",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCuIIFSp1UvHAmn\n0SMYb8tPXaOr6DP+f3vVymQ7VI9ZHC8WWDV9A89NrVp2FKMyYqlN+nyBnJQ8Vnx/\ntmhEoPIJXvTwtC3xVHeJOaNNe/JfaANMy7FNGJzwtGXpFa8ZjUUqD+5CXFAq0wNR\njih/iUmUnoDMjOwNz5IFT9sfnmIsrYCXqhw62ki9hgb5KWTOpuVqbS7KhOwfpnhY\nX6kH4+zFWglsWdMbISwRiMeIlQDa8XC+YM9id60EPIfILbnJO/TayGFD/ukxslaP\nlH580f/vGuJ6ahChf7tYd2J/4MKU/2P0WWlOO5KKsz/17BEH6iCqMmECUNXeYVl4\nnvWmymD1AgMBAAECggEAPo+yNzqkyfTGaVOkSuLbxsurgxe+Gpm+Ke16PrDeghM0\nvc/6g8yrHksC/frjObamArzVIBJcViNyvsYQR1wWKhTCZ3stKJCDFDwvtqaqSeoK\niXyD2uHVfUwrc2fVjhYqO/cWUSRurzw6bIJpfY0bcTjTqOqW401pNtxeq8kRl+A0\nL13Vli71UjGKMhROIAPiMQAuEE8zQUYD/LuB/YyePIPxX/8f/tkxQ/yshSmmfVED\nJtRiW3K/LSIZbBe7VJihFG2CgVS/3kR7ZQmOsLyqeHsb+6P4M1qjmkwuy8dXRB/h\nMQwbze3o0bfF1LdZ5wvWso+8CpToTzQViSRYqc73/wKBgQDojm6zU5Imb98ppXNT\nrGpOzupptHiTIyg8Dh2CFfmeSfFvFwSLJ8EDtfvK7HhS0iCIAjlIGKEnOvaG6p+j\nLFcHf9LqlufVRisTalcJAUcGgYDwGyQOaL7eosv7KE7P4io8KdxnzPLEyJcxNiv8\nrnQMjIWBCWo0dwgqivQQvss+NwKBgQC/rjBZEWqHISuMhjOElikPTMmNT/YIKzaJ\nXXr3omgIroQz8MWHuguC+udgmjJaCXO5g4Kmpp0rwA0Ib49ujycAHrRlD0Mx1DnD\noFhuHRDbSf/xnSRGNlo1TTqgVukuDLzoPot03lYeju8AyhOrGmlKU0frvOX37ZqM\nmvyKVDzkMwKBgQCtw+dxdQtqTwMXsjmHFvhkJHXBQAksIAPrQ7zGu7bFkIinMjLB\n65VsOWmHycNqVvnZxpeYiFa54nPcgamAmhv5TYiCovldQc3j9vxLjTnN4aw/PHhn\nj9q2rjvuUcL50Asw4zJ+GQR5B0z5h3m8l3m8+q6yqR9DToG6kBMoA/gHZwKBgHeO\nQS+80jIYuV378rQ3KMMXRPu0LSQpN+nz+Zftn3AS0fjHq50dqMJ4lsrFQrSwApNq\neJpTf+Li9f4V/2OZPF0xyZjjLSkuUx02rRF5ZaMxg8eDGTYF/rwSQIfzzZtgbI97\nO2aYqySCSIa4hA4L+jJWwZxDBTlf5S7gGLZ7FkPLAoGAT5e9tG2wQhmHpdIhx1Jd\nQqTfa6a9MRfmjsGeybilODTO1fGScj1Rq9clAg9ugaBdOv8CIUa5tve0lCB/tJEN\nCTqUYvcWxy/fWxZjlj+ovlNfgyXguXI2v0HOxY+nTGhybK3A0tyBPl53yHY8Xf9X\ne1HSaGWkxgTgfJUM9bGELB8=\n-----END PRIVATE KEY-----\n",
+  "client_email": "dummy-73@cloudesf-dummy.iam.gserviceaccount.com",
+  "client_id": "118366583695942267742",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/dummy-73%40cloudesf-dummy.iam.gserviceaccount.com"
+})";
+
+class ServiceAccountTokenTest : public testing::Test {
+ protected:
+  NiceMock<MockFactoryContext> context_;
+  MockFunction<int(std::string)> token_callback_;
+  ServiceAccountTokenPtr sc_token_;
+
+};  // namespace
+
+TEST_F(ServiceAccountTokenTest, MakeCallbackOnRefresh) {
+  EXPECT_CALL(token_callback_, Call(_)).Times(1);
+  sc_token_ = std::make_unique<ServiceAccountTokenGenerator>(
+      context_, kTestServiceAccountKey, "audience",
+      token_callback_.AsStdFunction());
+}
+}  // namespace
+}  // namespace Token
+}  // namespace Extensions
+}  // namespace Envoy

--- a/src/envoy/token/token_info.h
+++ b/src/envoy/token/token_info.h
@@ -1,0 +1,54 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "common/common/logger.h"
+#include "envoy/common/pure.h"
+#include "envoy/http/message.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Token {
+
+// For APIs that have no expiration time, use this.
+constexpr std::chrono::seconds kDefaultTokenExpiry(3599);
+
+typedef std::function<void(absl::string_view)> UpdateTokenCallback;
+typedef std::function<std::string()> GetTokenFunc;
+
+struct TokenResult {
+  std::string token;
+  std::chrono::seconds expiry_duration;
+};
+
+// `TokenInfo` is an adapter that knows how to create requests and parse
+// responses for identity and access tokens from various external APIs.
+class TokenInfo : public Envoy::Logger::Loggable<Envoy::Logger::Id::init> {
+ public:
+  virtual ~TokenInfo() = default;
+
+  virtual Envoy::Http::MessagePtr prepareRequest(
+      absl::string_view token_url) const PURE;
+  virtual bool parseAccessToken(absl::string_view response,
+                                TokenResult* ret) const PURE;
+  virtual bool parseIdentityToken(absl::string_view response,
+                                  TokenResult* ret) const PURE;
+};
+
+typedef std::unique_ptr<TokenInfo> TokenInfoPtr;
+
+}  // namespace Token
+}  // namespace Extensions
+}  // namespace Envoy

--- a/src/envoy/token/token_info.h
+++ b/src/envoy/token/token_info.h
@@ -22,12 +22,6 @@ namespace Envoy {
 namespace Extensions {
 namespace Token {
 
-// For APIs that have no expiration time, use this.
-constexpr std::chrono::seconds kDefaultTokenExpiry(3599);
-
-typedef std::function<void(absl::string_view)> UpdateTokenCallback;
-typedef std::function<std::string()> GetTokenFunc;
-
 struct TokenResult {
   std::string token;
   std::chrono::seconds expiry_duration;

--- a/src/envoy/token/token_subscriber.cc
+++ b/src/envoy/token/token_subscriber.cc
@@ -1,0 +1,191 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/envoy/token/token_subscriber.h"
+#include "absl/strings/str_cat.h"
+#include "common/common/enum_to_int.h"
+#include "common/http/headers.h"
+#include "common/http/message_impl.h"
+#include "common/http/utility.h"
+#include "envoy/http/async_client.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Token {
+
+// Request timeout.
+constexpr std::chrono::milliseconds kRequestTimeoutMs(5000);
+
+// Delay after a failed fetch.
+constexpr std::chrono::seconds kFailedRequestRetryTime(2);
+
+// Update the token `n` seconds before the expiration.
+constexpr std::chrono::seconds kRefreshBuffer(5);
+
+TokenSubscriber::TokenSubscriber(
+    Envoy::Server::Configuration::FactoryContext& context,
+    const TokenType& token_type, const std::string& token_cluster,
+    const std::string& token_url, UpdateTokenCallback callback,
+    TokenInfoPtr token_info)
+    : context_(context),
+      token_type_(token_type),
+      token_cluster_(token_cluster),
+      token_url_(token_url),
+      callback_(callback),
+      token_info_(std::move(token_info)),
+      active_request_(nullptr),
+      init_target_(nullptr) {
+  debug_name_ = absl::StrCat("TokenSubscriber(", token_url_, ")");
+}
+
+void TokenSubscriber::init() {
+  init_target_ = std::make_unique<Envoy::Init::TargetImpl>(
+      debug_name_, [this] { refresh(); });
+  refresh_timer_ =
+      context_.dispatcher().createTimer([this]() -> void { refresh(); });
+
+  context_.initManager().add(*init_target_);
+}
+
+TokenSubscriber::~TokenSubscriber() {
+  if (active_request_) {
+    active_request_->cancel();
+  }
+}
+
+void TokenSubscriber::handleFailResponse() {
+  active_request_ = nullptr;
+  refresh_timer_->enableTimer(kFailedRequestRetryTime);
+
+  // TODO(b/149491061): Remove so Envoy is only ready on success
+  init_target_->ready();
+}
+
+void TokenSubscriber::handleSuccessResponse(
+    absl::string_view token, const std::chrono::seconds& expires_in) {
+  active_request_ = nullptr;
+
+  ENVOY_LOG(debug, "{}: Got token with expiry duration: {} , {} sec",
+            debug_name_, token, expires_in.count());
+  callback_(token);
+
+  // Use the buffer to set the next refresh time.
+  if (expires_in <= kRefreshBuffer) {
+    refresh();
+  } else {
+    refresh_timer_->enableTimer(expires_in - kRefreshBuffer);
+  }
+
+  // Signal that we are ready for initialization.
+  init_target_->ready();
+}
+
+void TokenSubscriber::refresh() {
+  if (active_request_) {
+    active_request_->cancel();
+  }
+
+  ENVOY_LOG(debug, "{}: Sending TokenSubscriber request", debug_name_);
+
+  Envoy::Http::MessagePtr message = token_info_->prepareRequest(token_url_);
+  if (message == nullptr) {
+    // Preconditions in TokenInfo are not met, not an error.
+    ENVOY_LOG(warn, "{}: preconditions not met, retrying later", debug_name_);
+    handleFailResponse();
+    return;
+  }
+
+  const struct Envoy::Http::AsyncClient::RequestOptions options =
+      Envoy::Http::AsyncClient::RequestOptions()
+          .setTimeout(kRequestTimeoutMs)
+          // Metadata server rejects X-Forwarded-For requests.
+          // https://cloud.google.com/compute/docs/storing-retrieving-metadata#x-forwarded-for_header
+          .setSendXff(false);
+
+  active_request_ = context_.clusterManager()
+                        .httpAsyncClientForCluster(token_cluster_)
+                        .send(std::move(message), *this, options);
+}
+
+void TokenSubscriber::processResponse(Envoy::Http::MessagePtr&& response) {
+  try {
+    const uint64_t status_code =
+        Envoy::Http::Utility::getResponseStatus(response->headers());
+
+    if (status_code != enumToInt(Envoy::Http::Code::OK)) {
+      ENVOY_LOG(error, "{}: failed: {}", debug_name_, status_code);
+      handleFailResponse();
+      return;
+    }
+  } catch (const EnvoyException& e) {
+    // This occurs if the status header is missing.
+    // Catch the exception to prevent unwinding and skipping cleanup.
+    ENVOY_LOG(error, "{}: failed: {}", debug_name_, e.what());
+    handleFailResponse();
+    return;
+  }
+
+  // Delegate parsing the HTTP response.
+  TokenResult result{};
+  bool success;
+  switch (token_type_) {
+    case IdentityToken:
+      success =
+          token_info_->parseIdentityToken(response->bodyAsString(), &result);
+      break;
+    case AccessToken:
+      success =
+          token_info_->parseAccessToken(response->bodyAsString(), &result);
+      break;
+    default:
+      ENVOY_LOG(error, "{}: failed with unknown token type {}", debug_name_,
+                token_type_);
+      return;
+  }
+
+  // Determine status.
+  if (!success) {
+    handleFailResponse();
+    return;
+  }
+
+  handleSuccessResponse(result.token, result.expiry_duration);
+}
+
+void TokenSubscriber::onSuccess(Envoy::Http::MessagePtr&& response) {
+  ENVOY_LOG(debug, "{}: got response: {}", debug_name_,
+            response->bodyAsString());
+  processResponse(std::move(response));
+}
+
+void TokenSubscriber::onFailure(
+    Envoy::Http::AsyncClient::FailureReason reason) {
+  switch (reason) {
+    case Http::AsyncClient::FailureReason::Reset:
+      ENVOY_LOG(error, "{}: failed with error: the stream has been reset",
+                debug_name_);
+
+      break;
+    default:
+      ENVOY_LOG(error, "{}: failed with an unknown network failure",
+                debug_name_);
+      break;
+  }
+
+  handleFailResponse();
+}
+
+}  // namespace Token
+}  // namespace Extensions
+}  // namespace Envoy

--- a/src/envoy/token/token_subscriber.h
+++ b/src/envoy/token/token_subscriber.h
@@ -29,6 +29,8 @@ namespace Token {
 
 enum TokenType { AccessToken, IdentityToken };
 
+typedef std::function<void(absl::string_view)> UpdateTokenCallback;
+
 // `TokenSubscriber` class contains platform logic to initiate token refreshes
 // and callback to the clients.
 //

--- a/src/envoy/token/token_subscriber.h
+++ b/src/envoy/token/token_subscriber.h
@@ -1,0 +1,90 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "common/common/logger.h"
+#include "common/init/target_impl.h"
+#include "envoy/common/time.h"
+#include "envoy/event/dispatcher.h"
+#include "envoy/http/message.h"
+#include "envoy/server/filter_config.h"
+#include "envoy/upstream/cluster_manager.h"
+#include "src/envoy/token/token_info.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Token {
+
+enum TokenType { AccessToken, IdentityToken };
+
+// `TokenSubscriber` class contains platform logic to initiate token refreshes
+// and callback to the clients.
+//
+// It must be provided a `TokenInfo` adapter that knows how to parse the
+// token response.
+class TokenSubscriber
+    : public Envoy::Http::AsyncClient::Callbacks,
+      public Envoy::Logger::Loggable<Envoy::Logger::Id::init> {
+ public:
+  TokenSubscriber(Envoy::Server::Configuration::FactoryContext& context,
+                  const TokenType& token_type, const std::string& token_cluster,
+                  const std::string& token_url, UpdateTokenCallback callback,
+                  TokenInfoPtr token_info);
+  void init();
+
+  ~TokenSubscriber();
+
+ private:
+  void handleFailResponse();
+  void handleSuccessResponse(absl::string_view token,
+                             const std::chrono::seconds& expires_in);
+  void processResponse(Envoy::Http::MessagePtr&& response);
+  void refresh();
+
+  // Envoy::Http::AsyncClient::Callbacks implemented by this class.
+  void onSuccess(Envoy::Http::MessagePtr&& response) override;
+  void onFailure(Envoy::Http::AsyncClient::FailureReason reason) override;
+
+  Envoy::Server::Configuration::FactoryContext& context_;
+  const TokenType token_type_;
+  const std::string token_cluster_;
+  const std::string token_url_;
+  const UpdateTokenCallback callback_;
+  TokenInfoPtr token_info_;
+
+  Envoy::Http::AsyncClient::Request* active_request_{};
+
+  // This uses `Init::Manager` object. This is how `Init::Manager` works:
+  //
+  // * If your filter needs to make an async remote call, and needs to wait for
+  //   the response to continue the data flow, you need register your
+  //   `Init::Target` with `Init::Manager::add`.
+  //
+  // * `Init::Manager` initializes registered `Init::Target`s at the main
+  // thread.
+  //   Each target starts to make its remote call and signals `ready` to manager
+  //   when it is initialized.
+  Envoy::Event::TimerPtr refresh_timer_;
+  std::unique_ptr<Envoy::Init::TargetImpl> init_target_;
+
+  // Used in logs.
+  std::string debug_name_;
+};
+
+typedef std::unique_ptr<TokenSubscriber> TokenSubscriberPtr;
+
+}  // namespace Token
+}  // namespace Extensions
+}  // namespace Envoy

--- a/src/envoy/token/token_subscriber_factory.h
+++ b/src/envoy/token/token_subscriber_factory.h
@@ -16,6 +16,8 @@
 
 #include "src/envoy/token/sa_token_generator.h"
 #include "src/envoy/token/token_subscriber.h"
+#include "src/envoy/token/imds_token_info.h"
+#include "src/envoy/token/iam_token_info.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/src/envoy/token/token_subscriber_factory.h
+++ b/src/envoy/token/token_subscriber_factory.h
@@ -1,0 +1,46 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "src/envoy/token/sa_token_generator.h"
+#include "src/envoy/token/token_subscriber.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Token {
+
+class TokenSubscriberFactory {
+ public:
+  virtual ~TokenSubscriberFactory() = default;
+
+  virtual TokenSubscriberPtr createImdsTokenSubscriber(
+      const TokenType& token_type, const std::string& token_cluster,
+      const std::string& token_url, UpdateTokenCallback callback) const PURE;
+
+  virtual TokenSubscriberPtr createIamTokenSubscriber(
+      const TokenType& token_type, const std::string& token_cluster,
+      const std::string& token_url, UpdateTokenCallback callback,
+      const ::google::protobuf::RepeatedPtrField<std::string>& delegates,
+      const ::google::protobuf::RepeatedPtrField<std::string>& scopes,
+      GetTokenFunc access_token_fn) const PURE;
+
+  virtual ServiceAccountTokenPtr createServiceAccountTokenGenerator(
+      const std::string& service_account_key, const std::string& audience,
+      ServiceAccountTokenGenerator::TokenUpdateFunc callback) const PURE;
+};
+
+}  // namespace Token
+}  // namespace Extensions
+}  // namespace Envoy

--- a/src/envoy/token/token_subscriber_factory_impl.h
+++ b/src/envoy/token/token_subscriber_factory_impl.h
@@ -1,0 +1,71 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "src/envoy/token/iam_token_info.h"
+#include "src/envoy/token/imds_token_info.h"
+#include "src/envoy/token/token_subscriber.h"
+#include "src/envoy/token/token_subscriber_factory.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Token {
+
+class TokenSubscriberFactoryImpl : public TokenSubscriberFactory {
+ public:
+  TokenSubscriberFactoryImpl(Server::Configuration::FactoryContext& context)
+      : context_(context) {}
+
+  TokenSubscriberPtr createImdsTokenSubscriber(
+      const TokenType& token_type, const std::string& token_cluster,
+      const std::string& token_url,
+      UpdateTokenCallback callback) const override {
+    TokenInfoPtr info = std::make_unique<ImdsTokenInfo>();
+    TokenSubscriberPtr subscriber =
+        std::make_unique<TokenSubscriber>(context_, token_type, token_cluster,
+                                          token_url, callback, std::move(info));
+    subscriber->init();
+    return subscriber;
+  }
+
+  TokenSubscriberPtr createIamTokenSubscriber(
+      const TokenType& token_type, const std::string& token_cluster,
+      const std::string& token_url, UpdateTokenCallback callback,
+      const ::google::protobuf::RepeatedPtrField<std::string>& delegates,
+      const ::google::protobuf::RepeatedPtrField<std::string>& scopes,
+      GetTokenFunc access_token_fn) const override {
+    TokenInfoPtr info =
+        std::make_unique<IamTokenInfo>(delegates, scopes, access_token_fn);
+    TokenSubscriberPtr subscriber =
+        std::make_unique<TokenSubscriber>(context_, token_type, token_cluster,
+                                          token_url, callback, std::move(info));
+    subscriber->init();
+    return subscriber;
+  }
+
+  ServiceAccountTokenPtr createServiceAccountTokenGenerator(
+      const std::string& service_account_key, const std::string& audience,
+      ServiceAccountTokenGenerator::TokenUpdateFunc callback) const override {
+    return std::make_unique<ServiceAccountTokenGenerator>(
+        context_, service_account_key, audience, callback);
+  };
+
+ private:
+  Envoy::Server::Configuration::FactoryContext& context_;
+};
+
+}  // namespace Token
+}  // namespace Extensions
+}  // namespace Envoy

--- a/src/envoy/token/token_subscriber_test.cc
+++ b/src/envoy/token/token_subscriber_test.cc
@@ -1,0 +1,338 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/envoy/token/token_subscriber.h"
+#include "src/envoy/token/mocks.h"
+
+#include "common/http/message_impl.h"
+#include "common/tracing/http_tracer_impl.h"
+#include "test/mocks/init/mocks.h"
+#include "test/mocks/server/mocks.h"
+#include "test/test_common/utility.h"
+
+#include "gmock/gmock-generated-function-mockers.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Token {
+namespace Test {
+
+using ::Envoy::Server::Configuration::MockFactoryContext;
+
+using ::testing::_;
+using ::testing::ByMove;
+using ::testing::Invoke;
+using ::testing::MockFunction;
+using ::testing::Return;
+using ::testing::ReturnRef;
+
+constexpr std::chrono::milliseconds kFailedExpect(2000);
+
+class TokenSubscriberTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    // Setup mock info.
+    info_ = std::make_unique<NiceMock<MockTokenInfo>>();
+    mock_timer_ = new Envoy::Event::MockTimer{};
+  }
+
+  void setUp(const TokenType& token_type) {
+    Envoy::Init::TargetHandlePtr init_target_handle_;
+    EXPECT_CALL(context_.init_manager_, add(_))
+        .WillOnce(
+            Invoke([&init_target_handle_](const Envoy::Init::Target& target) {
+              init_target_handle_ = target.createHandle("test");
+            }));
+
+    // Setup mock http async client.
+    EXPECT_CALL(context_.cluster_manager_.async_client_, send_(_, _, _))
+        .WillRepeatedly(
+            Invoke([this](Envoy::Http::MessagePtr& message,
+                          Envoy::Http::AsyncClient::Callbacks& callback,
+                          const Envoy::Http::AsyncClient::RequestOptions&) {
+              call_count_++;
+              message_.swap(message);
+              client_callback_ = &callback;
+              return nullptr;
+            }));
+
+    // Setup mock refresh timer.
+    EXPECT_CALL(context_.dispatcher_, createTimer_(_))
+        .WillOnce(Invoke([this](Envoy::Event::TimerCb) { return mock_timer_; }))
+        .RetiresOnSaturation();
+
+    // Create token subscriber under test.
+    iam_token_sub_ = std::make_unique<TokenSubscriber>(
+        context_, token_type, "token_cluster", token_url_,
+        token_callback_.AsStdFunction(), std::move(info_));
+    iam_token_sub_->init();
+
+    // TokenSubscriber must call `ready` to signal Init::Manager once it
+    // finishes initializing.
+    EXPECT_CALL(init_watcher_, ready()).WillRepeatedly(Invoke([this]() {
+      init_ready_ = true;
+    }));
+
+    // Init::Manager should initialize its targets.
+    init_target_handle_->initialize(init_watcher_);
+  }
+
+  // Context
+  NiceMock<MockFactoryContext> context_;
+
+  // Params to class under test.
+  std::string token_url_ = "http://iam/uri_suffix";
+  MockFunction<int(absl::string_view)> token_callback_;
+
+  // Mocks for remote request.
+  Envoy::Http::AsyncClient::Callbacks* client_callback_;
+  Envoy::Http::MessagePtr message_;
+  int call_count_ = 0;
+
+  // Mocks for init.
+  Envoy::Event::MockTimer* mock_timer_;
+  NiceMock<Envoy::Init::ExpectableWatcherImpl> init_watcher_;
+  bool init_ready_ = false;
+
+  // Our classes.
+  MockTokenInfoPtr info_;
+  TokenSubscriberPtr iam_token_sub_;
+};
+
+TEST_F(TokenSubscriberTest, HandleMissingPreconditions) {
+  // Setup mocks for info.
+  EXPECT_CALL(*info_, prepareRequest(_))
+      .Times(1)
+      .WillRepeatedly(Return(ByMove(nullptr)));
+
+  // Expect subscriber does not succeed.
+  EXPECT_CALL(*mock_timer_, enableTimer(kFailedExpect, nullptr)).Times(1);
+  EXPECT_CALL(token_callback_, Call(_)).Times(0);
+
+  // Start class under test.
+  setUp(TokenType::IdentityToken);
+
+  // Assert subscriber did not succeed.
+  ASSERT_EQ(call_count_, 0);
+  ASSERT_TRUE(init_ready_);
+}
+
+TEST_F(TokenSubscriberTest, VerifyRemoteRequest) {
+  // Setup fake remote request.
+  Envoy::Http::HeaderMapImplPtr headers{new Envoy::Http::TestHeaderMapImpl{
+      {":method", "POST"}, {":authority", "TestValue"}}};
+  EXPECT_CALL(*info_, prepareRequest(token_url_))
+      .Times(1)
+      .WillRepeatedly(
+          Return(ByMove(std::make_unique<Envoy::Http::RequestMessageImpl>(
+              std::move(headers)))));
+
+  // Start class under test.
+  setUp(TokenType::IdentityToken);
+
+  // Assert remote call matches.
+  ASSERT_EQ(call_count_, 1);
+  EXPECT_EQ(message_->headers()
+                .get(Envoy::Http::Headers::get().Method)
+                ->value()
+                .getStringView(),
+            "POST");
+  EXPECT_EQ(message_->headers()
+                .get(Envoy::Http::Headers::get().Host)
+                ->value()
+                .getStringView(),
+            "TestValue");
+}
+
+TEST_F(TokenSubscriberTest, ProcessNon200Response) {
+  // Setup fake remote request.
+  Envoy::Http::HeaderMapImplPtr req_headers{
+      new Envoy::Http::TestHeaderMapImpl{}};
+  EXPECT_CALL(*info_, prepareRequest(token_url_))
+      .Times(1)
+      .WillRepeatedly(
+          Return(ByMove(std::make_unique<Envoy::Http::RequestMessageImpl>(
+              std::move(req_headers)))));
+
+  // Expect subscriber does not succeed.
+  EXPECT_CALL(*mock_timer_, enableTimer(kFailedExpect, nullptr)).Times(1);
+  EXPECT_CALL(token_callback_, Call(_)).Times(0);
+
+  // Start class under test.
+  setUp(TokenType::IdentityToken);
+
+  // Setup fake response.
+  Envoy::Http::HeaderMapImplPtr resp_headers{new Envoy::Http::TestHeaderMapImpl{
+      {":status", "504"},
+  }};
+  Envoy::Http::MessagePtr response(
+      new Envoy::Http::RequestMessageImpl(std::move(resp_headers)));
+
+  // Start the response.
+  client_callback_->onSuccess(std::move(response));
+
+  // Assert subscriber did not succeed.
+  ASSERT_EQ(call_count_, 1);
+  ASSERT_TRUE(init_ready_);
+}
+
+TEST_F(TokenSubscriberTest, ProcessMissingStatusResponse) {
+  // Setup fake remote request.
+  Envoy::Http::HeaderMapImplPtr req_headers{
+      new Envoy::Http::TestHeaderMapImpl{}};
+  EXPECT_CALL(*info_, prepareRequest(token_url_))
+      .Times(1)
+      .WillRepeatedly(
+          Return(ByMove(std::make_unique<Envoy::Http::RequestMessageImpl>(
+              std::move(req_headers)))));
+
+  // Expect subscriber does not succeed.
+  EXPECT_CALL(*mock_timer_, enableTimer(kFailedExpect, nullptr)).Times(1);
+  EXPECT_CALL(token_callback_, Call(_)).Times(0);
+
+  // Start class under test.
+  setUp(TokenType::IdentityToken);
+
+  // Setup fake response.
+  Envoy::Http::HeaderMapImplPtr resp_headers{
+      new Envoy::Http::TestHeaderMapImpl{}};
+  Envoy::Http::MessagePtr response(
+      new Envoy::Http::RequestMessageImpl(std::move(resp_headers)));
+
+  // Start the response.
+  client_callback_->onSuccess(std::move(response));
+
+  // Assert subscriber did not succeed.
+  ASSERT_EQ(call_count_, 1);
+  ASSERT_TRUE(init_ready_);
+}
+
+TEST_F(TokenSubscriberTest, BadParseIdentityToken) {
+  // Setup fake remote request.
+  Envoy::Http::HeaderMapImplPtr req_headers{
+      new Envoy::Http::TestHeaderMapImpl{}};
+  EXPECT_CALL(*info_, prepareRequest(token_url_))
+      .Times(1)
+      .WillRepeatedly(
+          Return(ByMove(std::make_unique<Envoy::Http::RequestMessageImpl>(
+              std::move(req_headers)))));
+
+  // Setup fake parse status.
+  EXPECT_CALL(*info_, parseIdentityToken(_, _)).WillOnce(Return(false));
+
+  // Expect subscriber does not succeed.
+  EXPECT_CALL(*mock_timer_, enableTimer(kFailedExpect, nullptr)).Times(1);
+  EXPECT_CALL(token_callback_, Call(_)).Times(0);
+
+  // Start class under test.
+  setUp(TokenType::IdentityToken);
+
+  // Setup fake response.
+  Envoy::Http::HeaderMapImplPtr resp_headers{new Envoy::Http::TestHeaderMapImpl{
+      {":status", "200"},
+  }};
+  Envoy::Http::MessagePtr response(
+      new Envoy::Http::RequestMessageImpl(std::move(resp_headers)));
+
+  // Start the response.
+  client_callback_->onSuccess(std::move(response));
+
+  // Assert subscriber did not succeed.
+  ASSERT_EQ(call_count_, 1);
+  ASSERT_TRUE(init_ready_);
+}
+
+TEST_F(TokenSubscriberTest, BadParseAccessToken) {
+  // Setup fake remote request.
+  Envoy::Http::HeaderMapImplPtr req_headers{
+      new Envoy::Http::TestHeaderMapImpl{}};
+  EXPECT_CALL(*info_, prepareRequest(token_url_))
+      .Times(1)
+      .WillRepeatedly(
+          Return(ByMove(std::make_unique<Envoy::Http::RequestMessageImpl>(
+              std::move(req_headers)))));
+
+  // Setup fake parse status.
+  EXPECT_CALL(*info_, parseAccessToken(_, _)).WillOnce(Return(false));
+
+  // Expect subscriber does not succeed.
+  EXPECT_CALL(*mock_timer_, enableTimer(kFailedExpect, nullptr)).Times(1);
+  EXPECT_CALL(token_callback_, Call(_)).Times(0);
+
+  // Start class under test.
+  setUp(TokenType::AccessToken);
+
+  // Setup fake response.
+  Envoy::Http::HeaderMapImplPtr resp_headers{new Envoy::Http::TestHeaderMapImpl{
+      {":status", "200"},
+  }};
+  Envoy::Http::MessagePtr response(
+      new Envoy::Http::RequestMessageImpl(std::move(resp_headers)));
+
+  // Start the response.
+  client_callback_->onSuccess(std::move(response));
+
+  // Assert subscriber did not succeed.
+  ASSERT_EQ(call_count_, 1);
+  ASSERT_TRUE(init_ready_);
+}
+
+TEST_F(TokenSubscriberTest, Success) {
+  // Setup fake remote request.
+  Envoy::Http::HeaderMapImplPtr req_headers{
+      new Envoy::Http::TestHeaderMapImpl{}};
+  EXPECT_CALL(*info_, prepareRequest(token_url_))
+      .Times(1)
+      .WillRepeatedly(
+          Return(ByMove(std::make_unique<Envoy::Http::RequestMessageImpl>(
+              std::move(req_headers)))));
+
+  // Setup fake parse status.
+  EXPECT_CALL(*info_, parseAccessToken(_, _))
+      .WillOnce(Invoke([](absl::string_view, TokenResult* ret) {
+        ret->token = "fake-token";
+        ret->expiry_duration = std::chrono::seconds(30);
+        return true;
+      }));
+
+  // Expect subscriber does succeed.
+  EXPECT_CALL(*mock_timer_,
+              enableTimer(std::chrono::milliseconds(25 * 1000), nullptr))
+      .Times(1);
+  EXPECT_CALL(token_callback_, Call("fake-token")).Times(1);
+
+  // Start class under test.
+  setUp(TokenType::AccessToken);
+
+  // Setup fake response.
+  Envoy::Http::HeaderMapImplPtr resp_headers{new Envoy::Http::TestHeaderMapImpl{
+      {":status", "200"},
+  }};
+  Envoy::Http::MessagePtr response(
+      new Envoy::Http::RequestMessageImpl(std::move(resp_headers)));
+
+  // Start the response.
+  client_callback_->onSuccess(std::move(response));
+
+  // Assert subscriber did succeed.
+  ASSERT_EQ(call_count_, 1);
+  ASSERT_TRUE(init_ready_);
+}
+
+}  // namespace Test
+}  // namespace Token
+}  // namespace Extensions
+}  // namespace Envoy


### PR DESCRIPTION
Notes:
- `TokenSubscriber`: Handles the init manager, refresh timer, making async http requests, etc.
- `TokenInfo`: A bridge for TokenSubscriber that provides request creation and response parsing logic.
- Follows the bridge design pattern.

Testing done:
- Added unit tests for TokenSubscriber and both TokenInfo.
- Kept fuzz test to work across both components.
- Verified all integration tests pass with no changes.
- Manually ran e2e tests with chain of delegates for backend auth identity token.

Future work:
- Switch over production code to use this new directory.
- The main request in b/149491061 will be implemented in a separate CL. The change is simple (removing one line), but new tests need to be added.

Signed-off-by: Teju Nareddy <nareddyt@google.com>