### PR TITLE
Make cloud-anthos e2e test use default network

### DIFF
--- a/tests/e2e/scripts/cloud-run/deploy.sh
+++ b/tests/e2e/scripts/cloud-run/deploy.sh
@@ -166,6 +166,7 @@ function setup() {
       --cluster-version=${CLUSTER_VERSION}\
       --enable-stackdriver-kubernetes \
       --service-account=${PROXY_RUNTIME_SERVICE_ACCOUNT} \
+      --network=default \
       --zone=${CLUSTER_ZONE} \
       --scopes cloud-platform
     sleep 1m


### PR DESCRIPTION
The cloud-anthos e2e test keeps creating new network, which is unnecessary so change it to use default one.