### PR TITLE
Update envoy to 2020-03-12

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -39,9 +39,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # 3) Check if envoy_build_config/extensions_build_config.bzl is up-to-date.
 # Try to match it with the one in source/extensions and comment out unneeded extensions.
 
-ENVOY_SHA1 = "5b1723ff54b1a51e104c514ee6363234aaa44366"  # 2020-03-03
+ENVOY_SHA1 = "97a76d991766d96df2e84a1f2e33b69cae844471"  # 2020-03-12
 
-ENVOY_SHA256 = "03e98c75079814a018f8544761723687afba829a1ce0c98c02009bd599b6ea3d"
+ENVOY_SHA256 = "7b08e9d466cda549212ef4379dfa2bc44f725a4f1879f5064ab23f700115575b"
 
 http_archive(
     name = "envoy",

--- a/src/envoy/http/service_control/handler_utils.cc
+++ b/src/envoy/http/service_control/handler_utils.cc
@@ -48,7 +48,7 @@ inline int64_t convertNsToMs(std::chrono::nanoseconds ns) {
   return std::chrono::duration_cast<std::chrono::milliseconds>(ns).count();
 }
 
-bool extractAPIKeyFromQuery(const Http::HeaderMap& headers,
+bool extractAPIKeyFromQuery(const Http::RequestHeaderMap& headers,
                             const std::string& query, bool& were_params_parsed,
                             Http::Utility::QueryParams& parsed_params,
                             std::string& api_key) {
@@ -69,7 +69,7 @@ bool extractAPIKeyFromQuery(const Http::HeaderMap& headers,
   return false;
 }
 
-bool extractAPIKeyFromHeader(const Http::HeaderMap& headers,
+bool extractAPIKeyFromHeader(const Http::RequestHeaderMap& headers,
                              const std::string& header, std::string& api_key) {
   // TODO(qiwzhang): optimize this by using LowerCaseString at init.
   auto* entry = headers.get(Http::LowerCaseString(header));
@@ -80,7 +80,7 @@ bool extractAPIKeyFromHeader(const Http::HeaderMap& headers,
   return false;
 }
 
-bool extractAPIKeyFromCookie(const Http::HeaderMap& headers,
+bool extractAPIKeyFromCookie(const Http::RequestHeaderMap& headers,
                              const std::string& cookie, std::string& api_key) {
   std::string parsed_api_key = Http::Utility::parseCookieValue(headers, cookie);
   if (!parsed_api_key.empty()) {
@@ -246,7 +246,7 @@ void fillJwtPayload(const envoy::config::core::v3::Metadata& metadata,
 }
 
 bool extractAPIKey(
-    const Http::HeaderMap& headers,
+    const Http::RequestHeaderMap& headers,
     const ::google::protobuf::RepeatedPtrField<
         ::google::api::envoy::http::service_control::ApiKeyLocation>& locations,
     std::string& api_key) {

--- a/src/envoy/http/service_control/handler_utils.h
+++ b/src/envoy/http/service_control/handler_utils.h
@@ -31,7 +31,7 @@ namespace ServiceControl {
 //
 // Returns whether an `api_key` was found.
 bool extractAPIKey(
-    const Http::HeaderMap& headers,
+    const Http::RequestHeaderMap& headers,
     const ::google::protobuf::RepeatedPtrField<
         ::google::api::envoy::http::service_control::ApiKeyLocation>& locations,
     std::string& api_key);

--- a/src/envoy/http/service_control/handler_utils_test.cc
+++ b/src/envoy/http/service_control/handler_utils_test.cc
@@ -88,7 +88,7 @@ TEST(ServiceControlUtils, FillLoggedHeader) {
   EXPECT_TRUE(output.empty());
 
   struct TestCase {
-    Http::TestHeaderMapImpl headers;
+    Http::TestRequestHeaderMapImpl headers;
     std::string service_proto;
     std::string expected_output;
   };
@@ -153,7 +153,7 @@ TEST(ServiceControlUtils, FillLoggedHeader) {
   std::string service_proto = R"(log_request_headers: "log-this")";
   ASSERT_TRUE(TextFormat::ParseFromString(service_proto, &service));
 
-  Http::TestHeaderMapImpl headers{{"log-this", "foo"}, {"log-this", "bar"}};
+  Http::TestRequestHeaderMapImpl headers{{"log-this", "foo"}, {"log-this", "bar"}};
   fillLoggedHeader(&headers, service.log_request_headers(), output);
   EXPECT_TRUE(output == "log-this=foo;" || output == "log-this=bar;");
 }
@@ -161,7 +161,7 @@ TEST(ServiceControlUtils, FillLoggedHeader) {
 TEST(ServiceControlUtils, ExtractApiKey) {
   struct TestCase {
     std::string requirement_proto;
-    Http::TestHeaderMapImpl headers;
+    Http::TestRequestHeaderMapImpl headers;
     std::string expected_api_key;
   };
 
@@ -399,7 +399,7 @@ TEST(ServiceControlUtils, GetBackendProtocol) {
 }
 
 TEST(ServiceControlUtils, GetFrontendProtocol) {
-  Http::TestHeaderMapImpl headers;
+  Http::TestRequestHeaderMapImpl headers;
   testing::NiceMock<StreamInfo::MockStreamInfo> mock_stream_info;
 
   // Test: header is nullptr and stream_info has no protocol


### PR DESCRIPTION
This is needed to improve tech debt related to fuzz failures.

Breaking change in the header map interface: https://github.com/envoyproxy/envoy/pull/10252

Signed-off-by: Teju Nareddy <nareddyt@google.com>