### PR TITLE
Handle null pointer for running envoy in a named pipe

### DIFF
--- a/api/envoy/http/service_control/config.proto
+++ b/api/envoy/http/service_control/config.proto
@@ -69,10 +69,14 @@ message Service {
   string backend_protocol = 5;
 
   // The array of request headers demanded to be logged
-  repeated string log_request_headers = 6 [(validate.rules).repeated.items.string.well_known_regex = HTTP_HEADER_NAME];
+  repeated string log_request_headers = 6
+      [(validate.rules).repeated .items.string.well_known_regex =
+           HTTP_HEADER_NAME];
 
   // The array of response headers demanded to be logged
-  repeated string log_response_headers = 7 [(validate.rules).repeated.items.string.well_known_regex = HTTP_HEADER_NAME];
+  repeated string log_response_headers = 7
+      [(validate.rules).repeated .items.string.well_known_regex =
+           HTTP_HEADER_NAME];
 
   // Minimum amount of time (milliseconds) between sending intermediate
   // reports on a stream.

--- a/src/envoy/http/service_control/handler_impl.cc
+++ b/src/envoy/http/service_control/handler_impl.cc
@@ -114,8 +114,13 @@ void ServiceControlHandlerImpl::fillOperationInfo(
   info.producer_project_id =
       require_ctx_->service_ctx().config().producer_project_id();
   info.current_time = time_source_.systemTime();
-  info.client_ip =
-      stream_info_.downstreamRemoteAddress()->ip()->addressAsString();
+
+  if (stream_info_.downstreamRemoteAddress()->type() ==
+      Envoy::Network::Address::Type::Ip) {
+    info.client_ip =
+        stream_info_.downstreamRemoteAddress()->ip()->addressAsString();
+  }
+
   info.api_key = api_key_;
 }
 

--- a/tests/fuzz/corpus/service_control_filter/crash-downstream-address-pipe.prototxt
+++ b/tests/fuzz/corpus/service_control_filter/crash-downstream-address-pipe.prototxt
@@ -1,0 +1,33 @@
+config {
+  services {
+    service_name: "echo-api.endpoints.cloudesf-testing.cloud.goog"
+    service_config_id: "test-config-id"
+    producer_project_id: "producer-project"
+    backend_protocol: "http1"
+    min_stream_report_interval_ms: 125754226507776
+    jwt_payload_metadata_name: "jwt_payloads"
+  }
+  requirements {
+    service_name: "echo-api.endpoints.cloudesf-testing.cloud.goog"
+    operation_name: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo"
+  }
+}
+downstream_request {
+  headers {
+    headers {
+      key: ":path"
+      value: "/echo?key=test-api-key"
+    }
+  }
+}
+upstream_response {
+}
+stream_info {
+  address {
+    pipe {
+      path: "IIIIIIIIIIIIIIIIIIIIIIIII"
+    }
+  }
+}
+sidestream_response {
+}


### PR DESCRIPTION
`Address` can either be a IP address or a named pipe. We try to read from a `nullptr` if the address is a named pipe. Even though we will never run into this problem with the current deployment model of ESPv2, we should still handle this case for other open-source users and simpler fuzzing.

Added reproducer test-case.

Ref: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=21174
Signed-off-by: Teju Nareddy <nareddyt@google.com>