### PR TITLE
Deploy proxy with the runtime service account in Cloud Run e2e tests

### DIFF
--- a/tests/e2e/scripts/cloud-run/deploy.sh
+++ b/tests/e2e/scripts/cloud-run/deploy.sh
@@ -123,7 +123,7 @@ function deployBackend() {
 function deployProxy() {
   local image_name="${1}"
   local env_vars="${2}"
-  local args=" --image=${image_name} --service-account=${PROXY_RUNTIME_SERVICE_ACCOUNT} --quiet"
+  local args=" --image=${image_name} --quiet"
   if [[ -n ${env_vars} ]];
   then
     args+=" --set-env-vars=ESPv2_ARGS=${proxy_args}"
@@ -131,7 +131,7 @@ function deployProxy() {
 
   case ${PROXY_PLATFORM} in
     "cloud-run")
-      args+=" --allow-unauthenticated --platform=managed"
+      args+=" --allow-unauthenticated --service-account=${PROXY_RUNTIME_SERVICE_ACCOUNT} --platform=managed"
       ;;
     "anthos-cloud-run")
       args+=" --platform=gke"

--- a/tests/e2e/scripts/cloud-run/deploy.sh
+++ b/tests/e2e/scripts/cloud-run/deploy.sh
@@ -123,7 +123,7 @@ function deployBackend() {
 function deployProxy() {
   local image_name="${1}"
   local env_vars="${2}"
-  local args=" --image=${image_name} --quiet"
+  local args=" --image=${image_name} --service-account=${PROXY_RUNTIME_SERVICE_ACCOUNT} --quiet"
   if [[ -n ${env_vars} ]];
   then
     args+=" --set-env-vars=ESPv2_ARGS=${proxy_args}"


### PR DESCRIPTION
This makes it easier to test IAM Delegation (manually). Anyways, we shouldn't be relying on the default compute service account to test Cloud Run Invoker permission.

Regression introduced in `6c121d54ad0db05dda5a4f06e121b0843d498bd1`.
Regression found while testing for b/149491061.

Signed-off-by: Teju Nareddy <nareddyt@google.com>