### PR TITLE
Delete clusters async in serverless janitor

### DIFF
--- a/prow/janitor.sh
+++ b/prow/janitor.sh
@@ -26,6 +26,7 @@ do
   echo "Deleting GKE service: ${service}"
   gcloud container clusters delete ${service} \
     --zone=us-central1-a \
+    --async \
     --quiet
 done
 


### PR DESCRIPTION
Sometimes causes timeouts, deleting a cluster takes long.

Signed-off-by: Teju Nareddy <nareddyt@google.com>