### PR TITLE
Update envoy to 2020-03-03

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -39,9 +39,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # 3) Check if envoy_build_config/extensions_build_config.bzl is up-to-date.
 # Try to match it with the one in source/extensions and comment out unneeded extensions.
 
-ENVOY_SHA1 = "f5e9c4f22c0573ac497424485994312e4f8df8b0"  # 2020-01-08
+ENVOY_SHA1 = "3d162074fca24448334e18fb2fa507ffd7819e7e"  # 2020-02-24
 
-ENVOY_SHA256 = "f34a6498044760ad710999a3753d0b7ce63b7e8c6e2c40ee3f81866e5a73cb47"
+ENVOY_SHA256 = "7a302b5075deeeb47fee9f9e55ecd0991d7ab744afe5a6190157343151fcac46"
 
 http_archive(
     name = "envoy",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -39,9 +39,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # 3) Check if envoy_build_config/extensions_build_config.bzl is up-to-date.
 # Try to match it with the one in source/extensions and comment out unneeded extensions.
 
-ENVOY_SHA1 = "3d162074fca24448334e18fb2fa507ffd7819e7e"  # 2020-02-24
+ENVOY_SHA1 = "5b1723ff54b1a51e104c514ee6363234aaa44366"  # 2020-03-03
 
-ENVOY_SHA256 = "7a302b5075deeeb47fee9f9e55ecd0991d7ab744afe5a6190157343151fcac46"
+ENVOY_SHA256 = "03e98c75079814a018f8544761723687afba829a1ce0c98c02009bd599b6ea3d"
 
 http_archive(
     name = "envoy",

--- a/src/envoy/http/backend_auth/filter.cc
+++ b/src/envoy/http/backend_auth/filter.cc
@@ -30,7 +30,7 @@ namespace BackendAuth {
 using Http::FilterDataStatus;
 using Http::FilterHeadersStatus;
 using Http::FilterTrailersStatus;
-using Http::HeaderMap;
+using Http::RequestHeaderMap;
 
 namespace {
 constexpr char kBearer[] = "Bearer ";
@@ -43,9 +43,9 @@ typedef ConstSingleton<RcDetailsValues> RcDetails;
 
 }  // namespace
 
-FilterHeadersStatus Filter::decodeHeaders(HeaderMap& headers, bool) {
+FilterHeadersStatus Filter::decodeHeaders(RequestHeaderMap& headers, bool) {
   absl::string_view operation = Utils::getStringFilterState(
-      decoder_callbacks_->streamInfo().filterState(), Utils::kOperation);
+      *decoder_callbacks_->streamInfo().filterState(), Utils::kOperation);
   // NOTE: this shouldn't happen in practice because Path Matcher filter would
   // have already rejected the request.
   if (operation.empty()) {

--- a/src/envoy/http/backend_auth/filter.h
+++ b/src/envoy/http/backend_auth/filter.h
@@ -33,7 +33,8 @@ class Filter : public Http::PassThroughDecoderFilter,
   Filter(FilterConfigSharedPtr config) : config_(config) {}
 
   // Http::StreamDecoderFilter
-  Http::FilterHeadersStatus decodeHeaders(Http::HeaderMap&, bool) override;
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap&,
+                                          bool) override;
 
  private:
   const FilterConfigSharedPtr config_;

--- a/src/envoy/http/backend_auth/filter_test.cc
+++ b/src/envoy/http/backend_auth/filter_test.cc
@@ -50,7 +50,8 @@ class BackendAuthFilterTest : public ::testing::Test {
 };
 
 TEST_F(BackendAuthFilterTest, NoOperationName) {
-  Http::TestHeaderMapImpl headers{{":method", "GET"}, {":path", "/books/1"}};
+  Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
+                                         {":path", "/books/1"}};
 
   EXPECT_CALL(*mock_filter_config_, cfg_parser).Times(0);
 
@@ -61,9 +62,10 @@ TEST_F(BackendAuthFilterTest, NoOperationName) {
 }
 
 TEST_F(BackendAuthFilterTest, NotHaveAudience) {
-  Http::TestHeaderMapImpl headers{{":method", "GET"}, {":path", "/books/1"}};
+  Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
+                                         {":path", "/books/1"}};
   Utils::setStringFilterState(
-      mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kOperation,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kOperation,
       "operation-without-audience");
 
   EXPECT_CALL(*mock_filter_config_, cfg_parser)
@@ -81,9 +83,10 @@ TEST_F(BackendAuthFilterTest, NotHaveAudience) {
 }
 
 TEST_F(BackendAuthFilterTest, HasAudienceButGetsEmptyToken) {
-  Http::TestHeaderMapImpl headers{{":method", "GET"}, {":path", "/books/1"}};
+  Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
+                                         {":path", "/books/1"}};
   Utils::setStringFilterState(
-      mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kOperation,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kOperation,
       "operation-with-audience");
 
   EXPECT_CALL(*mock_filter_config_, cfg_parser)
@@ -105,9 +108,10 @@ TEST_F(BackendAuthFilterTest, HasAudienceButGetsEmptyToken) {
 }
 
 TEST_F(BackendAuthFilterTest, SucceedAppendToken) {
-  Http::TestHeaderMapImpl headers{{":method", "GET"}, {":path", "/books/1"}};
+  Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
+                                         {":path", "/books/1"}};
   Utils::setStringFilterState(
-      mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kOperation,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kOperation,
       "operation-with-audience");
   testing::NiceMock<Stats::MockStore> scope;
   const std::string prefix = "";

--- a/src/envoy/http/backend_routing/filter.cc
+++ b/src/envoy/http/backend_routing/filter.cc
@@ -28,8 +28,9 @@ using Http::FilterHeadersStatus;
 
 Filter::Filter(FilterConfigSharedPtr config) : config_(config) {}
 
-FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool) {
-  const auto& filter_state = decoder_callbacks_->streamInfo().filterState();
+FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
+                                          bool) {
+  const auto& filter_state = *decoder_callbacks_->streamInfo().filterState();
   absl::string_view operation =
       Utils::getStringFilterState(filter_state, Utils::kOperation);
   // NOTE: this shouldn't happen in practice because Path Matcher filter would

--- a/src/envoy/http/backend_routing/filter.h
+++ b/src/envoy/http/backend_routing/filter.h
@@ -33,7 +33,8 @@ class Filter : public Http::PassThroughDecoderFilter,
   Filter(FilterConfigSharedPtr config);
 
   // Http::StreamDecoderFilter
-  Http::FilterHeadersStatus decodeHeaders(Http::HeaderMap&, bool) override;
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap&,
+                                          bool) override;
 
  private:
   const FilterConfigSharedPtr config_;

--- a/src/envoy/http/backend_routing/filter_fuzz_test.cc
+++ b/src/envoy/http/backend_routing/filter_fuzz_test.cc
@@ -37,12 +37,12 @@ DEFINE_PROTO_FUZZER(
 
     // Set the operation name using the first backend routing rule.
     Utils::setStringFilterState(
-        mock_decoder_callbacks.stream_info_.filter_state_, Utils::kOperation,
+        *mock_decoder_callbacks.stream_info_.filter_state_, Utils::kOperation,
         input.config().rules(0).operation());
 
     // Set the variable binding query params.
     Utils::setStringFilterState(
-        mock_decoder_callbacks.stream_info_.filter_state_, Utils::kQueryParams,
+        *mock_decoder_callbacks.stream_info_.filter_state_, Utils::kQueryParams,
         input.binding_query_params());
 
     // Create the filter.
@@ -52,7 +52,9 @@ DEFINE_PROTO_FUZZER(
     filter.setDecoderFilterCallbacks(mock_decoder_callbacks);
 
     // Generate the user request.
-    auto headers = Envoy::Fuzz::fromHeaders(input.user_request().headers());
+    auto headers =
+        Envoy::Fuzz::fromHeaders<Envoy::Http::TestRequestHeaderMapImpl>(
+            input.user_request().headers());
 
     // Functions under test.
     filter.decodeHeaders(headers, false);

--- a/src/envoy/http/backend_routing/filter_test.cc
+++ b/src/envoy/http/backend_routing/filter_test.cc
@@ -91,7 +91,8 @@ class BackendRoutingFilterTest : public ::testing::Test {
 };
 
 TEST_F(BackendRoutingFilterTest, NoOperationName) {
-  Http::TestHeaderMapImpl headers{{":method", "GET"}, {":path", "/books/1"}};
+  Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
+                                         {":path", "/books/1"}};
 
   // Call function under test
   Envoy::Http::FilterHeadersStatus status =
@@ -103,9 +104,10 @@ TEST_F(BackendRoutingFilterTest, NoOperationName) {
 }
 
 TEST_F(BackendRoutingFilterTest, UnknownOperationName) {
-  Http::TestHeaderMapImpl headers{{":method", "GET"}, {":path", "/books/1"}};
+  Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
+                                         {":path", "/books/1"}};
   Utils::setStringFilterState(
-      mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kOperation,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kOperation,
       "unknown-operation-name");
 
   // Call function under test
@@ -118,9 +120,9 @@ TEST_F(BackendRoutingFilterTest, UnknownOperationName) {
 }
 
 TEST_F(BackendRoutingFilterTest, NoPathHeader) {
-  Http::TestHeaderMapImpl headers{{":method", "GET"}};
+  Http::TestRequestHeaderMapImpl headers{{":method", "GET"}};
   Utils::setStringFilterState(
-      mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kOperation,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kOperation,
       "const-operation");
 
   // Call function under test
@@ -133,9 +135,10 @@ TEST_F(BackendRoutingFilterTest, NoPathHeader) {
 }
 
 TEST_F(BackendRoutingFilterTest, ConstantAddress) {
-  Http::TestHeaderMapImpl headers{{":method", "GET"}, {":path", "/books/1"}};
+  Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
+                                         {":path", "/books/1"}};
   Utils::setStringFilterState(
-      mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kOperation,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kOperation,
       "const-operation");
 
   // Call function under test
@@ -148,9 +151,10 @@ TEST_F(BackendRoutingFilterTest, ConstantAddress) {
 }
 
 TEST_F(BackendRoutingFilterTest, ConstantAddressWithBadPrefix) {
-  Http::TestHeaderMapImpl headers{{":method", "GET"}, {":path", "/books/1"}};
+  Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
+                                         {":path", "/books/1"}};
   Utils::setStringFilterState(
-      mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kOperation,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kOperation,
       "const-with-bad-prefix-operation");
 
   // Call function under test
@@ -166,12 +170,13 @@ TEST_F(BackendRoutingFilterTest, ConstantAddressWithBadPrefix) {
 }
 
 TEST_F(BackendRoutingFilterTest, ConstantAddressWithPathMatcherQueryParams) {
-  Http::TestHeaderMapImpl headers{{":method", "GET"}, {":path", "/books/1"}};
+  Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
+                                         {":path", "/books/1"}};
   Utils::setStringFilterState(
-      mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kOperation,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kOperation,
       "const-operation");
   Utils::setStringFilterState(
-      mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kQueryParams,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kQueryParams,
       "id=1");
 
   // Call function under test
@@ -190,10 +195,10 @@ class BackendRoutingFilterWithQueryParamsTest
     : public BackendRoutingFilterTest {};
 
 TEST_F(BackendRoutingFilterWithQueryParamsTest, AppendPathToAddress) {
-  Http::TestHeaderMapImpl headers{
+  Http::TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/books/1?view=summary&filter=deleted"}};
   Utils::setStringFilterState(
-      mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kOperation,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kOperation,
       "append-operation");
 
   // Call function under test
@@ -207,10 +212,10 @@ TEST_F(BackendRoutingFilterWithQueryParamsTest, AppendPathToAddress) {
 }
 
 TEST_F(BackendRoutingFilterWithQueryParamsTest, AppendPathToAddressWithPrefix) {
-  Http::TestHeaderMapImpl headers{
+  Http::TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/books/1?view=summary&filter=deleted"}};
   Utils::setStringFilterState(
-      mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kOperation,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kOperation,
       "append-with-prefix-operation");
 
   // Call function under test
@@ -224,10 +229,10 @@ TEST_F(BackendRoutingFilterWithQueryParamsTest, AppendPathToAddressWithPrefix) {
 }
 
 TEST_F(BackendRoutingFilterWithQueryParamsTest, ConstantAddress) {
-  Http::TestHeaderMapImpl headers{
+  Http::TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/books/1?view=summary&filter=deleted"}};
   Utils::setStringFilterState(
-      mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kOperation,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kOperation,
       "const-operation");
 
   // Call function under test
@@ -242,13 +247,13 @@ TEST_F(BackendRoutingFilterWithQueryParamsTest, ConstantAddress) {
 
 TEST_F(BackendRoutingFilterWithQueryParamsTest,
        ConstantAddressWithPathMatcherQueryParams) {
-  Http::TestHeaderMapImpl headers{
+  Http::TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/books/1?view=summary&filter=deleted"}};
   Utils::setStringFilterState(
-      mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kOperation,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kOperation,
       "const-operation");
   Utils::setStringFilterState(
-      mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kQueryParams,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kQueryParams,
       "id=1");
 
   // Call function under test
@@ -262,10 +267,10 @@ TEST_F(BackendRoutingFilterWithQueryParamsTest,
 }
 
 TEST_F(BackendRoutingFilterWithQueryParamsTest, ConstantAddressWithPrefix) {
-  Http::TestHeaderMapImpl headers{
+  Http::TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/books/1?view=summary&filter=deleted"}};
   Utils::setStringFilterState(
-      mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kOperation,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kOperation,
       "const-with-prefix-operation");
 
   // Call function under test

--- a/src/envoy/http/path_matcher/filter.cc
+++ b/src/envoy/http/path_matcher/filter.cc
@@ -39,7 +39,7 @@ typedef ConstSingleton<RcDetailsValues> RcDetails;
 
 }  // namespace
 
-Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers,
+Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
                                                 bool) {
   std::string method(Utils::getRequestHTTPMethodWithOverride(
       headers.Method()->value().getStringView(), headers));
@@ -53,7 +53,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers,
 
   ENVOY_LOG(debug, "matched operation: {}", *operation);
   StreamInfo::FilterState& filter_state =
-      decoder_callbacks_->streamInfo().filterState();
+      *decoder_callbacks_->streamInfo().filterState();
   Utils::setStringFilterState(filter_state, Utils::kOperation, *operation);
 
   if (config_->needParameterExtraction(*operation)) {

--- a/src/envoy/http/path_matcher/filter.h
+++ b/src/envoy/http/path_matcher/filter.h
@@ -29,7 +29,8 @@ class Filter : public Http::PassThroughDecoderFilter,
  public:
   Filter(FilterConfigSharedPtr config) : config_(config) {}
 
-  Http::FilterHeadersStatus decodeHeaders(Http::HeaderMap&, bool) override;
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap&,
+                                          bool) override;
 
  private:
   void rejectRequest(Http::Code code, absl::string_view error_msg);

--- a/src/envoy/http/path_matcher/filter_test.cc
+++ b/src/envoy/http/path_matcher/filter_test.cc
@@ -72,14 +72,14 @@ class FilterTest : public ::testing::Test {
 
 TEST_F(FilterTest, DecodeHeadersWithOperation) {
   // Test: a request matches a operation
-  Http::TestHeaderMapImpl headers{{":method", "GET"}, {":path", "/bar"}};
+  Http::TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/bar"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue,
             filter_->decodeHeaders(headers, false));
 
-  EXPECT_EQ(Utils::getStringFilterState(mock_cb_.stream_info_.filter_state_,
+  EXPECT_EQ(Utils::getStringFilterState(*mock_cb_.stream_info_.filter_state_,
                                         Utils::kOperation),
             "1.cloudesf_testing_cloud_goog.Bar");
-  EXPECT_EQ(Utils::getStringFilterState(mock_cb_.stream_info_.filter_state_,
+  EXPECT_EQ(Utils::getStringFilterState(*mock_cb_.stream_info_.filter_state_,
                                         Utils::kQueryParams),
             "");
 
@@ -92,19 +92,21 @@ TEST_F(FilterTest, DecodeHeadersWithOperation) {
 
   Buffer::OwnedImpl data("");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
+
+  Http::TestRequestTrailerMapImpl trailers;
   EXPECT_EQ(Http::FilterTrailersStatus::Continue,
-            filter_->decodeTrailers(headers));
+            filter_->decodeTrailers(trailers));
 }
 
 TEST_F(FilterTest, DecodeHeadersWithMethodOveride) {
   // Test: a request with a method override matches a operation
-  Http::TestHeaderMapImpl headers{{":method", "POST"},
-                                  {":path", "/bar"},
-                                  {"x-http-method-override", "GET"}};
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {":path", "/bar"},
+                                         {"x-http-method-override", "GET"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue,
             filter_->decodeHeaders(headers, true));
 
-  EXPECT_EQ(Utils::getStringFilterState(mock_cb_.stream_info_.filter_state_,
+  EXPECT_EQ(Utils::getStringFilterState(*mock_cb_.stream_info_.filter_state_,
                                         Utils::kOperation),
             "1.cloudesf_testing_cloud_goog.Bar");
 
@@ -118,14 +120,15 @@ TEST_F(FilterTest, DecodeHeadersWithMethodOveride) {
 
 TEST_F(FilterTest, DecodeHeadersExtractParameters) {
   // Test: a request needs to extract parameters
-  Http::TestHeaderMapImpl headers{{":method", "GET"}, {":path", "/foo/123"}};
+  Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
+                                         {":path", "/foo/123"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue,
             filter_->decodeHeaders(headers, true));
 
-  EXPECT_EQ(Utils::getStringFilterState(mock_cb_.stream_info_.filter_state_,
+  EXPECT_EQ(Utils::getStringFilterState(*mock_cb_.stream_info_.filter_state_,
                                         Utils::kOperation),
             "1.cloudesf_testing_cloud_goog.Foo");
-  EXPECT_EQ(Utils::getStringFilterState(mock_cb_.stream_info_.filter_state_,
+  EXPECT_EQ(Utils::getStringFilterState(*mock_cb_.stream_info_.filter_state_,
                                         Utils::kQueryParams),
             "fooBar=123");
 
@@ -139,7 +142,8 @@ TEST_F(FilterTest, DecodeHeadersExtractParameters) {
 
 TEST_F(FilterTest, DecodeHeadersNoMatch) {
   // Test: a request no match
-  Http::TestHeaderMapImpl headers{{":method", "POST"}, {":path", "/bar"}};
+  Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
+                                         {":path", "/bar"}};
 
   // Filter should reject this request
   EXPECT_CALL(
@@ -149,7 +153,7 @@ TEST_F(FilterTest, DecodeHeadersNoMatch) {
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(headers, true));
 
-  EXPECT_EQ(Utils::getStringFilterState(mock_cb_.stream_info_.filter_state_,
+  EXPECT_EQ(Utils::getStringFilterState(*mock_cb_.stream_info_.filter_state_,
                                         Utils::kOperation),
             "");
 

--- a/src/envoy/http/service_control/filter.cc
+++ b/src/envoy/http/service_control/filter.cc
@@ -42,7 +42,7 @@ void ServiceControlFilter::onDestroy() {
 }
 
 Http::FilterHeadersStatus ServiceControlFilter::decodeHeaders(
-    Http::HeaderMap& headers, bool) {
+    Http::RequestHeaderMap& headers, bool) {
   ENVOY_LOG(debug, "Called ServiceControl Filter : {}", __func__);
 
   Envoy::Tracing::Span& parent_span = decoder_callbacks_->activeSpan();
@@ -109,7 +109,7 @@ Http::FilterDataStatus ServiceControlFilter::decodeData(Buffer::Instance& data,
 }
 
 Http::FilterTrailersStatus ServiceControlFilter::decodeTrailers(
-    Http::HeaderMap&) {
+    Http::RequestTrailerMap&) {
   ENVOY_LOG(debug, "Called ServiceControl Filter : {}", __func__);
   if (state_ == Calling) {
     return Http::FilterTrailersStatus::StopIteration;
@@ -118,7 +118,7 @@ Http::FilterTrailersStatus ServiceControlFilter::decodeTrailers(
 }
 
 Http::FilterHeadersStatus ServiceControlFilter::encodeHeaders(
-    Http::HeaderMap& headers, bool) {
+    Http::ResponseHeaderMap& headers, bool) {
   ENVOY_LOG(debug, "Called ServiceControl Filter : {} before", __func__);
 
   // For the cases the decodeHeaders not called, like the request get failed in
@@ -138,10 +138,11 @@ Http::FilterDataStatus ServiceControlFilter::encodeData(Buffer::Instance& data,
   return Http::FilterDataStatus::Continue;
 }
 
-void ServiceControlFilter::log(const Http::HeaderMap* request_headers,
-                               const Http::HeaderMap* response_headers,
-                               const Http::HeaderMap* response_trailers,
-                               const StreamInfo::StreamInfo& stream_info) {
+void ServiceControlFilter::log(
+    const Http::RequestHeaderMap* request_headers,
+    const Http::ResponseHeaderMap* response_headers,
+    const Http::ResponseTrailerMap* response_trailers,
+    const StreamInfo::StreamInfo& stream_info) {
   ENVOY_LOG(debug, "Called ServiceControl Filter : {}", __func__);
   if (!handler_) {
     if (!request_headers) return;

--- a/src/envoy/http/service_control/filter.h
+++ b/src/envoy/http/service_control/filter.h
@@ -42,22 +42,22 @@ class ServiceControlFilter : public Http::PassThroughFilter,
   void onDestroy() override;
 
   // Http::StreamDecoderFilter
-  Http::FilterHeadersStatus decodeHeaders(Http::HeaderMap& headers,
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers,
                                           bool) override;
   Http::FilterDataStatus decodeData(Buffer::Instance& data,
                                     bool end_stream) override;
-  Http::FilterTrailersStatus decodeTrailers(Http::HeaderMap&) override;
+  Http::FilterTrailersStatus decodeTrailers(Http::RequestTrailerMap&) override;
 
   // Http::StreamEncoderFilter
-  Http::FilterHeadersStatus encodeHeaders(Http::HeaderMap& headers,
+  Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap& headers,
                                           bool) override;
   Http::FilterDataStatus encodeData(Buffer::Instance& data,
                                     bool end_stream) override;
 
   // Called when the request is completed.
-  void log(const Http::HeaderMap* request_headers,
-           const Http::HeaderMap* response_headers,
-           const Http::HeaderMap* response_trailers,
+  void log(const Http::RequestHeaderMap* request_headers,
+           const Http::ResponseHeaderMap* response_headers,
+           const Http::ResponseTrailerMap* response_trailers,
            const StreamInfo::StreamInfo& stream_info) override;
 
   // For Handler::CheckDoneCallback, called when callCheck() is done

--- a/src/envoy/http/service_control/filter_test.cc
+++ b/src/envoy/http/service_control/filter_test.cc
@@ -60,7 +60,10 @@ class FilterTest : public ::testing::Test {
   testing::NiceMock<MockBuffer> mock_buffer_;
   testing::NiceMock<Stats::MockStore> mock_stats_scope_;
   ServiceControlFilterStatBase stats_base_;
-  Http::TestHeaderMapImpl headers_;
+  Http::TestRequestHeaderMapImpl req_headers_;
+  Http::TestRequestTrailerMapImpl req_trailer_;
+  Http::TestResponseHeaderMapImpl resp_headers_;
+  Http::TestResponseTrailerMapImpl resp_trailer_;
 
   // Tracing mocks
   std::unique_ptr<Envoy::Tracing::MockSpan> mock_span_;
@@ -74,12 +77,12 @@ TEST_F(FilterTest, DecodeHeadersSyncOKStatus) {
 
   // Call onCheckDone synchronously
   EXPECT_CALL(*mock_handler, callCheck(_, _, _))
-      .WillOnce(Invoke([](Http::HeaderMap&, Envoy::Tracing::Span&,
+      .WillOnce(Invoke([](Http::RequestHeaderMap&, Envoy::Tracing::Span&,
                           ServiceControlHandler::CheckDoneCallback& callback) {
         callback.onCheckDone(Status::OK);
       }));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue,
-            filter_->decodeHeaders(headers_, true));
+            filter_->decodeHeaders(req_headers_, true));
 
   // Verify handler->onDestroy is called when filter::onDestroy() is called
   EXPECT_CALL(*mock_handler, onDestroy()).Times(1);
@@ -100,7 +103,7 @@ TEST_F(FilterTest, DecodeHeadersSyncBadStatus) {
 
   // Call onCheckDone synchronously
   EXPECT_CALL(*mock_handler, callCheck(_, _, _))
-      .WillOnce(Invoke([](Http::HeaderMap&, Envoy::Tracing::Span&,
+      .WillOnce(Invoke([](Http::RequestHeaderMap&, Envoy::Tracing::Span&,
                           ServiceControlHandler::CheckDoneCallback& callback) {
         callback.onCheckDone(kBadStatus);
       }));
@@ -111,7 +114,7 @@ TEST_F(FilterTest, DecodeHeadersSyncBadStatus) {
       setResponseFlag(StreamInfo::ResponseFlag::UnauthorizedExternalService));
 
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
-            filter_->decodeHeaders(headers_, true));
+            filter_->decodeHeaders(req_headers_, true));
 }
 
 TEST_F(FilterTest, DecodeHeadersAsyncGoodStatus) {
@@ -128,12 +131,12 @@ TEST_F(FilterTest, DecodeHeadersAsyncGoodStatus) {
       // This invocation works around SaveArg storing the value to
       // the pointer in a way that does not work with the interface
       .WillOnce(Invoke([&stored_check_done_callback](
-                           Http::HeaderMap&, Envoy::Tracing::Span&,
+                           Http::RequestHeaderMap&, Envoy::Tracing::Span&,
                            ServiceControlHandler::CheckDoneCallback& callback) {
         stored_check_done_callback = &callback;
       }));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
-            filter_->decodeHeaders(headers_, true));
+            filter_->decodeHeaders(req_headers_, true));
 
   EXPECT_CALL(mock_decoder_callbacks_, continueDecoding());
   stored_check_done_callback->onCheckDone(Status::OK);
@@ -156,12 +159,12 @@ TEST_F(FilterTest, DecodeHeadersAsyncBadStatus) {
           // This invocation works around SaveArg storing the value to
           // the pointer in a way that does not work with the interface
           Invoke([&stored_check_done_callback](
-                     Http::HeaderMap&, Envoy::Tracing::Span&,
+                     Http::RequestHeaderMap&, Envoy::Tracing::Span&,
                      ServiceControlHandler::CheckDoneCallback& callback) {
             stored_check_done_callback = &callback;
           }));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
-            filter_->decodeHeaders(headers_, true));
+            filter_->decodeHeaders(req_headers_, true));
 
   // Filter should reject this request
   // TODO(toddbeckman) Figure out how to EXPECT_CALL sendLocalReply directly
@@ -176,7 +179,7 @@ TEST_F(FilterTest, LogWithoutHandlerOrHeaders) {
   EXPECT_CALL(mock_handler_factory_, createHandler_(_, _)).Times(0);
 
   // Filter has no handler. If it tries to callReport, it will seg fault
-  filter_->log(nullptr, &headers_, &headers_,
+  filter_->log(nullptr, &resp_headers_, &resp_trailer_,
                mock_decoder_callbacks_.stream_info_);
 }
 
@@ -186,7 +189,7 @@ TEST_F(FilterTest, LogWithoutHandler) {
   EXPECT_CALL(mock_handler_factory_, createHandler_(_, _))
       .WillOnce(Return(mock_handler));
   EXPECT_CALL(*mock_handler, callReport(_, _, _, _));
-  filter_->log(&headers_, &headers_, &headers_,
+  filter_->log(&req_headers_, &resp_headers_, &resp_trailer_,
                mock_decoder_callbacks_.stream_info_);
 }
 
@@ -196,11 +199,11 @@ TEST_F(FilterTest, LogWithHandler) {
   auto* mock_handler = new testing::NiceMock<MockServiceControlHandler>();
   EXPECT_CALL(mock_handler_factory_, createHandler_(_, _))
       .WillOnce(Return(mock_handler));
-  filter_->decodeHeaders(headers_, true);
+  filter_->decodeHeaders(req_headers_, true);
 
   EXPECT_CALL(mock_handler_factory_, createHandler_(_, _)).Times(0);
   EXPECT_CALL(*mock_handler, callReport(_, _, _, _));
-  filter_->log(&headers_, &headers_, &headers_,
+  filter_->log(&req_headers_, &resp_headers_, &resp_trailer_,
                mock_decoder_callbacks_.stream_info_);
 }
 
@@ -210,7 +213,7 @@ TEST_F(FilterTest, DecodeHelpersWhileStopped) {
   EXPECT_CALL(mock_handler_factory_, createHandler_(_, _))
       .WillOnce(Return(mock_handler));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
-            filter_->decodeHeaders(headers_, true));
+            filter_->decodeHeaders(req_headers_, true));
 
   // Test: While Filter is Calling/stopped, decodeData returns Stop
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndWatermark,
@@ -218,7 +221,7 @@ TEST_F(FilterTest, DecodeHelpersWhileStopped) {
 
   // Test: While Filter is Calling/stopped, decodeTrailers returns Stop
   EXPECT_EQ(Http::FilterTrailersStatus::StopIteration,
-            filter_->decodeTrailers(headers_));
+            filter_->decodeTrailers(req_trailer_));
 }
 
 TEST_F(FilterTest, DecodeHelpersWhileContinuing) {
@@ -227,12 +230,12 @@ TEST_F(FilterTest, DecodeHelpersWhileContinuing) {
   EXPECT_CALL(mock_handler_factory_, createHandler_(_, _))
       .WillOnce(Return(mock_handler));
   EXPECT_CALL(*mock_handler, callCheck(_, _, _))
-      .WillOnce(Invoke([](Http::HeaderMap&, Envoy::Tracing::Span&,
+      .WillOnce(Invoke([](Http::RequestHeaderMap&, Envoy::Tracing::Span&,
                           ServiceControlHandler::CheckDoneCallback& callback) {
         callback.onCheckDone(Status::OK);
       }));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue,
-            filter_->decodeHeaders(headers_, true));
+            filter_->decodeHeaders(req_headers_, true));
 
   // Test: When Filter is Complete, decodeData returns Continue
   EXPECT_EQ(Http::FilterDataStatus::Continue,
@@ -240,7 +243,7 @@ TEST_F(FilterTest, DecodeHelpersWhileContinuing) {
 
   // Test: When Filter is Complete, decodeTrailers returns Continue
   EXPECT_EQ(Http::FilterTrailersStatus::Continue,
-            filter_->decodeTrailers(headers_));
+            filter_->decodeTrailers(req_trailer_));
 }
 
 TEST_F(FilterTest, DecodeDataSendStreamReport) {
@@ -249,12 +252,12 @@ TEST_F(FilterTest, DecodeDataSendStreamReport) {
   EXPECT_CALL(mock_handler_factory_, createHandler_(_, _))
       .WillOnce(Return(mock_handler));
   EXPECT_CALL(*mock_handler, callCheck(_, _, _))
-      .WillOnce(Invoke([](Http::HeaderMap&, Envoy::Tracing::Span&,
+      .WillOnce(Invoke([](Http::RequestHeaderMap&, Envoy::Tracing::Span&,
                           ServiceControlHandler::CheckDoneCallback& callback) {
         callback.onCheckDone(Status::OK);
       }));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue,
-            filter_->decodeHeaders(headers_, /*end_stream=*/true));
+            filter_->decodeHeaders(req_headers_, /*end_stream=*/true));
 
   mock_buffer_.add("filler");
 
@@ -268,12 +271,12 @@ TEST_F(FilterTest, EncodeDataSendStreamReport) {
   EXPECT_CALL(mock_handler_factory_, createHandler_(_, _))
       .WillOnce(Return(mock_handler));
   EXPECT_CALL(*mock_handler, callCheck(_, _, _))
-      .WillOnce(Invoke([](Http::HeaderMap&, Envoy::Tracing::Span&,
+      .WillOnce(Invoke([](Http::RequestHeaderMap&, Envoy::Tracing::Span&,
                           ServiceControlHandler::CheckDoneCallback& callback) {
         callback.onCheckDone(Status::OK);
       }));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue,
-            filter_->decodeHeaders(headers_, /*end_stream=*/true));
+            filter_->decodeHeaders(req_headers_, /*end_stream=*/true));
 
   mock_buffer_.add("filler");
 

--- a/src/envoy/http/service_control/handler.h
+++ b/src/envoy/http/service_control/handler.h
@@ -37,14 +37,14 @@ class ServiceControlHandler {
 
   // Make an async check call.
   // The headers could be modified by adding some.
-  virtual void callCheck(Http::HeaderMap& headers,
+  virtual void callCheck(Http::RequestHeaderMap& headers,
                          Envoy::Tracing::Span& parent_span,
                          CheckDoneCallback& callback) PURE;
 
   // Make a report call.
-  virtual void callReport(const Http::HeaderMap* request_headers,
-                          const Http::HeaderMap* response_headers,
-                          const Http::HeaderMap* response_trailers,
+  virtual void callReport(const Http::RequestHeaderMap* request_headers,
+                          const Http::ResponseHeaderMap* response_headers,
+                          const Http::ResponseTrailerMap* response_trailers,
                           std::chrono::system_clock::time_point now) PURE;
 
   // If the stream report interval has passed,
@@ -55,7 +55,7 @@ class ServiceControlHandler {
   // Process the response header to get the information needed for sending
   // intermediate reports.
   virtual void processResponseHeaders(
-      const Http::HeaderMap& response_headers) PURE;
+      const Http::ResponseHeaderMap& response_headers) PURE;
 
   // The request is about to be destroyed need to cancel all async requests.
   virtual void onDestroy() PURE;
@@ -67,7 +67,7 @@ class ServiceControlHandlerFactory {
   virtual ~ServiceControlHandlerFactory() = default;
 
   virtual ServiceControlHandlerPtr createHandler(
-      const Http::HeaderMap& headers,
+      const Http::RequestHeaderMap& headers,
       const StreamInfo::StreamInfo& stream_info) const PURE;
 };
 

--- a/src/envoy/http/service_control/handler_impl.cc
+++ b/src/envoy/http/service_control/handler_impl.cc
@@ -45,8 +45,9 @@ constexpr char JwtPayloadIssuerPath[] = "iss";
 constexpr char JwtPayloadAuidencePath[] = "aud";
 
 ServiceControlHandlerImpl::ServiceControlHandlerImpl(
-    const Http::HeaderMap& headers, const StreamInfo::StreamInfo& stream_info,
-    const std::string& uuid, const FilterConfigParser& cfg_parser,
+    const Http::RequestHeaderMap& headers,
+    const StreamInfo::StreamInfo& stream_info, const std::string& uuid,
+    const FilterConfigParser& cfg_parser,
     std::chrono::system_clock::time_point now)
     : cfg_parser_(cfg_parser),
       stream_info_(stream_info),
@@ -141,7 +142,7 @@ void ServiceControlHandlerImpl::prepareReportRequest(
   fillGCPInfo(cfg_parser_.config(), info);
 }
 
-void ServiceControlHandlerImpl::callCheck(Http::HeaderMap& headers,
+void ServiceControlHandlerImpl::callCheck(Http::RequestHeaderMap& headers,
                                           Envoy::Tracing::Span& parent_span,
                                           CheckDoneCallback& callback) {
   if (!isConfigured()) {
@@ -216,7 +217,7 @@ void ServiceControlHandlerImpl::callQuota() {
 }
 
 void ServiceControlHandlerImpl::onCheckResponse(
-    Http::HeaderMap& headers, const Status& status,
+    Http::RequestHeaderMap& headers, const Status& status,
     const CheckResponseInfo& response_info) {
   check_response_info_ = response_info;
 
@@ -237,15 +238,15 @@ void ServiceControlHandlerImpl::onCheckResponse(
 }
 
 void ServiceControlHandlerImpl::processResponseHeaders(
-    const Http::HeaderMap& response_headers) {
+    const Http::ResponseHeaderMap& response_headers) {
   frontend_protocol_ = getFrontendProtocol(&response_headers, stream_info_);
   response_header_size_ = response_headers.byteSize();
 }
 
 void ServiceControlHandlerImpl::callReport(
-    const Http::HeaderMap* request_headers,
-    const Http::HeaderMap* response_headers,
-    const Http::HeaderMap* response_trailers,
+    const Http::RequestHeaderMap* request_headers,
+    const Http::ResponseHeaderMap* response_headers,
+    const Http::ResponseTrailerMap* response_trailers,
     std::chrono::system_clock::time_point now) {
   if (require_ctx_ == nullptr) {
     require_ctx_ = cfg_parser_.non_match_rqm_ctx();

--- a/src/envoy/http/service_control/handler_impl.h
+++ b/src/envoy/http/service_control/handler_impl.h
@@ -38,7 +38,7 @@ namespace ServiceControl {
 class ServiceControlHandlerImpl : public Logger::Loggable<Logger::Id::filter>,
                                   public ServiceControlHandler {
  public:
-  ServiceControlHandlerImpl(const Http::HeaderMap& headers,
+  ServiceControlHandlerImpl(const Http::RequestHeaderMap& headers,
                             const StreamInfo::StreamInfo& stream_info,
                             const std::string& uuid,
                             const FilterConfigParser& cfg_parser,
@@ -46,18 +46,20 @@ class ServiceControlHandlerImpl : public Logger::Loggable<Logger::Id::filter>,
                                 std::chrono::system_clock::now());
   ~ServiceControlHandlerImpl() override;
 
-  void callCheck(Http::HeaderMap& headers, Envoy::Tracing::Span& parent_span,
+  void callCheck(Http::RequestHeaderMap& headers,
+                 Envoy::Tracing::Span& parent_span,
                  CheckDoneCallback& callback) override;
 
-  void callReport(const Http::HeaderMap* request_headers,
-                  const Http::HeaderMap* response_headers,
-                  const Http::HeaderMap* response_trailers,
+  void callReport(const Http::RequestHeaderMap* request_headers,
+                  const Http::ResponseHeaderMap* response_headers,
+                  const Http::ResponseTrailerMap* response_trailers,
                   std::chrono::system_clock::time_point now) override;
 
   void tryIntermediateReport(
       std::chrono::system_clock::time_point now) override;
 
-  void processResponseHeaders(const Http::HeaderMap& response_headers) override;
+  void processResponseHeaders(
+      const Http::ResponseHeaderMap& response_headers) override;
 
   void onDestroy() override;
 
@@ -88,7 +90,8 @@ class ServiceControlHandlerImpl : public Logger::Loggable<Logger::Id::filter>,
   bool hasApiKey() const { return !api_key_.empty(); }
 
   void onCheckResponse(
-      Http::HeaderMap& headers, const ::google::protobuf::util::Status& status,
+      Http::RequestHeaderMap& headers,
+      const ::google::protobuf::util::Status& status,
       const ::google::api_proxy::service_control::CheckResponseInfo&
           response_info);
 
@@ -133,7 +136,7 @@ class ServiceControlHandlerFactoryImpl : public ServiceControlHandlerFactory {
       : random_(random), cfg_parser_(cfg_parser) {}
 
   ServiceControlHandlerPtr createHandler(
-      const Http::HeaderMap& headers,
+      const Http::RequestHeaderMap& headers,
       const StreamInfo::StreamInfo& stream_info) const override {
     return std::make_unique<ServiceControlHandlerImpl>(
         headers, stream_info, random_.uuid(), cfg_parser_);

--- a/src/envoy/http/service_control/handler_utils.cc
+++ b/src/envoy/http/service_control/handler_utils.cc
@@ -215,7 +215,7 @@ Protocol getBackendProtocol(const Service& service) {
 }
 
 // TODO(taoxuy): Add Unit Test
-void fillJwtPayloads(const envoy::config::core::v3alpha::Metadata& metadata,
+void fillJwtPayloads(const envoy::config::core::v3::Metadata& metadata,
                      const std::string& jwt_payload_metadata_name,
                      const ::google::protobuf::RepeatedPtrField<::std::string>&
                          jwt_payload_paths,
@@ -225,21 +225,21 @@ void fillJwtPayloads(const envoy::config::core::v3alpha::Metadata& metadata,
         absl::StrSplit(jwt_payload_path, kJwtPayLoadsDelimeter);
     steps.insert(steps.begin(), jwt_payload_metadata_name);
     const ProtobufWkt::Value& value = Config::Metadata::metadataValue(
-        metadata, HttpFilters::HttpFilterNames::get().JwtAuthn, steps);
+        &metadata, HttpFilters::HttpFilterNames::get().JwtAuthn, steps);
     if (&value != &ProtobufWkt::Value::default_instance()) {
       extractJwtPayload(value, jwt_payload_path, info_jwt_payloads);
     }
   }
 }
 
-void fillJwtPayload(const envoy::config::core::v3alpha::Metadata& metadata,
+void fillJwtPayload(const envoy::config::core::v3::Metadata& metadata,
                     const std::string& jwt_payload_metadata_name,
                     const std::string& jwt_payload_path,
                     std::string& info_iss_or_aud) {
   std::vector<std::string> steps = {jwt_payload_metadata_name,
                                     jwt_payload_path};
   const ProtobufWkt::Value& value = Config::Metadata::metadataValue(
-      metadata, HttpFilters::HttpFilterNames::get().JwtAuthn, steps);
+      &metadata, HttpFilters::HttpFilterNames::get().JwtAuthn, steps);
   if (&value != &ProtobufWkt::Value::default_instance()) {
     absl::StrAppend(&info_iss_or_aud, value.string_value());
   }

--- a/src/envoy/http/service_control/handler_utils.h
+++ b/src/envoy/http/service_control/handler_utils.h
@@ -55,13 +55,13 @@ void fillLatency(const StreamInfo::StreamInfo& stream_info,
                  ::google::api_proxy::service_control::LatencyInfo& latency);
 
 // Fills the jwt payload of the info provided
-void fillJwtPayloads(const envoy::config::core::v3alpha::Metadata& metadata,
+void fillJwtPayloads(const envoy::config::core::v3::Metadata& metadata,
                      const std::string& jwt_payload_metadata_name,
                      const ::google::protobuf::RepeatedPtrField<::std::string>&
                          jwt_payload_paths,
                      std::string& info_jwt_payloads);
 
-void fillJwtPayload(const envoy::config::core::v3alpha::Metadata& metadata,
+void fillJwtPayload(const envoy::config::core::v3::Metadata& metadata,
                     const std::string& jwt_payload_metadata_name,
                     const std::string& jwt_payload_path,
                     std::string& info_iss_or_aud);

--- a/src/envoy/http/service_control/http_call.cc
+++ b/src/envoy/http/service_control/http_call.cc
@@ -70,7 +70,7 @@ class HttpCallImpl : public HttpCall,
   void call() override { makeOneCall(); }
 
   // HTTP async receive methods
-  void onSuccess(Http::MessagePtr&& response) override {
+  void onSuccess(Http::ResponseMessagePtr&& response) override {
     ENVOY_LOG(trace, "{}", __func__);
     const uint64_t status_code =
         Http::Utility::getResponseStatus(response->headers());
@@ -174,7 +174,7 @@ class HttpCallImpl : public HttpCall,
     request_span_->setTag(Tracing::Tags::get().HttpUrl, uri_);
     request_span_->setTag(Tracing::Tags::get().HttpMethod, "POST");
 
-    Http::MessagePtr message = prepareHeaders(token);
+    Http::RequestMessagePtr message = prepareHeaders(token);
     ENVOY_LOG(debug, "http call from [uri = {}]: start", uri_);
     request_ = cm_.httpAsyncClientForCluster(http_uri_.cluster())
                    .send(std::move(message), *this,
@@ -205,8 +205,8 @@ class HttpCallImpl : public HttpCall,
 
   void reset() { request_ = nullptr; }
 
-  Http::MessagePtr prepareHeaders(const std::string& token) {
-    Http::MessagePtr message(new Http::RequestMessageImpl());
+  Http::RequestMessagePtr prepareHeaders(const std::string& token) {
+    Http::RequestMessagePtr message(new Http::RequestMessageImpl());
     message->headers().setPath(path_);
     message->headers().setHost(host_);
 

--- a/src/envoy/http/service_control/http_call_test.cc
+++ b/src/envoy/http/service_control/http_call_test.cc
@@ -67,7 +67,7 @@ class HttpCallTest : public testing::Test {
     ON_CALL(cm_, httpAsyncClientForCluster("test_cluster"))
         .WillByDefault(ReturnRef(http_client_));
     ON_CALL(http_client_, send_(_, _, _))
-        .WillByDefault(Invoke([this](Http::MessagePtr& message_ptr,
+        .WillByDefault(Invoke([this](Http::RequestMessagePtr& message_ptr,
                                      Http::AsyncClient::Callbacks& callbacks,
                                      const Http::AsyncClient::RequestOptions)
                                   -> Http::AsyncClient::Request* {
@@ -116,9 +116,11 @@ class HttpCallTest : public testing::Test {
     return mock_child_span_ptr;
   }
 
-  static Http::MessagePtr makeResponseWithStatus(const uint64_t status_code) {
+  static Http::ResponseMessagePtr makeResponseWithStatus(
+      const uint64_t status_code) {
     // Headers with status code
-    Http::HeaderMapPtr header_map = std::make_unique<Http::HeaderMapImpl>();
+    Http::ResponseHeaderMapPtr header_map =
+        std::make_unique<Http::ResponseHeaderMapImpl>();
     header_map->setStatus(status_code);
 
     // Message with no body

--- a/src/envoy/http/service_control/mocks.h
+++ b/src/envoy/http/service_control/mocks.h
@@ -26,20 +26,21 @@ namespace ServiceControl {
 
 class MockServiceControlHandler : public ServiceControlHandler {
  public:
-  MOCK_METHOD3(callCheck,
-               void(Http::HeaderMap& headers, Envoy::Tracing::Span& parent_span,
-                    CheckDoneCallback& callback));
+  MOCK_METHOD3(callCheck, void(Http::RequestHeaderMap& headers,
+                               Envoy::Tracing::Span& parent_span,
+                               CheckDoneCallback& callback));
 
-  MOCK_METHOD4(callReport, void(const Http::HeaderMap* request_headers,
-                                const Http::HeaderMap* response_headers,
-                                const Http::HeaderMap* response_trailers,
-                                std::chrono::system_clock::time_point now));
+  MOCK_METHOD4(callReport,
+               void(const Http::RequestHeaderMap* request_headers,
+                    const Http::ResponseHeaderMap* response_headers,
+                    const Http::ResponseTrailerMap* response_trailers,
+                    std::chrono::system_clock::time_point now));
 
   MOCK_METHOD1(tryIntermediateReport,
                void(std::chrono::system_clock::time_point now));
 
   MOCK_METHOD1(processResponseHeaders,
-               void(const Http::HeaderMap& response_headers));
+               void(const Http::ResponseHeaderMap& response_headers));
 
   MOCK_METHOD0(onDestroy, void());
 };
@@ -47,14 +48,14 @@ class MockServiceControlHandler : public ServiceControlHandler {
 class MockServiceControlHandlerFactory : public ServiceControlHandlerFactory {
  public:
   ServiceControlHandlerPtr createHandler(
-      const Http::HeaderMap& headers,
+      const Http::RequestHeaderMap& headers,
       const StreamInfo::StreamInfo& stream_info) const override {
     return ServiceControlHandlerPtr{createHandler_(headers, stream_info)};
   }
 
   MOCK_CONST_METHOD2(
       createHandler_,
-      ServiceControlHandler*(const Http::HeaderMap& headers,
+      ServiceControlHandler*(const Http::RequestHeaderMap& headers,
                              const StreamInfo::StreamInfo& stream_info));
 };
 

--- a/src/envoy/token/iam_token_info.h
+++ b/src/envoy/token/iam_token_info.h
@@ -33,7 +33,7 @@ class IamTokenInfo : public TokenInfo {
       const ::google::protobuf::RepeatedPtrField<std::string>& scopes,
       const bool include_email, const GetTokenFunc access_token_fn);
 
-  Envoy::Http::MessagePtr prepareRequest(
+  Envoy::Http::RequestMessagePtr prepareRequest(
       absl::string_view token_url) const override;
   bool parseAccessToken(absl::string_view response,
                         TokenResult* ret) const override;

--- a/src/envoy/token/iam_token_info_test.cc
+++ b/src/envoy/token/iam_token_info_test.cc
@@ -44,7 +44,7 @@ TEST_F(IamTokenInfoTest, FailPreconditions) {
       std::make_unique<IamTokenInfo>(delegates, scopes, false, access_token_fn);
 
   // Call function under test.
-  Envoy::Http::MessagePtr got_msg = info_->prepareRequest("iam-url");
+  Envoy::Http::RequestMessagePtr got_msg = info_->prepareRequest("iam-url");
 
   // Assert preconditions failed.
   EXPECT_EQ(got_msg, nullptr);
@@ -59,7 +59,7 @@ TEST_F(IamTokenInfoTest, SimpleSuccess) {
       std::make_unique<IamTokenInfo>(delegates, scopes, false, access_token_fn);
 
   // Call function under test.
-  Envoy::Http::MessagePtr got_msg =
+  Envoy::Http::RequestMessagePtr got_msg =
       info_->prepareRequest("https://iam-url.com/path1");
 
   // Assert success.
@@ -100,7 +100,7 @@ TEST_F(IamTokenInfoTest, SetDelegatesAndScopes) {
       std::make_unique<IamTokenInfo>(delegates, scopes, false, access_token_fn);
 
   // Call function under test.
-  Envoy::Http::MessagePtr got_msg = info_->prepareRequest("iam-url");
+  Envoy::Http::RequestMessagePtr got_msg = info_->prepareRequest("iam-url");
 
   // Assert success.
   EXPECT_NE(got_msg, nullptr);
@@ -120,7 +120,7 @@ TEST_F(IamTokenInfoTest, OnlySetDelegates) {
       std::make_unique<IamTokenInfo>(delegates, scopes, false, access_token_fn);
 
   // Call function under test.
-  Envoy::Http::MessagePtr got_msg = info_->prepareRequest("iam-url");
+  Envoy::Http::RequestMessagePtr got_msg = info_->prepareRequest("iam-url");
 
   // Assert success.
   EXPECT_NE(got_msg, nullptr);
@@ -140,7 +140,7 @@ TEST_F(IamTokenInfoTest, OnlySetScopes) {
       std::make_unique<IamTokenInfo>(delegates, scopes, false, access_token_fn);
 
   // Call function under test.
-  Envoy::Http::MessagePtr got_msg = info_->prepareRequest("iam-url");
+  Envoy::Http::RequestMessagePtr got_msg = info_->prepareRequest("iam-url");
 
   // Assert success.
   EXPECT_NE(got_msg, nullptr);
@@ -232,7 +232,7 @@ TEST_F(IamParseTokenTest, SetIncludeEmail) {
       std::make_unique<IamTokenInfo>(delegates, scopes, true, access_token_fn);
 
   // Call function under test.
-  Envoy::Http::MessagePtr got_msg = info_->prepareRequest("iam-url");
+  Envoy::Http::RequestMessagePtr got_msg = info_->prepareRequest("iam-url");
 
   // Assert success.
   EXPECT_NE(got_msg, nullptr);

--- a/src/envoy/token/imds_token_info.cc
+++ b/src/envoy/token/imds_token_info.cc
@@ -34,18 +34,19 @@ constexpr std::chrono::seconds kDefaultTokenExpiry(3599);
 
 ImdsTokenInfo::ImdsTokenInfo() {}
 
-Envoy::Http::MessagePtr ImdsTokenInfo::prepareRequest(
+Envoy::Http::RequestMessagePtr ImdsTokenInfo::prepareRequest(
     absl::string_view token_url) const {
   absl::string_view host, path;
   Http::Utility::extractHostPathFromUri(token_url, host, path);
 
-  Envoy::Http::HeaderMapImplPtr headers{new Envoy::Http::HeaderMapImpl{
-      {Envoy::Http::Headers::get().Method, "GET"},
-      {Envoy::Http::Headers::get().Host, std::string(host)},
-      {Envoy::Http::Headers::get().Path, std::string(path)},
-      {kMetadataFlavorKey, kMetadataFlavor}}};
+  auto headers =
+      Envoy::Http::createHeaderMap<Envoy::Http::RequestHeaderMapImpl>(
+          {{Envoy::Http::Headers::get().Method, "GET"},
+           {Envoy::Http::Headers::get().Host, std::string(host)},
+           {Envoy::Http::Headers::get().Path, std::string(path)},
+           {kMetadataFlavorKey, kMetadataFlavor}});
 
-  Envoy::Http::MessagePtr message(
+  Envoy::Http::RequestMessagePtr message(
       new Envoy::Http::RequestMessageImpl(std::move(headers)));
 
   return message;

--- a/src/envoy/token/imds_token_info.h
+++ b/src/envoy/token/imds_token_info.h
@@ -26,7 +26,7 @@ class ImdsTokenInfo : public TokenInfo {
  public:
   ImdsTokenInfo();
 
-  Envoy::Http::MessagePtr prepareRequest(
+  Envoy::Http::RequestMessagePtr prepareRequest(
       absl::string_view token_url) const override;
   bool parseAccessToken(absl::string_view response,
                         TokenResult* ret) const override;

--- a/src/envoy/token/imds_token_info_test.cc
+++ b/src/envoy/token/imds_token_info_test.cc
@@ -35,7 +35,7 @@ class ImdsTokenInfoTest : public testing::Test {
 
 TEST_F(ImdsTokenInfoTest, SimpleSuccess) {
   // Call function under test.
-  Envoy::Http::MessagePtr got_msg =
+  Envoy::Http::RequestMessagePtr got_msg =
       info_->prepareRequest("https://imds-url.com/path2");
 
   // Assert success.

--- a/src/envoy/token/mocks.h
+++ b/src/envoy/token/mocks.h
@@ -49,7 +49,7 @@ class MockTokenSubscriberFactory : public TokenSubscriberFactory {
 
 class MockTokenInfo : public TokenInfo {
  public:
-  MOCK_METHOD(Envoy::Http::MessagePtr, prepareRequest,
+  MOCK_METHOD(Envoy::Http::RequestMessagePtr, prepareRequest,
               (absl::string_view token_url), (const));
 
   MOCK_METHOD(bool, parseAccessToken,

--- a/src/envoy/token/token_info.h
+++ b/src/envoy/token/token_info.h
@@ -33,7 +33,7 @@ class TokenInfo : public Envoy::Logger::Loggable<Envoy::Logger::Id::init> {
  public:
   virtual ~TokenInfo() = default;
 
-  virtual Envoy::Http::MessagePtr prepareRequest(
+  virtual Envoy::Http::RequestMessagePtr prepareRequest(
       absl::string_view token_url) const PURE;
   virtual bool parseAccessToken(absl::string_view response,
                                 TokenResult* ret) const PURE;

--- a/src/envoy/token/token_subscriber.cc
+++ b/src/envoy/token/token_subscriber.cc
@@ -95,7 +95,8 @@ void TokenSubscriber::refresh() {
 
   ENVOY_LOG(debug, "{}: Sending TokenSubscriber request", debug_name_);
 
-  Envoy::Http::MessagePtr message = token_info_->prepareRequest(token_url_);
+  Envoy::Http::RequestMessagePtr message =
+      token_info_->prepareRequest(token_url_);
   if (message == nullptr) {
     // Preconditions in TokenInfo are not met, not an error.
     ENVOY_LOG(warn, "{}: preconditions not met, retrying later", debug_name_);
@@ -115,7 +116,8 @@ void TokenSubscriber::refresh() {
                         .send(std::move(message), *this, options);
 }
 
-void TokenSubscriber::processResponse(Envoy::Http::MessagePtr&& response) {
+void TokenSubscriber::processResponse(
+    Envoy::Http::ResponseMessagePtr&& response) {
   try {
     const uint64_t status_code =
         Envoy::Http::Utility::getResponseStatus(response->headers());
@@ -160,7 +162,7 @@ void TokenSubscriber::processResponse(Envoy::Http::MessagePtr&& response) {
   handleSuccessResponse(result.token, result.expiry_duration);
 }
 
-void TokenSubscriber::onSuccess(Envoy::Http::MessagePtr&& response) {
+void TokenSubscriber::onSuccess(Envoy::Http::ResponseMessagePtr&& response) {
   ENVOY_LOG(debug, "{}: got response: {}", debug_name_,
             response->bodyAsString());
   processResponse(std::move(response));

--- a/src/envoy/token/token_subscriber.h
+++ b/src/envoy/token/token_subscriber.h
@@ -52,11 +52,11 @@ class TokenSubscriber
   void handleFailResponse();
   void handleSuccessResponse(absl::string_view token,
                              const std::chrono::seconds& expires_in);
-  void processResponse(Envoy::Http::MessagePtr&& response);
+  void processResponse(Envoy::Http::ResponseMessagePtr&& response);
   void refresh();
 
   // Envoy::Http::AsyncClient::Callbacks implemented by this class.
-  void onSuccess(Envoy::Http::MessagePtr&& response) override;
+  void onSuccess(Envoy::Http::ResponseMessagePtr&& response) override;
   void onFailure(Envoy::Http::AsyncClient::FailureReason reason) override;
 
   Envoy::Server::Configuration::FactoryContext& context_;

--- a/src/envoy/token/token_subscriber_test.cc
+++ b/src/envoy/token/token_subscriber_test.cc
@@ -58,7 +58,7 @@ class TokenSubscriberTest : public testing::Test {
     // Setup mock http async client.
     EXPECT_CALL(context_.cluster_manager_.async_client_, send_(_, _, _))
         .WillRepeatedly(
-            Invoke([this](Envoy::Http::MessagePtr& message,
+            Invoke([this](Envoy::Http::RequestMessagePtr& message,
                           Envoy::Http::AsyncClient::Callbacks& callback,
                           const Envoy::Http::AsyncClient::RequestOptions&) {
               call_count_++;
@@ -100,7 +100,7 @@ class TokenSubscriberTest : public testing::Test {
 
   // Mocks for remote request.
   Envoy::Http::AsyncClient::Callbacks* client_callback_;
-  Envoy::Http::MessagePtr message_;
+  Envoy::Http::RequestMessagePtr message_;
   int call_count_ = 0;
 
   // Mocks for init.
@@ -135,8 +135,9 @@ TEST_F(TokenSubscriberTest, HandleMissingPreconditions) {
 
 TEST_F(TokenSubscriberTest, VerifyRemoteRequest) {
   // Setup fake remote request.
-  Envoy::Http::HeaderMapImplPtr headers{new Envoy::Http::TestHeaderMapImpl{
-      {":method", "POST"}, {":authority", "TestValue"}}};
+  Envoy::Http::RequestHeaderMapPtr headers(
+      new Envoy::Http::TestRequestHeaderMapImpl(
+          {{":method", "POST"}, {":authority", "TestValue"}}));
   EXPECT_CALL(*info_, prepareRequest(token_url_))
       .Times(1)
       .WillRepeatedly(
@@ -162,8 +163,8 @@ TEST_F(TokenSubscriberTest, VerifyRemoteRequest) {
 
 TEST_F(TokenSubscriberTest, ProcessNon200Response) {
   // Setup fake remote request.
-  Envoy::Http::HeaderMapImplPtr req_headers{
-      new Envoy::Http::TestHeaderMapImpl{}};
+  Envoy::Http::RequestHeaderMapPtr req_headers(
+      new Envoy::Http::TestRequestHeaderMapImpl());
   EXPECT_CALL(*info_, prepareRequest(token_url_))
       .Times(1)
       .WillRepeatedly(
@@ -178,11 +179,12 @@ TEST_F(TokenSubscriberTest, ProcessNon200Response) {
   setUp(TokenType::IdentityToken);
 
   // Setup fake response.
-  Envoy::Http::HeaderMapImplPtr resp_headers{new Envoy::Http::TestHeaderMapImpl{
-      {":status", "504"},
-  }};
-  Envoy::Http::MessagePtr response(
-      new Envoy::Http::RequestMessageImpl(std::move(resp_headers)));
+  Envoy::Http::ResponseHeaderMapPtr resp_headers(
+      new Envoy::Http::TestResponseHeaderMapImpl({
+          {":status", "504"},
+      }));
+  Envoy::Http::ResponseMessagePtr response(
+      new Envoy::Http::ResponseMessageImpl(std::move(resp_headers)));
 
   // Start the response.
   client_callback_->onSuccess(std::move(response));
@@ -194,8 +196,8 @@ TEST_F(TokenSubscriberTest, ProcessNon200Response) {
 
 TEST_F(TokenSubscriberTest, ProcessMissingStatusResponse) {
   // Setup fake remote request.
-  Envoy::Http::HeaderMapImplPtr req_headers{
-      new Envoy::Http::TestHeaderMapImpl{}};
+  Envoy::Http::RequestHeaderMapPtr req_headers(
+      new Envoy::Http::TestRequestHeaderMapImpl());
   EXPECT_CALL(*info_, prepareRequest(token_url_))
       .Times(1)
       .WillRepeatedly(
@@ -210,10 +212,10 @@ TEST_F(TokenSubscriberTest, ProcessMissingStatusResponse) {
   setUp(TokenType::IdentityToken);
 
   // Setup fake response.
-  Envoy::Http::HeaderMapImplPtr resp_headers{
-      new Envoy::Http::TestHeaderMapImpl{}};
-  Envoy::Http::MessagePtr response(
-      new Envoy::Http::RequestMessageImpl(std::move(resp_headers)));
+  Envoy::Http::ResponseHeaderMapPtr resp_headers(
+      new Envoy::Http::TestResponseHeaderMapImpl());
+  Envoy::Http::ResponseMessagePtr response(
+      new Envoy::Http::ResponseMessageImpl(std::move(resp_headers)));
 
   // Start the response.
   client_callback_->onSuccess(std::move(response));
@@ -225,8 +227,8 @@ TEST_F(TokenSubscriberTest, ProcessMissingStatusResponse) {
 
 TEST_F(TokenSubscriberTest, BadParseIdentityToken) {
   // Setup fake remote request.
-  Envoy::Http::HeaderMapImplPtr req_headers{
-      new Envoy::Http::TestHeaderMapImpl{}};
+  Envoy::Http::RequestHeaderMapPtr req_headers(
+      new Envoy::Http::TestRequestHeaderMapImpl());
   EXPECT_CALL(*info_, prepareRequest(token_url_))
       .Times(1)
       .WillRepeatedly(
@@ -244,11 +246,12 @@ TEST_F(TokenSubscriberTest, BadParseIdentityToken) {
   setUp(TokenType::IdentityToken);
 
   // Setup fake response.
-  Envoy::Http::HeaderMapImplPtr resp_headers{new Envoy::Http::TestHeaderMapImpl{
-      {":status", "200"},
-  }};
-  Envoy::Http::MessagePtr response(
-      new Envoy::Http::RequestMessageImpl(std::move(resp_headers)));
+  Envoy::Http::ResponseHeaderMapPtr resp_headers(
+      new Envoy::Http::TestResponseHeaderMapImpl({
+          {":status", "200"},
+      }));
+  Envoy::Http::ResponseMessagePtr response(
+      new Envoy::Http::ResponseMessageImpl(std::move(resp_headers)));
 
   // Start the response.
   client_callback_->onSuccess(std::move(response));
@@ -260,8 +263,8 @@ TEST_F(TokenSubscriberTest, BadParseIdentityToken) {
 
 TEST_F(TokenSubscriberTest, BadParseAccessToken) {
   // Setup fake remote request.
-  Envoy::Http::HeaderMapImplPtr req_headers{
-      new Envoy::Http::TestHeaderMapImpl{}};
+  Envoy::Http::RequestHeaderMapPtr req_headers(
+      new Envoy::Http::TestRequestHeaderMapImpl());
   EXPECT_CALL(*info_, prepareRequest(token_url_))
       .Times(1)
       .WillRepeatedly(
@@ -279,11 +282,12 @@ TEST_F(TokenSubscriberTest, BadParseAccessToken) {
   setUp(TokenType::AccessToken);
 
   // Setup fake response.
-  Envoy::Http::HeaderMapImplPtr resp_headers{new Envoy::Http::TestHeaderMapImpl{
-      {":status", "200"},
-  }};
-  Envoy::Http::MessagePtr response(
-      new Envoy::Http::RequestMessageImpl(std::move(resp_headers)));
+  Envoy::Http::ResponseHeaderMapPtr resp_headers(
+      new Envoy::Http::TestResponseHeaderMapImpl({
+          {":status", "200"},
+      }));
+  Envoy::Http::ResponseMessagePtr response(
+      new Envoy::Http::ResponseMessageImpl(std::move(resp_headers)));
 
   // Start the response.
   client_callback_->onSuccess(std::move(response));
@@ -295,8 +299,8 @@ TEST_F(TokenSubscriberTest, BadParseAccessToken) {
 
 TEST_F(TokenSubscriberTest, Success) {
   // Setup fake remote request.
-  Envoy::Http::HeaderMapImplPtr req_headers{
-      new Envoy::Http::TestHeaderMapImpl{}};
+  Envoy::Http::RequestHeaderMapPtr req_headers(
+      new Envoy::Http::TestRequestHeaderMapImpl());
   EXPECT_CALL(*info_, prepareRequest(token_url_))
       .Times(1)
       .WillRepeatedly(
@@ -321,11 +325,12 @@ TEST_F(TokenSubscriberTest, Success) {
   setUp(TokenType::AccessToken);
 
   // Setup fake response.
-  Envoy::Http::HeaderMapImplPtr resp_headers{new Envoy::Http::TestHeaderMapImpl{
-      {":status", "200"},
-  }};
-  Envoy::Http::MessagePtr response(
-      new Envoy::Http::RequestMessageImpl(std::move(resp_headers)));
+  Envoy::Http::ResponseHeaderMapPtr resp_headers(
+      new Envoy::Http::TestResponseHeaderMapImpl({
+          {":status", "200"},
+      }));
+  Envoy::Http::ResponseMessagePtr response(
+      new Envoy::Http::ResponseMessageImpl(std::move(resp_headers)));
 
   // Start the response.
   client_callback_->onSuccess(std::move(response));
@@ -339,8 +344,8 @@ TEST_F(TokenSubscriberTest, RetryMissingPreconditionThenSuccess) {
   // Part 1: Failed due to missing precondition
 
   // Setup mocks for info. Fail on the first time, then work later.
-  Envoy::Http::HeaderMapImplPtr req_headers{
-      new Envoy::Http::TestHeaderMapImpl{}};
+  Envoy::Http::RequestHeaderMapPtr req_headers(
+      new Envoy::Http::TestRequestHeaderMapImpl());
   EXPECT_CALL(*info_, prepareRequest(_))
       .WillOnce(Return(ByMove(nullptr)))
       .WillRepeatedly(
@@ -373,11 +378,12 @@ TEST_F(TokenSubscriberTest, RetryMissingPreconditionThenSuccess) {
   timer_cb_();
 
   // Setup fake response.
-  Envoy::Http::HeaderMapImplPtr resp_headers{new Envoy::Http::TestHeaderMapImpl{
-      {":status", "200"},
-  }};
-  Envoy::Http::MessagePtr response(
-      new Envoy::Http::RequestMessageImpl(std::move(resp_headers)));
+  Envoy::Http::ResponseHeaderMapPtr resp_headers(
+      new Envoy::Http::TestResponseHeaderMapImpl({
+          {":status", "200"},
+      }));
+  Envoy::Http::ResponseMessagePtr response(
+      new Envoy::Http::ResponseMessageImpl(std::move(resp_headers)));
 
   // Start the response.
   client_callback_->onSuccess(std::move(response));


### PR DESCRIPTION

Key changes:
1)  HeaderMap splited into 
    RequestHeaderMap, RequestTrailerMap, ResponseHeaderMap, ResponseTrailerMap
2) stream_info.filterState() is a share_ptr,  not a reference
3) handle_impLtest fails, change its macro for easy debug test falure.