### PR TITLE
Validate urls in fuzz tests

### DIFF
--- a/src/envoy/token/iam_token_info_fuzz_test.cc
+++ b/src/envoy/token/iam_token_info_fuzz_test.cc
@@ -38,7 +38,7 @@ DEFINE_PROTO_FUZZER(const tests::fuzz::protos::IamTokenInfoInput& input) {
 
     // Call functions under test.
     TokenResult ret;
-    (void)token_info.prepareRequest(input.token_url());
+    (void)token_info.prepareRequest(Envoy::Fuzz::replaceInvalidHostCharacters(input.token_url()));
     (void)token_info.parseAccessToken(input.resp_body(), &ret);
     (void)token_info.parseIdentityToken(input.resp_body(), &ret);
 

--- a/src/envoy/token/imds_token_info_fuzz_test.cc
+++ b/src/envoy/token/imds_token_info_fuzz_test.cc
@@ -33,7 +33,7 @@ DEFINE_PROTO_FUZZER(const tests::fuzz::protos::ImdsTokenInfoInput& input) {
 
     // Call functions under test.
     TokenResult ret;
-    (void)token_info.prepareRequest(input.token_url());
+    (void)token_info.prepareRequest(Envoy::Fuzz::replaceInvalidHostCharacters(input.token_url()));
     (void)token_info.parseAccessToken(input.resp_body(), &ret);
     (void)token_info.parseIdentityToken(input.resp_body(), &ret);
 

--- a/tests/fuzz/corpus/iam_token_info/invalid-url.prototxt
+++ b/tests/fuzz/corpus/iam_token_info/invalid-url.prototxt
@@ -1,0 +1,4 @@
+include_email: false
+access_token: "access-token"
+token_url: "https://invalid-url.com/ \n test"
+resp_body: "{ \"accessToken\": \"fake-access-token\", \"expireTime\": \"2020-02-20T23:15:34-08:00\" }"

--- a/tests/fuzz/corpus/imds_token_info/invalid-url.prototxt
+++ b/tests/fuzz/corpus/imds_token_info/invalid-url.prototxt
@@ -1,0 +1,2 @@
+token_url: "https://invalid-url.com/ \n test"
+resp_body: "valid-response"

--- a/tests/fuzz/corpus/imds_token_info/valid-url.prototxt
+++ b/tests/fuzz/corpus/imds_token_info/valid-url.prototxt
@@ -1,0 +1,2 @@
+token_url: "http://127.0.0.1:42761/v1/instance/service-accounts/default/token"
+resp_body: "{ \"access_token\": \"fake-access-token\", \"expires_in\": 383929 }"

--- a/tests/fuzz/structured_inputs/iam_token_info.proto
+++ b/tests/fuzz/structured_inputs/iam_token_info.proto
@@ -13,7 +13,7 @@ message IamTokenInfoInput {
 
   // Arguments for starting the request.
   string access_token = 4;
-  string token_url = 5;
+  string token_url = 5 [(validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_VALUE}];
 
   // Arguments for parsing the tokens.
   string resp_body = 6;

--- a/tests/fuzz/structured_inputs/imds_token_info.proto
+++ b/tests/fuzz/structured_inputs/imds_token_info.proto
@@ -6,7 +6,7 @@ import "validate/validate.proto";
 
 message ImdsTokenInfoInput {
   // Arguments for starting the request.
-  string token_url = 1;
+  string token_url = 1 [(validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_VALUE}];
 
   // Arguments for parsing the tokens.
   string resp_body = 2;


### PR DESCRIPTION
As discussed offline, URLs generated by config manager should be valid. We don't need to fuzz test these. This will unblock fuzzing.

Signed-off-by: Teju Nareddy <nareddyt@google.com>