### PR TITLE
Add unit and integration test for HTTP/2 backends

### DIFF
--- a/tests/endpoints/echo/server/app.go
+++ b/tests/endpoints/echo/server/app.go
@@ -285,7 +285,7 @@ func createServer() (*http.Server, error) {
 	}
 
 	// Disable HTTP/2 support if needed by setting an empty handler.
-	if *disableHttp2 {
+	if *isHttps && *disableHttp2 {
 		server.TLSNextProto = map[string]func(*http.Server, *tls.Conn, http.Handler){}
 	}
 

--- a/tests/endpoints/echo/server/app.go
+++ b/tests/endpoints/echo/server/app.go
@@ -35,6 +35,7 @@ import (
 var (
 	port                  = flag.Int("port", 8082, "server port")
 	isHttps               = flag.Bool("enable_https", false, "true for HTTPS, false for HTTP")
+	disableHttp2          = flag.Bool("disable_http2", false, "Set to true to disable http/2 handler. By default, accepts http/1 and http/2 connections.")
 	mtlsCertFile          = flag.String("mtls_cert_file", "", "Enable Mutual authentication with the cert chain file")
 	enableRootPathHandler = flag.Bool("enable_root_path_handler", false, "true for adding root path for dynamic routing handler")
 	httpsCertPath         = flag.String("https_cert_path", "", "path for HTTPS cert path")
@@ -278,14 +279,21 @@ func errorf(w http.ResponseWriter, code int, format string, a ...interface{}) {
 }
 
 func createServer() (*http.Server, error) {
-	var server *http.Server
 	addr := fmt.Sprintf("%v:%d", platform.GetLoopbackAddress(), *port)
+	server := &http.Server{
+		Addr: addr,
+	}
+
+	// Disable HTTP/2 support if needed by setting an empty handler.
+	if *disableHttp2 {
+		server.TLSNextProto = map[string]func(*http.Server, *tls.Conn, http.Handler){}
+	}
 
 	if *mtlsCertFile == "" {
-		server = &http.Server{Addr: addr}
 		return server, nil
 	}
 
+	// Setup mTLS.
 	if !*isHttps {
 		return nil, fmt.Errorf("server must be HTTPS server when mTLS is required")
 	}
@@ -306,8 +314,6 @@ func createServer() (*http.Server, error) {
 
 	tlsConfig.BuildNameToCertificate()
 
-	return &http.Server{
-		Addr:      addr,
-		TLSConfig: tlsConfig,
-	}, nil
+	server.TLSConfig = tlsConfig
+	return server, nil
 }

--- a/tests/env/components/echo_http_server.go
+++ b/tests/env/components/echo_http_server.go
@@ -22,17 +22,18 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 )
 
-// Echo stores data for Echo HTTP/1 backend process.
+// Echo stores data for Echo HTTP backend process.
 type EchoHTTPServer struct {
 	*Cmd
 }
 
-func NewEchoHTTPServer(port uint16, enableHttps bool, enableRootPathHandler, useWrongCert bool, mtlsCertFile string) (*EchoHTTPServer, error) {
+func NewEchoHTTPServer(port uint16, enableHttps bool, enableRootPathHandler, useWrongCert bool, mtlsCertFile string, disableHttp2 bool) (*EchoHTTPServer, error) {
 	serverArgs := []string{
 		fmt.Sprint("--alsologtostderr"),
 		fmt.Sprintf("--port=%v", port),
 		fmt.Sprintf("--enable_https=%v", enableHttps),
 		fmt.Sprintf("--enable_root_path_handler=%v", enableRootPathHandler),
+		fmt.Sprintf("--disable_http2=%v", disableHttp2),
 	}
 
 	// If Backend server uses different cert as Proxy, the HTTPS call fails.
@@ -51,6 +52,7 @@ func NewEchoHTTPServer(port uint16, enableHttps bool, enableRootPathHandler, use
 	}
 
 	cmd := exec.Command(platform.GetFilePath(platform.Echo), serverArgs...)
+
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	return &EchoHTTPServer{

--- a/tests/env/components/ports.go
+++ b/tests/env/components/ports.go
@@ -39,6 +39,7 @@ const (
 	TestBackendAuthWithImdsIdToken
 	TestBackendAuthWithImdsIdTokenRetries
 	TestBackendAuthWithImdsIdTokenWhileAllowCors
+	TestBackendHttpProtocol
 	TestDeadlinesForCatchAllBackend
 	TestDeadlinesForDynamicRouting
 	TestDeadlinesForGrpcCatchAllBackend

--- a/tests/env/env.go
+++ b/tests/env/env.go
@@ -75,6 +75,8 @@ type TestEnv struct {
 	healthRegistry                  *components.HealthRegistry
 	FakeJwtService                  *components.FakeJwtService
 	skipHealthChecks                bool
+	// Only implemented for the HTTP Echo backend.
+	disableHttp2ForBackend bool
 }
 
 func NewTestEnv(testId uint16, backend platform.Backend) *TestEnv {
@@ -189,6 +191,12 @@ func (e *TestEnv) AppendBackendRules(rules []*confpb.BackendRule) {
 	e.fakeServiceConfig.Backend.Rules = append(e.fakeServiceConfig.Backend.Rules, rules...)
 }
 
+// RemoveAllBackendRules removes all Service.Backend.Rules.
+// This is useful for testing
+func (e *TestEnv) RemoveAllBackendRules() {
+	e.fakeServiceConfig.Backend = &confpb.Backend{}
+}
+
 // EnableScNetworkFailOpen sets enableScNetworkFailOpen to be true.
 func (e *TestEnv) EnableScNetworkFailOpen() {
 	e.enableScNetworkFailOpen = true
@@ -232,6 +240,10 @@ func addDynamicRoutingBackendPort(serviceConfig *confpb.Service, port uint16) er
 func (e *TestEnv) SetupFakeTraceServer() {
 	// Start fake stackdriver server
 	e.FakeStackdriverServer = components.NewFakeStackdriver()
+}
+
+func (e *TestEnv) DisableHttp2ForBackend() {
+	e.disableHttp2ForBackend = true
 }
 
 // Setup setups Envoy, Config Manager, and Backend server for test.
@@ -357,7 +369,7 @@ func (e *TestEnv) Setup(confArgs []string) error {
 
 	switch e.backend {
 	case platform.EchoSidecar:
-		e.echoBackend, err = components.NewEchoHTTPServer(e.ports.BackendServerPort /*enableHttps=*/, false /*enableRootPathHandler=*/, e.enableEchoServerRootPathHandler /*useAuthorizedBackendCert*/, false, e.backendMTLSCertFile)
+		e.echoBackend, err = components.NewEchoHTTPServer(e.ports.BackendServerPort /*enableHttps=*/, false /*enableRootPathHandler=*/, e.enableEchoServerRootPathHandler /*useAuthorizedBackendCert*/, false, e.backendMTLSCertFile, e.disableHttp2ForBackend)
 		if err != nil {
 			return err
 		}
@@ -365,7 +377,7 @@ func (e *TestEnv) Setup(confArgs []string) error {
 			return err
 		}
 	case platform.EchoRemote:
-		e.echoBackend, err = components.NewEchoHTTPServer(e.ports.DynamicRoutingBackendPort /*enableHttps=*/, true /*enableRootPathHandler=*/, true, e.useWrongBackendCert, e.backendMTLSCertFile)
+		e.echoBackend, err = components.NewEchoHTTPServer(e.ports.DynamicRoutingBackendPort /*enableHttps=*/, true /*enableRootPathHandler=*/, true, e.useWrongBackendCert, e.backendMTLSCertFile, e.disableHttp2ForBackend)
 		if err != nil {
 			return err
 		}

--- a/tests/env/env.go
+++ b/tests/env/env.go
@@ -42,9 +42,8 @@ var (
 )
 
 type TestEnv struct {
-	testId              uint16
-	backend             platform.Backend
-	useWrongBackendCert bool
+	testId  uint16
+	backend platform.Backend
 	// used to enable mutual authentication for HTTPS backend
 	backendMTLSCertFile             string
 	mockMetadata                    bool
@@ -75,8 +74,10 @@ type TestEnv struct {
 	healthRegistry                  *components.HealthRegistry
 	FakeJwtService                  *components.FakeJwtService
 	skipHealthChecks                bool
-	// Only implemented for the HTTP Echo backend.
-	disableHttp2ForBackend bool
+
+	// Only implemented for the RemoteEcho backend.
+	useWrongBackendCert         bool
+	disableHttp2ForHttpsBackend bool
 }
 
 func NewTestEnv(testId uint16, backend platform.Backend) *TestEnv {
@@ -242,8 +243,8 @@ func (e *TestEnv) SetupFakeTraceServer() {
 	e.FakeStackdriverServer = components.NewFakeStackdriver()
 }
 
-func (e *TestEnv) DisableHttp2ForBackend() {
-	e.disableHttp2ForBackend = true
+func (e *TestEnv) DisableHttp2ForHttpsBackend() {
+	e.disableHttp2ForHttpsBackend = true
 }
 
 // Setup setups Envoy, Config Manager, and Backend server for test.
@@ -369,7 +370,7 @@ func (e *TestEnv) Setup(confArgs []string) error {
 
 	switch e.backend {
 	case platform.EchoSidecar:
-		e.echoBackend, err = components.NewEchoHTTPServer(e.ports.BackendServerPort /*enableHttps=*/, false /*enableRootPathHandler=*/, e.enableEchoServerRootPathHandler /*useAuthorizedBackendCert*/, false, e.backendMTLSCertFile, e.disableHttp2ForBackend)
+		e.echoBackend, err = components.NewEchoHTTPServer(e.ports.BackendServerPort /*enableHttps=*/, false /*enableRootPathHandler=*/, e.enableEchoServerRootPathHandler /*useAuthorizedBackendCert*/, false, e.backendMTLSCertFile, e.disableHttp2ForHttpsBackend)
 		if err != nil {
 			return err
 		}
@@ -377,7 +378,7 @@ func (e *TestEnv) Setup(confArgs []string) error {
 			return err
 		}
 	case platform.EchoRemote:
-		e.echoBackend, err = components.NewEchoHTTPServer(e.ports.DynamicRoutingBackendPort /*enableHttps=*/, true /*enableRootPathHandler=*/, true, e.useWrongBackendCert, e.backendMTLSCertFile, e.disableHttp2ForBackend)
+		e.echoBackend, err = components.NewEchoHTTPServer(e.ports.DynamicRoutingBackendPort /*enableHttps=*/, true /*enableRootPathHandler=*/, true, e.useWrongBackendCert, e.backendMTLSCertFile, e.disableHttp2ForHttpsBackend)
 		if err != nil {
 			return err
 		}

--- a/tests/integration_test/backend_auth_disable_auth_test.go
+++ b/tests/integration_test/backend_auth_disable_auth_test.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/echo/client"
-	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
+	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
 
 	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"

--- a/tests/integration_test/backend_auth_using_iam_test.go
+++ b/tests/integration_test/backend_auth_using_iam_test.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/echo/client"
-	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
+	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
 
 	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"

--- a/tests/integration_test/backend_auth_using_imds_test.go
+++ b/tests/integration_test/backend_auth_using_imds_test.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/echo/client"
-	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
+	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
 
 	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"

--- a/tests/integration_test/backend_protocol_test.go
+++ b/tests/integration_test/backend_protocol_test.go
@@ -103,19 +103,16 @@ func TestBackendHttpProtocol(t *testing.T) {
 			if tc.httpCallError != nil {
 				// Expect an error.
 				if err == nil {
-					t.Fatalf("Test(%s) expected error: %v, got: none", tc.desc, tc.httpCallError)
-				}
-				if !strings.Contains(err.Error(), tc.httpCallError.Error()) {
-					t.Fatalf("Test(%s) expected error: %v, got: %v", tc.desc, tc.httpCallError, err)
+					t.Errorf("Test(%s) expected error: %v, got: none", tc.desc, tc.httpCallError)
+				} else if !strings.Contains(err.Error(), tc.httpCallError.Error()) {
+					t.Errorf("Test(%s) expected error: %v, got: %v", tc.desc, tc.httpCallError, err)
 				}
 			} else {
 				// Expect success.
 				if err != nil {
-					t.Fatalf("Test(%s) expected success, got err: %v", tc.desc, err)
-				}
-				gotRespStr := string(gotResp)
-				if err := util.JsonEqual(tc.wantResp, gotRespStr); err != nil {
-					t.Fatalf("Test(%s) expected success: \n %s", tc.desc, err)
+					t.Errorf("Test(%s) expected success, got err: %v", tc.desc, err)
+				} else if err := util.JsonEqual(tc.wantResp, string(gotResp)); err != nil {
+					t.Errorf("Test(%s) expected success: \n %s", tc.desc, err)
 				}
 			}
 

--- a/tests/integration_test/backend_protocol_test.go
+++ b/tests/integration_test/backend_protocol_test.go
@@ -1,0 +1,129 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
+	"github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/echo/client"
+	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
+	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
+
+	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
+	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
+)
+
+var testBackendProtocolArgs = []string{
+	"--service_config_id=test-config-id",
+	"--rollout_strategy=fixed",
+	"--backend_dns_lookup_family=v4only",
+	"--suppress_envoy_headers",
+}
+
+func TestBackendHttpProtocol(t *testing.T) {
+
+	testData := []struct {
+		desc           string
+		backendIsHttp2 bool
+		configHttp2    bool
+		wantResp       string
+		httpCallError  error
+	}{
+		{
+			desc:           "Success when backend is http/1 only and envoy is configured for http/1 backend",
+			backendIsHttp2: false,
+			configHttp2:    false,
+			wantResp:       `{"message":"hello"}`,
+		},
+		{
+			desc:           "Success when backend is http/2 and envoy is configured for http/1 backend",
+			backendIsHttp2: true,
+			configHttp2:    false,
+			wantResp:       `{"message":"hello"}`,
+		},
+		{
+			desc:           "Success when backend is http/2 and envoy is configured for http/2 backend",
+			backendIsHttp2: true,
+			configHttp2:    true,
+			wantResp:       `{"message":"hello"}`,
+		},
+		{
+			desc:           "Failure when backend is http/1 only and envoy is configured for http/2 backend",
+			backendIsHttp2: false,
+			configHttp2:    true,
+			httpCallError:  fmt.Errorf("503 Service Unavailable, upstream connect error or disconnect/reset before headers. reset reason: connection termination"),
+		},
+	}
+	for _, tc := range testData {
+		func() {
+
+			httpProtocol := "http/1.1"
+			if tc.configHttp2 {
+				httpProtocol = "h2"
+			}
+
+			// Setup the protocol in the backend rule for the endpoint under test.
+			s := env.NewTestEnv(comp.TestBackendHttpProtocol, platform.EchoRemote)
+			s.RemoveAllBackendRules()
+			s.AppendBackendRules([]*confpb.BackendRule{
+				{
+					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo",
+					Address:         "https://localhost:-1/echo",
+					PathTranslation: confpb.BackendRule_CONSTANT_ADDRESS,
+					Protocol:        httpProtocol,
+				},
+			})
+
+			// Explicitly setup which protocol the echo backend operates under.
+			if !tc.backendIsHttp2 {
+				s.DisableHttp2ForBackend()
+			}
+
+			// Setup test env.
+			defer s.TearDown()
+			if err := s.Setup(testBackendProtocolArgs); err != nil {
+				t.Fatalf("fail to setup test env, %v", err)
+			}
+
+			// Do test.
+			url := fmt.Sprintf("http://localhost:%v%v", s.Ports().ListenerPort, "/echo?key=api-key")
+			gotResp, err := client.DoWithHeaders(url, "POST", "hello", nil)
+
+			// Assertions.
+			if tc.httpCallError != nil {
+				// Expect an error.
+				if err == nil {
+					t.Fatalf("Test(%s) expected error: %v, got: none", tc.desc, tc.httpCallError)
+				}
+				if !strings.Contains(err.Error(), tc.httpCallError.Error()) {
+					t.Fatalf("Test(%s) expected error: %v, got: %v", tc.desc, tc.httpCallError, err)
+				}
+			} else {
+				// Expect success.
+				if err != nil {
+					t.Fatalf("Test(%s) expected success, got err: %v", tc.desc, err)
+				}
+				gotRespStr := string(gotResp)
+				if err := util.JsonEqual(tc.wantResp, gotRespStr); err != nil {
+					t.Fatalf("Test(%s) expected success: \n %s", tc.desc, err)
+				}
+			}
+
+		}()
+	}
+}

--- a/tests/integration_test/backend_protocol_test.go
+++ b/tests/integration_test/backend_protocol_test.go
@@ -23,17 +23,11 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/echo/client"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
+	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
 
 	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
 )
-
-var testBackendProtocolArgs = []string{
-	"--service_config_id=test-config-id",
-	"--rollout_strategy=fixed",
-	"--backend_dns_lookup_family=v4only",
-	"--suppress_envoy_headers",
-}
 
 func TestBackendHttpProtocol(t *testing.T) {
 
@@ -70,6 +64,7 @@ func TestBackendHttpProtocol(t *testing.T) {
 		},
 	}
 	for _, tc := range testData {
+		// Place in closure to allow deferring in loop.
 		func() {
 
 			httpProtocol := "http/1.1"
@@ -91,12 +86,12 @@ func TestBackendHttpProtocol(t *testing.T) {
 
 			// Explicitly setup which protocol the echo backend operates under.
 			if !tc.backendIsHttp2 {
-				s.DisableHttp2ForBackend()
+				s.DisableHttp2ForHttpsBackend()
 			}
 
 			// Setup test env.
 			defer s.TearDown()
-			if err := s.Setup(testBackendProtocolArgs); err != nil {
+			if err := s.Setup(utils.CommonArgs()); err != nil {
 				t.Fatalf("fail to setup test env, %v", err)
 			}
 


### PR DESCRIPTION
Added unit test to verify ordering for duplicated backend rules with different protocols.

Added integration test to ensure Envoy configuration for HTTP/2 by testing the negative case where:
- Envoy is configured to use HTTP/2 for a backend
- Backend does not support HTTP/2 (HTTP/1-only backend)

Integration test implementation notes:
- Add option to HTTP echo backend to disable default HTTP/2 support.

Signed-off-by: Teju Nareddy <nareddyt@google.com>