### PR TITLE
use envoy timeSource in service control filter

### DIFF
--- a/src/envoy/http/service_control/BUILD
+++ b/src/envoy/http/service_control/BUILD
@@ -240,6 +240,7 @@ envoy_cc_test(
         "@envoy//test/mocks/server:server_mocks",
         "@envoy//test/mocks/stats:stats_mocks",
         "@envoy//test/mocks/tracing:tracing_mocks",
+        "@envoy//test/test_common:simulated_time_system_lib",
         "@envoy//test/test_common:utility_lib",
     ],
 )

--- a/src/envoy/http/service_control/filter.cc
+++ b/src/envoy/http/service_control/filter.cc
@@ -99,7 +99,7 @@ Http::FilterDataStatus ServiceControlFilter::decodeData(Buffer::Instance& data,
                                                         bool end_stream) {
   ENVOY_LOG(debug, "Called ServiceControl Filter : {}", __func__);
   if (!end_stream && data.length() > 0) {
-    handler_->tryIntermediateReport(std::chrono::system_clock::now());
+    handler_->tryIntermediateReport();
   }
 
   if (state_ == Calling) {
@@ -133,7 +133,7 @@ Http::FilterDataStatus ServiceControlFilter::encodeData(Buffer::Instance& data,
                                                         bool end_stream) {
   ENVOY_LOG(debug, "Called ServiceControl Filter : {}", __func__);
   if (!end_stream && data.length() > 0) {
-    handler_->tryIntermediateReport(std::chrono::system_clock::now());
+    handler_->tryIntermediateReport();
   }
   return Http::FilterDataStatus::Continue;
 }
@@ -149,8 +149,7 @@ void ServiceControlFilter::log(
     handler_ = factory_.createHandler(*request_headers, stream_info);
   }
 
-  handler_->callReport(request_headers, response_headers, response_trailers,
-                       std::chrono::system_clock::now());
+  handler_->callReport(request_headers, response_headers, response_trailers);
 }
 
 }  // namespace ServiceControl

--- a/src/envoy/http/service_control/filter_config.h
+++ b/src/envoy/http/service_control/filter_config.h
@@ -44,7 +44,8 @@ class ServiceControlFilterConfig : public Logger::Loggable<Logger::Id::filter>,
                 proto_config)),
         call_factory_(proto_config_, context),
         config_parser_(*proto_config_, call_factory_),
-        handler_factory_(context.random(), config_parser_) {}
+        handler_factory_(context.random(), config_parser_,
+                         context.timeSource()) {}
 
   const ServiceControlHandlerFactory& handler_factory() const {
     return handler_factory_;

--- a/src/envoy/http/service_control/filter_test.cc
+++ b/src/envoy/http/service_control/filter_test.cc
@@ -188,7 +188,7 @@ TEST_F(ServiceControlFilterTest, LogWithoutHandler) {
   auto* mock_handler = new testing::NiceMock<MockServiceControlHandler>();
   EXPECT_CALL(mock_handler_factory_, createHandler_(_, _))
       .WillOnce(Return(mock_handler));
-  EXPECT_CALL(*mock_handler, callReport(_, _, _, _));
+  EXPECT_CALL(*mock_handler, callReport(_, _, _));
   filter_->log(&req_headers_, &resp_headers_, &resp_trailer_,
                mock_decoder_callbacks_.stream_info_);
 }
@@ -202,7 +202,7 @@ TEST_F(ServiceControlFilterTest, LogWithHandler) {
   filter_->decodeHeaders(req_headers_, true);
 
   EXPECT_CALL(mock_handler_factory_, createHandler_(_, _)).Times(0);
-  EXPECT_CALL(*mock_handler, callReport(_, _, _, _));
+  EXPECT_CALL(*mock_handler, callReport(_, _, _));
   filter_->log(&req_headers_, &resp_headers_, &resp_trailer_,
                mock_decoder_callbacks_.stream_info_);
 }
@@ -261,7 +261,7 @@ TEST_F(ServiceControlFilterTest, DecodeDataSendStreamReport) {
 
   mock_buffer_.add("filler");
 
-  EXPECT_CALL(*mock_handler, tryIntermediateReport(_));
+  EXPECT_CALL(*mock_handler, tryIntermediateReport());
   filter_->decodeData(mock_buffer_, /*end_stream=*/false);
 }
 
@@ -280,7 +280,7 @@ TEST_F(ServiceControlFilterTest, EncodeDataSendStreamReport) {
 
   mock_buffer_.add("filler");
 
-  EXPECT_CALL(*mock_handler, tryIntermediateReport(_));
+  EXPECT_CALL(*mock_handler, tryIntermediateReport());
   filter_->encodeData(mock_buffer_, /*end_stream=*/false);
 }
 

--- a/src/envoy/http/service_control/handler.h
+++ b/src/envoy/http/service_control/handler.h
@@ -42,15 +42,14 @@ class ServiceControlHandler {
                          CheckDoneCallback& callback) PURE;
 
   // Make a report call.
-  virtual void callReport(const Http::RequestHeaderMap* request_headers,
-                          const Http::ResponseHeaderMap* response_headers,
-                          const Http::ResponseTrailerMap* response_trailers,
-                          std::chrono::system_clock::time_point now) PURE;
+  virtual void callReport(
+      const Http::RequestHeaderMap* request_headers,
+      const Http::ResponseHeaderMap* response_headers,
+      const Http::ResponseTrailerMap* response_trailers) PURE;
 
   // If the stream report interval has passed,
   // make an intermediate report call for long-lived gRPC streaming.
-  virtual void tryIntermediateReport(
-      std::chrono::system_clock::time_point now) PURE;
+  virtual void tryIntermediateReport() PURE;
 
   // Process the response header to get the information needed for sending
   // intermediate reports.

--- a/src/envoy/http/service_control/mocks.h
+++ b/src/envoy/http/service_control/mocks.h
@@ -30,14 +30,12 @@ class MockServiceControlHandler : public ServiceControlHandler {
                                Envoy::Tracing::Span& parent_span,
                                CheckDoneCallback& callback));
 
-  MOCK_METHOD4(callReport,
+  MOCK_METHOD3(callReport,
                void(const Http::RequestHeaderMap* request_headers,
                     const Http::ResponseHeaderMap* response_headers,
-                    const Http::ResponseTrailerMap* response_trailers,
-                    std::chrono::system_clock::time_point now));
+                    const Http::ResponseTrailerMap* response_trailers));
 
-  MOCK_METHOD1(tryIntermediateReport,
-               void(std::chrono::system_clock::time_point now));
+  MOCK_METHOD0(tryIntermediateReport, void());
 
   MOCK_METHOD1(processResponseHeaders,
                void(const Http::ResponseHeaderMap& response_headers));


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

Changes:
1) remove "now" argument in handler interface: callReport() and tryIntermeidateReport()
2) pass timeSource to handlerImpl class
3) fixed handler_impl_test.cc to use Envoy SimulatedTimeSystem.