### PR TITLE
b/149491061: Signal ready only when all tokens are successfully retried

### DIFF
--- a/src/envoy/token/token_subscriber.cc
+++ b/src/envoy/token/token_subscriber.cc
@@ -67,9 +67,6 @@ TokenSubscriber::~TokenSubscriber() {
 void TokenSubscriber::handleFailResponse() {
   active_request_ = nullptr;
   refresh_timer_->enableTimer(kFailedRequestRetryTime);
-
-  // TODO(b/149491061): Remove so Envoy is only ready on success
-  init_target_->ready();
 }
 
 void TokenSubscriber::handleSuccessResponse(

--- a/src/envoy/token/token_subscriber_test.cc
+++ b/src/envoy/token/token_subscriber_test.cc
@@ -50,10 +50,9 @@ class TokenSubscriberTest : public testing::Test {
   }
 
   void setUp(const TokenType& token_type) {
-    Envoy::Init::TargetHandlePtr init_target_handle_;
     EXPECT_CALL(context_.init_manager_, add(_))
         .WillOnce(
-            Invoke([&init_target_handle_](const Envoy::Init::Target& target) {
+            Invoke([this](const Envoy::Init::Target& target) {
               init_target_handle_ = target.createHandle("test");
             }));
 
@@ -75,10 +74,10 @@ class TokenSubscriberTest : public testing::Test {
         .RetiresOnSaturation();
 
     // Create token subscriber under test.
-    iam_token_sub_ = std::make_unique<TokenSubscriber>(
+    token_sub_ = std::make_unique<TokenSubscriber>(
         context_, token_type, "token_cluster", token_url_,
         token_callback_.AsStdFunction(), std::move(info_));
-    iam_token_sub_->init();
+    token_sub_->init();
 
     // TokenSubscriber must call `ready` to signal Init::Manager once it
     // finishes initializing.
@@ -103,13 +102,14 @@ class TokenSubscriberTest : public testing::Test {
   int call_count_ = 0;
 
   // Mocks for init.
+  Envoy::Init::TargetHandlePtr init_target_handle_;
   Envoy::Event::MockTimer* mock_timer_;
   NiceMock<Envoy::Init::ExpectableWatcherImpl> init_watcher_;
   bool init_ready_ = false;
 
   // Our classes.
   MockTokenInfoPtr info_;
-  TokenSubscriberPtr iam_token_sub_;
+  TokenSubscriberPtr token_sub_;
 };
 
 TEST_F(TokenSubscriberTest, HandleMissingPreconditions) {
@@ -127,7 +127,7 @@ TEST_F(TokenSubscriberTest, HandleMissingPreconditions) {
 
   // Assert subscriber did not succeed.
   ASSERT_EQ(call_count_, 0);
-  ASSERT_TRUE(init_ready_);
+  ASSERT_FALSE(init_ready_);
 }
 
 TEST_F(TokenSubscriberTest, VerifyRemoteRequest) {
@@ -186,7 +186,7 @@ TEST_F(TokenSubscriberTest, ProcessNon200Response) {
 
   // Assert subscriber did not succeed.
   ASSERT_EQ(call_count_, 1);
-  ASSERT_TRUE(init_ready_);
+  ASSERT_FALSE(init_ready_);
 }
 
 TEST_F(TokenSubscriberTest, ProcessMissingStatusResponse) {
@@ -217,7 +217,7 @@ TEST_F(TokenSubscriberTest, ProcessMissingStatusResponse) {
 
   // Assert subscriber did not succeed.
   ASSERT_EQ(call_count_, 1);
-  ASSERT_TRUE(init_ready_);
+  ASSERT_FALSE(init_ready_);
 }
 
 TEST_F(TokenSubscriberTest, BadParseIdentityToken) {
@@ -252,7 +252,7 @@ TEST_F(TokenSubscriberTest, BadParseIdentityToken) {
 
   // Assert subscriber did not succeed.
   ASSERT_EQ(call_count_, 1);
-  ASSERT_TRUE(init_ready_);
+  ASSERT_FALSE(init_ready_);
 }
 
 TEST_F(TokenSubscriberTest, BadParseAccessToken) {
@@ -287,7 +287,7 @@ TEST_F(TokenSubscriberTest, BadParseAccessToken) {
 
   // Assert subscriber did not succeed.
   ASSERT_EQ(call_count_, 1);
-  ASSERT_TRUE(init_ready_);
+  ASSERT_FALSE(init_ready_);
 }
 
 TEST_F(TokenSubscriberTest, Success) {
@@ -316,6 +316,58 @@ TEST_F(TokenSubscriberTest, Success) {
 
   // Start class under test.
   setUp(TokenType::AccessToken);
+
+  // Setup fake response.
+  Envoy::Http::HeaderMapImplPtr resp_headers{new Envoy::Http::TestHeaderMapImpl{
+      {":status", "200"},
+  }};
+  Envoy::Http::MessagePtr response(
+      new Envoy::Http::RequestMessageImpl(std::move(resp_headers)));
+
+  // Start the response.
+  client_callback_->onSuccess(std::move(response));
+
+  // Assert subscriber did succeed.
+  ASSERT_EQ(call_count_, 1);
+  ASSERT_TRUE(init_ready_);
+}
+
+TEST_F(TokenSubscriberTest, RetryMissingPreconditionThenSuccess) {
+  // Part 1: Failed due to missing precondition
+
+  // Setup mocks for info. Fail on the first time, then work later.
+  Envoy::Http::HeaderMapImplPtr req_headers{
+      new Envoy::Http::TestHeaderMapImpl{}};
+  EXPECT_CALL(*info_, prepareRequest(_))
+      .WillOnce(Return(ByMove(nullptr)))
+      .WillRepeatedly(
+          Return(ByMove(std::make_unique<Envoy::Http::RequestMessageImpl>(
+              std::move(req_headers)))));
+
+  // Setup fake parse status.
+  EXPECT_CALL(*info_, parseAccessToken(_, _))
+      .WillOnce(Invoke([](absl::string_view, TokenResult* ret) {
+        ret->token = "fake-token";
+        ret->expiry_duration = std::chrono::seconds(30);
+        return true;
+      }));
+
+  // Expect subscriber does not succeed at first, but then does.
+  EXPECT_CALL(*mock_timer_, enableTimer(kFailedExpect, nullptr)).Times(1);
+  EXPECT_CALL(*mock_timer_,
+              enableTimer(std::chrono::milliseconds(25 * 1000), nullptr))
+      .Times(1);
+  EXPECT_CALL(token_callback_, Call("fake-token")).Times(1);
+
+  // Start class under test.
+  setUp(TokenType::AccessToken);
+
+  // Assert subscriber did not succeed.
+  ASSERT_EQ(call_count_, 0);
+  ASSERT_FALSE(init_ready_);
+
+  // Part 2: Retry, will result in a success.
+  init_target_handle_->initialize(init_watcher_);
 
   // Setup fake response.
   Envoy::Http::HeaderMapImplPtr resp_headers{new Envoy::Http::TestHeaderMapImpl{

--- a/tests/env/components/ports.go
+++ b/tests/env/components/ports.go
@@ -39,6 +39,8 @@ const (
 	TestBackendAuthWithIamIdToken
 	TestBackendAuthWithIamIdTokenRetries
 	TestBackendAuthUsingIamIdTokenWithDelegates
+	TestDataPathImdsSuccessWhenIamDown
+	TestDataPathIamFailWhenImdsDown
 	TestDifferentOriginPreflightCors
 	TestDifferentOriginSimpleCors
 	TestDynamicRouting

--- a/tests/env/components/ports.go
+++ b/tests/env/components/ports.go
@@ -39,8 +39,7 @@ const (
 	TestBackendAuthWithIamIdToken
 	TestBackendAuthWithIamIdTokenRetries
 	TestBackendAuthUsingIamIdTokenWithDelegates
-	TestDataPathImdsSuccessWhenIamDown
-	TestDataPathIamFailWhenImdsDown
+	TestIamImdsDataPath
 	TestDifferentOriginPreflightCors
 	TestDifferentOriginSimpleCors
 	TestDynamicRouting

--- a/tests/env/env.go
+++ b/tests/env/env.go
@@ -279,7 +279,7 @@ func (e *TestEnv) Setup(confArgs []string) error {
 		bootstrapperArgs = append(bootstrapperArgs, "--metadata_url="+e.MockMetadataServer.GetURL())
 	}
 
-	if e.mockIamResps != nil {
+	if e.mockIamResps != nil || e.mockIamFailures != 0 {
 		e.MockIamServer = components.NewIamMetadata(e.mockIamResps, e.mockIamFailures)
 		confArgs = append(confArgs, "--iam_url="+e.MockIamServer.GetURL())
 	}

--- a/tests/integration_test/backend_auth_using_imds_test/backend_auth_using_imds_test.go
+++ b/tests/integration_test/backend_auth_using_imds_test/backend_auth_using_imds_test.go
@@ -100,6 +100,8 @@ func TestBackendAuthWithImdsIdToken(t *testing.T) {
 
 func TestBackendAuthWithImdsIdTokenRetries(t *testing.T) {
 	s := NewBackendAuthTestEnv(comp.TestBackendAuthWithImdsIdTokenRetries)
+	// Health checks prevent envoy from starting up due to bad responses from IMDS for tokens.
+	s.SkipHealthChecks()
 
 	testData := []struct {
 		desc           string
@@ -114,7 +116,7 @@ func TestBackendAuthWithImdsIdTokenRetries(t *testing.T) {
 			method:         "GET",
 			path:           "/bearertoken/constant/42",
 			wantNumFails:   5,
-			wantInitialErr: `500 Internal Server Error, missing tokens`,
+			wantInitialErr: `connect: connection refused`,
 			wantFinalResp:  `{"Authorization": "Bearer ya29.constant", "RequestURI": "/bearertoken/constant?foo=42"}`,
 		},
 	}

--- a/tests/integration_test/iam_imds_data_path_test/iam_imds_data_path_test.go
+++ b/tests/integration_test/iam_imds_data_path_test/iam_imds_data_path_test.go
@@ -1,0 +1,110 @@
+package iam_imds_data_path_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/echo/client"
+	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
+	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
+	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
+
+	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
+)
+
+var testDataPathArgs = []string{
+	"--service_config_id=test-config-id",
+	"--rollout_strategy=fixed",
+	"--backend_dns_lookup_family=v4only",
+	"--suppress_envoy_headers",
+}
+
+func TestDataPathImdsSuccessWhenIamDown(t *testing.T) {
+	s := env.NewTestEnv(comp.TestDataPathImdsSuccessWhenIamDown, platform.EchoRemote)
+
+	// Simulate Iam failures.
+	s.SetIamResps(map[string]string{}, 100)
+
+	defer s.TearDown()
+	if err := s.Setup(testDataPathArgs); err != nil {
+		t.Fatalf("fail to setup test env, %v", err)
+	}
+
+	testData := []struct {
+		desc     string
+		method   string
+		path     string
+		message  string
+		wantResp string
+	}{
+		{
+			desc:     "Backend auth with IMDS works, even when IAM is down",
+			method:   "GET",
+			path:     "/bearertoken/constant/42",
+			wantResp: `{"Authorization": "Bearer ya29.new", "RequestURI": "/bearertoken/constant?foo=42"}`,
+		},
+	}
+
+	for _, tc := range testData {
+		url := fmt.Sprintf("http://localhost:%v%v", s.Ports().ListenerPort, tc.path)
+		resp, err := client.DoWithHeaders(url, tc.method, tc.message, nil)
+
+		if err != nil {
+			t.Fatalf("Test Desc(%s): %v", tc.desc, err)
+		}
+
+		gotResp := string(resp)
+		if !utils.JsonEqual(gotResp, tc.wantResp) {
+			t.Errorf("Test Desc(%s): want: %s, got: %s", tc.desc, tc.wantResp, gotResp)
+		}
+	}
+}
+
+func TestDataPathIamFailWhenImdsDown(t *testing.T) {
+	s := env.NewTestEnv(comp.TestDataPathIamFailWhenImdsDown, platform.EchoRemote)
+
+	// Use IAM instead of IMDS.
+	serviceAccount := "fakeServiceAccount@google.com"
+	s.SetBackendAuthIamServiceAccount(serviceAccount)
+
+	// Simulate IMDS failures.
+	s.OverrideMockMetadata(map[string]string{}, 100)
+
+	// Skip health checks, we expect these to fail.
+	s.SkipHealthChecks()
+
+	defer s.TearDown()
+	if err := s.Setup(testDataPathArgs); err != nil {
+		t.Fatalf("fail to setup test env, %v", err)
+	}
+
+	testData := []struct {
+		desc    string
+		method  string
+		path    string
+		message string
+		wantErr string
+	}{
+		{
+			desc:    "If IMDS is down, then Envoy will fail to start, even when using IAM",
+			method:  "GET",
+			path:    "/bearertoken/constant/42",
+			wantErr: `connect: connection refused`,
+		},
+	}
+
+	for _, tc := range testData {
+		url := fmt.Sprintf("http://localhost:%v%v", s.Ports().ListenerPort, tc.path)
+		_, err := client.DoWithHeaders(url, tc.method, tc.message, nil)
+
+		if err == nil {
+			t.Errorf("Test Desc(%s): expected err, got none", tc.desc)
+			continue
+		}
+
+		if !strings.Contains(err.Error(), tc.wantErr) {
+			t.Errorf("Test Desc(%s): want err: %s, got err: %s", tc.desc, tc.wantErr, err)
+		}
+	}
+}

--- a/tests/integration_test/iam_imds_data_path_test/iam_imds_data_path_test.go
+++ b/tests/integration_test/iam_imds_data_path_test/iam_imds_data_path_test.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/echo/client"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
+	"github.com/golang/glog"
 
 	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 )
@@ -20,91 +22,108 @@ var testDataPathArgs = []string{
 	"--suppress_envoy_headers",
 }
 
-func TestDataPathImdsSuccessWhenIamDown(t *testing.T) {
-	s := env.NewTestEnv(comp.TestDataPathImdsSuccessWhenIamDown, platform.EchoRemote)
-
-	// Simulate Iam failures.
-	s.SetIamResps(map[string]string{}, 100)
-
-	defer s.TearDown()
-	if err := s.Setup(testDataPathArgs); err != nil {
-		t.Fatalf("fail to setup test env, %v", err)
-	}
-
+func TestIamImdsDataPath(t *testing.T) {
 	testData := []struct {
-		desc     string
-		method   string
-		path     string
-		message  string
-		wantResp string
+		desc         string
+		useIam       bool
+		fakeIamDown  bool
+		fakeImdsDown bool
+		wantResp     string
+		wantErr      string
 	}{
 		{
-			desc:     "Backend auth with IMDS works, even when IAM is down",
-			method:   "GET",
-			path:     "/bearertoken/constant/42",
+			desc:     "Backend auth with IMDS works when everything is up",
 			wantResp: `{"Authorization": "Bearer ya29.new", "RequestURI": "/bearertoken/constant?foo=42"}`,
 		},
-	}
-
-	for _, tc := range testData {
-		url := fmt.Sprintf("http://localhost:%v%v", s.Ports().ListenerPort, tc.path)
-		resp, err := client.DoWithHeaders(url, tc.method, tc.message, nil)
-
-		if err != nil {
-			t.Fatalf("Test Desc(%s): %v", tc.desc, err)
-		}
-
-		gotResp := string(resp)
-		if !utils.JsonEqual(gotResp, tc.wantResp) {
-			t.Errorf("Test Desc(%s): want: %s, got: %s", tc.desc, tc.wantResp, gotResp)
-		}
-	}
-}
-
-func TestDataPathIamFailWhenImdsDown(t *testing.T) {
-	s := env.NewTestEnv(comp.TestDataPathIamFailWhenImdsDown, platform.EchoRemote)
-
-	// Use IAM instead of IMDS.
-	serviceAccount := "fakeServiceAccount@google.com"
-	s.SetBackendAuthIamServiceAccount(serviceAccount)
-
-	// Simulate IMDS failures.
-	s.OverrideMockMetadata(map[string]string{}, 100)
-
-	// Skip health checks, we expect these to fail.
-	s.SkipHealthChecks()
-
-	defer s.TearDown()
-	if err := s.Setup(testDataPathArgs); err != nil {
-		t.Fatalf("fail to setup test env, %v", err)
-	}
-
-	testData := []struct {
-		desc    string
-		method  string
-		path    string
-		message string
-		wantErr string
-	}{
 		{
-			desc:    "If IMDS is down, then Envoy will fail to start, even when using IAM",
-			method:  "GET",
-			path:    "/bearertoken/constant/42",
-			wantErr: `connect: connection refused`,
+			desc:        "Backend auth with IMDS works, even when IAM is down",
+			fakeIamDown: true,
+			wantResp:    `{"Authorization": "Bearer ya29.new", "RequestURI": "/bearertoken/constant?foo=42"}`,
+		},
+		{
+			desc:         "Backend auth with IMDS fails (envoy doesn't start) when IMDS is down",
+			fakeImdsDown: true,
+			wantErr:      `connect: connection refused`,
+		},
+		{
+			desc:     "Backend auth with IAM works when everything is up",
+			useIam:   true,
+			wantResp: `{"Authorization": "Bearer default-test-id-token", "RequestURI": "/bearertoken/constant?foo=42"}`,
+		},
+		{
+			desc:        "Backend auth with IAM fails (envoy doesn't start) when IAM is down",
+			useIam:      true,
+			fakeIamDown: true,
+			wantErr:     `connect: connection refused`,
+		},
+		{
+			desc:         "Backend auth with IAM fails (envoy doesn't start) when IMDS is down",
+			useIam:       true,
+			fakeImdsDown: true,
+			wantErr:      `connect: connection refused`,
 		},
 	}
 
 	for _, tc := range testData {
-		url := fmt.Sprintf("http://localhost:%v%v", s.Ports().ListenerPort, tc.path)
-		_, err := client.DoWithHeaders(url, tc.method, tc.message, nil)
 
-		if err == nil {
-			t.Errorf("Test Desc(%s): expected err, got none", tc.desc)
-			continue
-		}
+		// Place in closure to allow deferring in loop.
+		func() {
 
-		if !strings.Contains(err.Error(), tc.wantErr) {
-			t.Errorf("Test Desc(%s): want err: %s, got err: %s", tc.desc, tc.wantErr, err)
-		}
+			// By default, IMDS will be used for service control and backend auth.
+			s := env.NewTestEnv(comp.TestIamImdsDataPath, platform.EchoRemote)
+
+			if tc.useIam {
+				// Use IAM for service control and backend auth.
+				serviceAccount := "fakeServiceAccount@google.com"
+				s.SetBackendAuthIamServiceAccount(serviceAccount)
+				s.SetIamResps(map[string]string{}, 1)
+			}
+
+			if tc.fakeImdsDown {
+				// Fake IMDS will respond with failures.
+				s.OverrideMockMetadata(map[string]string{}, 100)
+			}
+
+			if tc.fakeIamDown {
+				// Fake IAM will respond with failures.
+				s.SetIamResps(map[string]string{}, 100)
+			}
+
+			if tc.wantErr != "" {
+				// Skip health checks since we expect an error.
+				s.SkipHealthChecks()
+				glog.Infof("Sleeping to ensure Envoy is starting")
+				time.Sleep(7 * time.Second)
+			}
+
+			defer s.TearDown()
+			if err := s.Setup(testDataPathArgs); err != nil {
+				t.Fatalf("fail to setup test env, %v", err)
+			}
+
+			url := fmt.Sprintf("http://localhost:%v%v", s.Ports().ListenerPort, "/bearertoken/constant/42")
+			resp, err := client.DoWithHeaders(url, "GET", "", nil)
+
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Errorf("Test Desc(%s): expected err, got none", tc.desc)
+					return
+				}
+
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("Test Desc(%s): want err: %s, got err: %s", tc.desc, tc.wantErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Test Desc(%s): %v", tc.desc, err)
+					return
+				}
+
+				gotResp := string(resp)
+				if !utils.JsonEqual(gotResp, tc.wantResp) {
+					t.Errorf("Test Desc(%s): want: %s, got: %s", tc.desc, tc.wantResp, gotResp)
+				}
+			}
+		}()
 	}
 }


### PR DESCRIPTION
Change is simple: Just remove the `ready()` on failures in `TokenSubscriber`.

Testing Done:
- Unit tests for retry.
- Adjusted pre-existing integration tests to not fail when envoy fails to start.
- Added new integration tests to ensure envoy does not start up.