### PR TITLE
b/149050012: Support HTTP protocols for remote backends

### DIFF
--- a/examples/dynamic_routing/envoy_config.json
+++ b/examples/dynamic_routing/envoy_config.json
@@ -95,6 +95,7 @@
             },
             {
                 "connectTimeout": "20s",
+                "http2ProtocolOptions":{},
                 "loadAssignment": {
                     "clusterName": "http-bookstore-abc123456-uc.a.run.app",
                     "endpoints": [
@@ -120,6 +121,7 @@
                     "typedConfig": {
                         "@type": "type.googleapis.com/envoy.api.v2.auth.UpstreamTlsContext",
                         "commonTlsContext": {
+                            "alpnProtocols":["h2"],
                             "validationContext": {
                                 "trustedCa": {
                                     "filename": "/etc/ssl/certs/ca-certificates.crt"

--- a/examples/dynamic_routing/openapi_swagger.json
+++ b/examples/dynamic_routing/openapi_swagger.json
@@ -23,7 +23,8 @@
           "address": "https://http-bookstore-abc123456-uc.a.run.app/shelves",
           "jwt_audience": "ESPv2",
           "path_translation": "APPEND_PATH_TO_ADDRESS",
-          "deadline": 5.0
+          "deadline": 5.0,
+          "protocol": "h2"
         },
         "description": "Returns all shelves in the bookstore.",
         "operationId": "listShelves",
@@ -44,7 +45,8 @@
           "address": "https://http-bookstore-edf123456-uc.a.run.app/shelves",
           "path_translation": "CONSTANT_ADDRESS",
           "disable_auth": true,
-          "deadline": 30.0
+          "deadline": 30.0,
+          "protocol": "http/1.1"
         },
         "description": "Creates a new shelf in the bookstore.",
         "operationId": "createShelf",

--- a/examples/dynamic_routing/service_config_generated.json
+++ b/examples/dynamic_routing/service_config_generated.json
@@ -26,6 +26,7 @@
       {
         "address": "https://http-bookstore-abc123456-uc.a.run.app/shelves",
         "deadline": 5.0,
+        "protocol": "h2",
         "jwtAudience": "ESPv2",
         "pathTranslation": "APPEND_PATH_TO_ADDRESS",
         "selector": "1.esp_bookstore_f6x3rlu5aa_uc_a_run_app.ListShelves"
@@ -33,6 +34,7 @@
       {
         "address": "https://http-bookstore-edf123456-uc.a.run.app/shelves",
         "deadline": 30.0,
+        "protocol": "http/1.1",
         "disableAuth": true,
         "pathTranslation": "CONSTANT_ADDRESS",
         "selector": "1.esp_bookstore_f6x3rlu5aa_uc_a_run_app.CreateShelf"

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,6 @@ require (
 	golang.org/x/net v0.0.0-20190628185345-da137c7871d7
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	google.golang.org/api v0.7.0
-	google.golang.org/genproto v0.0.0-20200207204624-4f3edf09f4f6
+	google.golang.org/genproto v0.0.0-20200228133532-8c2c7df3a383
 	google.golang.org/grpc v1.27.0
 )

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,8 @@ google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 h1:gSJIx1SDwno+2El
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200207204624-4f3edf09f4f6 h1:tirixpud1WdjE3/NrL9ar4ot0ADfwls8sOcIf1ivRDw=
 google.golang.org/genproto v0.0.0-20200207204624-4f3edf09f4f6/go.mod h1:GmwEX6Z4W5gMy59cAlVYjN9JhxgbQH6Gn+gFDQe2lzA=
+google.golang.org/genproto v0.0.0-20200228133532-8c2c7df3a383 h1:Vo0fD5w0fUKriWlZLyrim2GXbumyN0D6euW79T9PgEE=
+google.golang.org/genproto v0.0.0-20200228133532-8c2c7df3a383/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=

--- a/src/go/configgenerator/cluster_generator.go
+++ b/src/go/configgenerator/cluster_generator.go
@@ -177,7 +177,7 @@ func makeJwtProviderClusters(serviceInfo *sc.ServiceInfo) ([]*v2pb.Cluster, erro
 			ConnectTimeout: connectTimeoutProto,
 			// Note: It may not be V4.
 			DnsLookupFamily:      v2pb.Cluster_V4_ONLY,
-			ClusterDiscoveryType: &v2pb.Cluster_Type{v2pb.Cluster_LOGICAL_DNS},
+			ClusterDiscoveryType: &v2pb.Cluster_Type{Type: v2pb.Cluster_LOGICAL_DNS},
 			LoadAssignment:       util.CreateLoadAssignment(hostname, port),
 		}
 		if scheme == "https" {
@@ -201,12 +201,11 @@ func makeBackendCluster(opt *options.ConfigGeneratorOptions, brc *sc.BackendRout
 		Name:                 brc.ClusterName,
 		LbPolicy:             v2pb.Cluster_ROUND_ROBIN,
 		ConnectTimeout:       ptypes.DurationProto(opt.ClusterConnectTimeout),
-		ClusterDiscoveryType: &v2pb.Cluster_Type{v2pb.Cluster_LOGICAL_DNS},
+		ClusterDiscoveryType: &v2pb.Cluster_Type{Type: v2pb.Cluster_LOGICAL_DNS},
 		LoadAssignment:       util.CreateLoadAssignment(brc.Hostname, brc.Port),
 	}
 
-	// TODO(nareddyt): Support HTTP2
-	isHttp2 := brc.Protocol == util.GRPC
+	isHttp2 := brc.Protocol == util.GRPC || brc.Protocol == util.HTTP2
 
 	if brc.UseTLS {
 		var alpnProtocols []string

--- a/src/go/configinfo/service_info.go
+++ b/src/go/configinfo/service_info.go
@@ -142,7 +142,8 @@ func (s *ServiceInfo) buildCatchAllBackend() error {
 		return fmt.Errorf("error parsing backend uri: %v", err)
 	}
 
-	protocol, tls, err := util.ParseBackendProtocol(scheme)
+	// For local backend, user cannot configure http protocol explicitly.
+	protocol, tls, err := util.ParseBackendProtocol(scheme, "")
 	if err != nil {
 		return err
 	}
@@ -417,7 +418,7 @@ func (s *ServiceInfo) processBackendRule() error {
 			address := fmt.Sprintf("%v:%v", hostname, port)
 
 			if _, exist := backendRoutingClustersMap[address]; !exist {
-				protocol, tls, err := util.ParseBackendProtocol(scheme)
+				protocol, tls, err := util.ParseBackendProtocol(scheme, r.Protocol)
 				if err != nil {
 					return err
 				}
@@ -580,7 +581,7 @@ func (s *ServiceInfo) BackendClusterName() string {
 
 // If the backend address's scheme is grpc/grpcs, it should be changed it http or https.
 func getJwtAudienceFromBackendAddr(scheme, hostname string) string {
-	_, tls, _ := util.ParseBackendProtocol(scheme)
+	_, tls, _ := util.ParseBackendProtocol(scheme, "")
 	if tls {
 		return fmt.Sprintf("https://%s", hostname)
 	}

--- a/src/go/util/util.go
+++ b/src/go/util/util.go
@@ -116,8 +116,9 @@ const (
 type BackendProtocol int32
 
 // Backend protocol.
-// TODO(nareddyt): add in HTTP2
 const (
-	HTTP1 BackendProtocol = iota
+	UNKNOWN BackendProtocol = iota
+	HTTP1
+	HTTP2
 	GRPC
 )


### PR DESCRIPTION
Modify `ParseBackendProtocol` to differentiate between `HTTP1` and `HTTP2`.

Implementation notes:
- Add `UNKNOWN` to `BackendProtocol`, easier to test and safer in prod code.
- If http protocol is empty string, then default to `HTTP1`.

Testing:
- New unit tests.
- Added http protocol to dynamic routing example.
- Will add integration tests once #32 is merged, as that adds a h2 client.

Signed-off-by: Teju Nareddy <nareddyt@google.com>