### PR TITLE
Minor changes to fuzz targets

### DIFF
--- a/src/envoy/http/backend_routing/BUILD
+++ b/src/envoy/http/backend_routing/BUILD
@@ -57,7 +57,7 @@ envoy_cc_test(
 )
 
 envoy_cc_fuzz_test(
-    name = "filter_fuzz_test",
+    name = "backend_routing_filter_fuzz_test",
     srcs = ["filter_fuzz_test.cc"],
     corpus = "//tests/fuzz/corpus:backend_routing_filter_corpus",
     repository = "@envoy",

--- a/tests/fuzz/corpus/iam_token_subscriber/invalid-header-values.prototxt
+++ b/tests/fuzz/corpus/iam_token_subscriber/invalid-header-values.prototxt
@@ -1,0 +1,13 @@
+iam_service_cluster: "test-@cluster-1"
+iam_service_uri: "test-uri-3"
+access_token: "test-access-token-3"
+async_client_response {
+  headers {
+    headers {
+      key: "-"
+    }
+  }
+  data: "-"
+  trailers {
+  }
+}


### PR DESCRIPTION
- Add a failure case that will pass once Envoy is updated.
- Rename fuzz target. Envoy fuzz setup on oss-fuzz requires each target to have a unique name, even across directories.

Signed-off-by: Teju Nareddy <nareddyt@google.com>