### PR TITLE
Validate logged header format in service control config

### DIFF
--- a/api/envoy/http/service_control/config.proto
+++ b/api/envoy/http/service_control/config.proto
@@ -69,10 +69,10 @@ message Service {
   string backend_protocol = 5;
 
   // The array of request headers demanded to be logged
-  repeated string log_request_headers = 6;
+  repeated string log_request_headers = 6 [(validate.rules).repeated.items.string.well_known_regex = HTTP_HEADER_NAME];
 
   // The array of response headers demanded to be logged
-  repeated string log_response_headers = 7;
+  repeated string log_response_headers = 7 [(validate.rules).repeated.items.string.well_known_regex = HTTP_HEADER_NAME];
 
   // Minimum amount of time (milliseconds) between sending intermediate
   // reports on a stream.

--- a/tests/fuzz/corpus/service_control_filter/crash-log-request-headers.prototxt
+++ b/tests/fuzz/corpus/service_control_filter/crash-log-request-headers.prototxt
@@ -1,0 +1,23 @@
+config {
+  services {
+    service_name: "echo-api.endpoints.cloudesf-testing.cloud.goog"
+    service_config_id: "test-config-id"
+    producer_project_id: "producer-project"
+    backend_protocol: "http1"
+    log_request_headers: "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n"
+    jwt_payload_metadata_name: "jwt_payloads"
+  }
+  requirements {
+    service_name: "echo-api.endpoints.cloudesf-testing.cloud.goog"
+    operation_name: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo"
+  }
+}
+downstream_request {
+}
+upstream_response {
+}
+stream_info {
+  start_time: 1560281088
+}
+sidestream_response {
+}


### PR DESCRIPTION
Bug type: User Experience

If an API producer configures an incorrect format for `--log_request_headers`, then ESPv2 will startup and listen for traffic. But when the first request finishes and SC Report is called, Envoy will crash with an assertion fail. This is bad user experience, we should fail early at config time.

Use protoc-gen-validate's well-known types to assert header format in service control config proto. This should not be a breaking API change.

Added reproducer testcase to the corpus.

Ref: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=21170
Signed-off-by: Teju Nareddy <nareddyt@google.com>