### PR TITLE
Add script to upload publicly-viewable C++ unit test coverage data

### DIFF
--- a/docker/Dockerfile-prow-env
+++ b/docker/Dockerfile-prow-env
@@ -65,6 +65,9 @@ RUN wget -q "https://storage.googleapis.com/golang/${GO_TARBALL}" && \
     tar xzf "${GO_TARBALL}" -C /usr/local && \
     rm "${GO_TARBALL}"
 
+# Install buildifier
+RUN go get github.com/bazelbuild/buildtools/buildifier
+
 # install gcloud package
 RUN curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz > /tmp/google-cloud-sdk.tar.gz
 RUN mkdir -p /usr/local/gcloud \

--- a/docker/Dockerfile-prow-env
+++ b/docker/Dockerfile-prow-env
@@ -24,7 +24,7 @@ RUN apt-get update && \
     apt-get -y install \
     wget make cmake python python-pip pkg-config coreutils \
     zlib1g-dev curl libtool automake zip time rsync ninja-build \
-    git bash-completion clang-format-7 jq
+    git bash-completion clang-format-7 jq default-jdk
 
 # clang is used for formatting
 RUN sh -c 'curl http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -'

--- a/prow/gcpproxy-coverage.sh
+++ b/prow/gcpproxy-coverage.sh
@@ -17,13 +17,11 @@
 # Presubmit script triggered by Prow.
 
 # Fail on any error.
-set -eox pipefail
+set -eo pipefail
 
 gcloud config set core/project cloudesf-testing
-gcloud auth list
-echo $CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
-echo $GOOGLE_APPLICATION_CREDENTIALS
-gcloud auth activate-service-account --key-file=/etc/cloudesf-testing-github-prow-service-account/service-account.json
+gcloud auth activate-service-account \
+  --key-file=/etc/cloudesf-testing-github-prow-service-account/service-account.json
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${ROOT}"

--- a/prow/gcpproxy-coverage.sh
+++ b/prow/gcpproxy-coverage.sh
@@ -46,12 +46,11 @@ echo '======================================================='
 PUBLIC_DIRECTORY=""
 case "${JOB_TYPE}" in
   "presubmit")
-    # Store in directory with job id.
-    # IMPORTANT: Default to a some directory to prevent messy copy on unset var.
-    PUBLIC_DIRECTORY="${PROW_JOB_ID:-tmp}"
+    # Store in directory with the SHA for each presubmit run.
+    PUBLIC_DIRECTORY=$(get_tag_name)
     ;;
   "periodic")
-    # Overwrite global directory with latest coverage.
+    # Overwrite global directory with latest coverage for all continuous runs.
     PUBLIC_DIRECTORY="latest"
     ;;
   *)

--- a/prow/gcpproxy-coverage.sh
+++ b/prow/gcpproxy-coverage.sh
@@ -21,7 +21,7 @@ set -eo pipefail
 
 gcloud config set core/project cloudesf-testing
 gcloud auth activate-service-account \
-  --key-file=/etc/cloudesf-testing-github-prow-service-account/service-account.json
+  --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${ROOT}"

--- a/prow/gcpproxy-coverage.sh
+++ b/prow/gcpproxy-coverage.sh
@@ -21,6 +21,9 @@ set -eox pipefail
 
 gcloud config set core/project cloudesf-testing
 gcloud auth list
+echo $CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
+echo $GOOGLE_APPLICATION_CREDENTIALS
+gcloud auth activate-service-account --key-file=/etc/cloudesf-testing-github-prow-service-account/service-account.json
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${ROOT}"

--- a/prow/gcpproxy-coverage.sh
+++ b/prow/gcpproxy-coverage.sh
@@ -40,6 +40,9 @@ echo '======================================================='
 echo '======================================================='
 echo '=================== Upload Coverage ==================='
 echo '======================================================='
+
+# Note that JOB_TYPE is set by Prow.
+# https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#job-environment-variables
 PUBLIC_DIRECTORY=""
 case "${JOB_TYPE}" in
   "presubmit")
@@ -47,7 +50,7 @@ case "${JOB_TYPE}" in
     # IMPORTANT: Default to a some directory to prevent messy copy on unset var.
     PUBLIC_DIRECTORY="${PROW_JOB_ID:-tmp}"
     ;;
-  "continuous")
+  "periodic")
     # Overwrite global directory with latest coverage.
     PUBLIC_DIRECTORY="latest"
     ;;

--- a/prow/gcpproxy-coverage.sh
+++ b/prow/gcpproxy-coverage.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Copyright 2019 Google LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Presubmit script triggered by Prow.
+
+# Fail on any error.
+set -eo pipefail
+
+gcloud config set core/project cloudesf-testing
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT}"
+. ${ROOT}/scripts/all-utilities.sh || { echo 'Cannot load Bash utilities';
+exit 1; }
+
+echo '======================================================='
+echo '===================== Setup Cache ====================='
+echo '======================================================='
+try_setup_bazel_remote_cache "${PROW_JOB_ID}" "${IMAGE}" "${ROOT}" "${JOB_TYPE}-coverage"
+
+
+echo '======================================================='
+echo '==================== C++ Coverage ====================='
+echo '======================================================='
+. ${ROOT}/third_party/tools/coverage/cpp_unit.sh
+
+echo '======================================================='
+echo '=================== Upload Coverage ==================='
+echo '======================================================='
+PUBLIC_DIRECTORY=""
+case "${JOB_TYPE}" in
+  "presubmit")
+    # Store in directory with job id.
+    # IMPORTANT: Default to a some directory to prevent messy copy on unset var.
+    PUBLIC_DIRECTORY="${PROW_JOB_ID:-tmp}"
+    ;;
+  "continuous")
+    # Overwrite global directory with latest coverage.
+    PUBLIC_DIRECTORY="latest"
+    ;;
+  *)
+    # If running locally, just upload to special-case folder.
+    echo "Unknown job type: ${JOB_TYPE}"
+    PUBLIC_DIRECTORY="local-run"
+    ;;
+esac
+
+# Upload folder.
+gsutil -m rsync -r -d "${ROOT}/generated" "gs://esp-v2-coverage/${PUBLIC_DIRECTORY}"
+
+# No browser cache since some directories change often and that would be misleading.
+gsutil -m setmeta -h "Cache-Control:private, max-age=0, no-transform" "gs://esp-v2-coverage/${PUBLIC_DIRECTORY}/**"
+
+echo '======================================================='
+echo '==================== View Coverage ===================='
+echo '======================================================='
+echo "C++ Unit test coverage is viewable at the URL below"
+echo "https://storage.googleapis.com/esp-v2-coverage/${PUBLIC_DIRECTORY}/third_party/tools/coverage/coverage_tests/index.html"

--- a/prow/gcpproxy-coverage.sh
+++ b/prow/gcpproxy-coverage.sh
@@ -17,9 +17,10 @@
 # Presubmit script triggered by Prow.
 
 # Fail on any error.
-set -eo pipefail
+set -eox pipefail
 
 gcloud config set core/project cloudesf-testing
+gcloud auth list
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${ROOT}"

--- a/prow/gcpproxy-presubmit.sh
+++ b/prow/gcpproxy-presubmit.sh
@@ -26,7 +26,6 @@ ROOT=$(dirname "$WD")
 export PATH=$PATH:$GOPATH/bin
 
 gcloud config set core/project cloudesf-testing
-gcloud auth list
 
 cd "${ROOT}"
 . ${ROOT}/scripts/all-utilities.sh || { echo 'Cannot load Bash utilities';

--- a/prow/gcpproxy-presubmit.sh
+++ b/prow/gcpproxy-presubmit.sh
@@ -26,6 +26,7 @@ ROOT=$(dirname "$WD")
 export PATH=$PATH:$GOPATH/bin
 
 gcloud config set core/project cloudesf-testing
+gcloud auth list
 
 cd "${ROOT}"
 . ${ROOT}/scripts/all-utilities.sh || { echo 'Cannot load Bash utilities';

--- a/third_party/tools/coverage/cpp_unit.sh
+++ b/third_party/tools/coverage/cpp_unit.sh
@@ -20,12 +20,11 @@ else
 fi
 
 # Make sure //third_party/tools/coverage:coverage_tests is up-to-date.
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-"${SCRIPT_DIR}"/gen_build.sh ${COVERAGE_TARGETS}
+. $(pwd)/third_party/tools/coverage/gen_build.sh ${COVERAGE_TARGETS}
 
 TARGET=//third_party/tools/coverage:coverage_tests
 TARGET_PATH=${TARGET:2}
 TARGET_PATH=${TARGET_PATH//://}
 echo ${TARGET_PATH}
 
-. "${SCRIPT_DIR}"/gen_coverage.sh
+. $(pwd)/third_party/tools/coverage/gen_coverage.sh

--- a/third_party/tools/coverage/gen_build.sh
+++ b/third_party/tools/coverage/gen_build.sh
@@ -12,7 +12,7 @@ set -e
 [ -z "${BUILDIFIER_BIN}" ] && BUILDIFIER_BIN=buildifier
 
 # Path to the generated BUILD file for the coverage target.
-[ -z "${BUILD_PATH}" ] && BUILD_PATH="$(dirname "$0")"/BUILD
+[ -z "${BUILD_PATH}" ] && BUILD_PATH=$(pwd)/third_party/tools/coverage/BUILD
 
 # Extra repository information to include when generating coverage targets. This is useful for
 # consuming projects. E.g., "@envoy".
@@ -62,8 +62,7 @@ EOF
   done
   cat << EOF
     ],
-    # no-remote due to https://github.com/bazelbuild/bazel/issues/4685
-    tags = ["manual", "no-remote"],
+    tags = ["manual"],
     coverage = False,
     # Due to the nature of coverage_tests, the shard of coverage_tests are very uneven, some of
     # shard can take 100s and some takes only 10s, so we use the maximum sharding to here to let

--- a/third_party/tools/coverage/gen_coverage.sh
+++ b/third_party/tools/coverage/gen_coverage.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Using GTEST_SHUFFLE here to workaround https://github.com/envoyproxy/envoy/issues/10108
-BAZEL_USE_LLVM_NATIVE_COVERAGE=1 GCOV=llvm-profdata CC=clang-8 CXX=clang++-8 \
+BAZEL_USE_LLVM_NATIVE_COVERAGE=1 GCOV=llvm-profdata-8 CC=clang-8 CXX=clang++-8 \
     bazel coverage ${BAZEL_BUILD_OPTIONS} \
     -c fastbuild --copt=-DNDEBUG --instrumentation_filter="//src/..." \
     --test_timeout=2000 --cxxopt="-DENVOY_CONFIG_COVERAGE=1" --test_output=errors \
@@ -18,15 +18,15 @@ COVERAGE_BINARY="bazel-bin/${TARGET_PATH}"
 COVERAGE_DATA="${COVERAGE_DIR}/coverage.dat"
 
 echo "Merging coverage data..."
-llvm-profdata merge -sparse -o ${COVERAGE_DATA} $(find -L bazel-out/k8-fastbuild/testlogs/${TARGET_PATH} -name coverage.dat)
+llvm-profdata-8 merge -sparse -o ${COVERAGE_DATA} $(find -L bazel-out/k8-fastbuild/testlogs/${TARGET_PATH} -name coverage.dat)
 
 echo "Generating report..."
-llvm-cov show "${COVERAGE_BINARY}" -instr-profile="${COVERAGE_DATA}" -Xdemangler=c++filt \
+llvm-cov-8 show "${COVERAGE_BINARY}" -instr-profile="${COVERAGE_DATA}" -Xdemangler=c++filt \
   -ignore-filename-regex="${COVERAGE_IGNORE_REGEX}" -output-dir=${COVERAGE_DIR} -format=html
 sed -i -e 's|>proc/self/cwd/|>|g' "${COVERAGE_DIR}/index.html"
 sed -i -e 's|>bazel-out/[^/]*/bin/\([^/]*\)/[^<]*/_virtual_includes/[^/]*|>\1|g' "${COVERAGE_DIR}/index.html"
 
-COVERAGE_VALUE=$(llvm-cov export "${COVERAGE_BINARY}" -instr-profile="${COVERAGE_DATA}" \
+COVERAGE_VALUE=$(llvm-cov-8 export "${COVERAGE_BINARY}" -instr-profile="${COVERAGE_DATA}" \
     -ignore-filename-regex="${COVERAGE_IGNORE_REGEX}" -summary-only | \
     python3 -c "import sys, json; print(json.load(sys.stdin)['data'][0]['totals']['lines']['percent'])")
 echo "Covered lines percentage: ${COVERAGE_VALUE}"


### PR DESCRIPTION
Example test coverage report: https://storage.googleapis.com/esp-v2-coverage/local-run/third_party/tools/coverage/coverage_tests/index.html

Waiting for GoogleCloudPlatform/oss-test-infra#314 to auto-generate reports per PR.

Signed-off-by: Teju Nareddy <nareddyt@google.com>