### PR TITLE
Refactory: user request_info.current_time

### DIFF
--- a/src/api_proxy/service_control/request_builder.cc
+++ b/src/api_proxy/service_control/request_builder.cc
@@ -1159,8 +1159,7 @@ Status RequestBuilder::FillAllocateQuotaRequest(
 }
 
 Status RequestBuilder::FillCheckRequest(
-    const CheckRequestInfo& info, CheckRequest* request,
-    std::chrono::system_clock::time_point now) const {
+    const CheckRequestInfo& info, CheckRequest* request) const {
   Status status = VerifyRequiredCheckFields(info);
   if (!status.ok()) {
     return status;
@@ -1168,7 +1167,7 @@ Status RequestBuilder::FillCheckRequest(
   request->set_service_name(service_name_);
   request->set_service_config_id(service_config_id_);
 
-  Timestamp current_time = CreateTimestamp(now);
+  Timestamp current_time = CreateTimestamp(info.current_time);
   Operation* op = request->mutable_operation();
   SetOperationCommonFields(info, current_time, op);
 
@@ -1197,8 +1196,7 @@ Status RequestBuilder::FillCheckRequest(
 }
 
 Status RequestBuilder::FillReportRequest(
-    const ReportRequestInfo& info, ReportRequest* request,
-    std::chrono::system_clock::time_point now) const {
+    const ReportRequestInfo& info, ReportRequest* request) const {
   Status status = VerifyRequiredReportFields(info);
   if (!status.ok()) {
     return status;
@@ -1206,7 +1204,7 @@ Status RequestBuilder::FillReportRequest(
   request->set_service_name(service_name_);
   request->set_service_config_id(service_config_id_);
 
-  Timestamp current_time = CreateTimestamp(now);
+  Timestamp current_time = CreateTimestamp(info.current_time);
   Operation* op = request->add_operations();
   SetOperationCommonFields(info, current_time, op);
 

--- a/src/api_proxy/service_control/request_builder.h
+++ b/src/api_proxy/service_control/request_builder.h
@@ -53,9 +53,7 @@ class RequestBuilder final {
   // These buffers may be freed after the FillCheckRequest call.
   ::google::protobuf::util::Status FillCheckRequest(
       const CheckRequestInfo& info,
-      ::google::api::servicecontrol::v1::CheckRequest* request,
-      std::chrono::system_clock::time_point now =
-          std::chrono::system_clock::now()) const;
+      ::google::api::servicecontrol::v1::CheckRequest* request) const;
 
   ::google::protobuf::util::Status FillAllocateQuotaRequest(
       const QuotaRequestInfo& info,
@@ -66,9 +64,7 @@ class RequestBuilder final {
   // These buffers may be freed after the FillReportRequest call.
   ::google::protobuf::util::Status FillReportRequest(
       const ReportRequestInfo& info,
-      ::google::api::servicecontrol::v1::ReportRequest* request,
-      std::chrono::system_clock::time_point now =
-          std::chrono::system_clock::now()) const;
+      ::google::api::servicecontrol::v1::ReportRequest* request) const;
 
   // Append a new consumer project Operations to the ReportRequest, if customer
   // project id from the CheckResponse is not empty

--- a/src/api_proxy/service_control/request_info.h
+++ b/src/api_proxy/service_control/request_info.h
@@ -82,9 +82,9 @@ struct OperationInfo {
   // Origin header. If both of them not present, it's empty.
   std::string referer;
 
-  // The start time of the call. Used to set operation.start_time for both Check
+  // The current time used for operation.start_time for both Check
   // and Report.
-  std::chrono::system_clock::time_point request_start_time;
+  std::chrono::system_clock::time_point current_time;
 
   // The client IP address.
   std::string client_ip;

--- a/src/envoy/http/service_control/handler_impl.h
+++ b/src/envoy/http/service_control/handler_impl.h
@@ -67,9 +67,11 @@ class ServiceControlHandlerImpl : public Logger::Loggable<Logger::Id::filter>,
   void callQuota();
 
   void fillOperationInfo(
-      ::google::api_proxy::service_control::OperationInfo& info);
+      ::google::api_proxy::service_control::OperationInfo& info,
+      std::chrono::system_clock::time_point now);
   void prepareReportRequest(
-      ::google::api_proxy::service_control::ReportRequestInfo& info);
+      ::google::api_proxy::service_control::ReportRequestInfo& info,
+      std::chrono::system_clock::time_point now);
 
   bool isConfigured() const { return require_ctx_ != nullptr; }
 


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

This is first PR to achieve the end goal is to use envoy server.timeSource()

Old code:
RequestBuilder public functions are calling now() directly. (In the default arguement)

New change:
request_info.request_start_time is not used.  rename it to current_time
use it to pass time info.

 
