### PR TITLE
Validate URIs in envoy config

### DIFF
--- a/api/envoy/http/backend_routing/config.proto
+++ b/api/envoy/http/backend_routing/config.proto
@@ -32,7 +32,6 @@ message BackendRoutingRule {
   // Example for APPEND_PATH_TO_ADDRESS:
   //     https://my-project-id.appspot.com
   string path_prefix = 3 [(validate.rules).string = {
-    min_bytes: 1,
     well_known_regex: HTTP_HEADER_VALUE,
     strict: false
   }];

--- a/api/envoy/http/backend_routing/config.proto
+++ b/api/envoy/http/backend_routing/config.proto
@@ -31,7 +31,11 @@ message BackendRoutingRule {
   //     https://us-central1-my-project-id.cloudfunctions.net/helloGET
   // Example for APPEND_PATH_TO_ADDRESS:
   //     https://my-project-id.appspot.com
-  string path_prefix = 3;
+  string path_prefix = 3 [(validate.rules).string = {
+    min_bytes: 1,
+    well_known_regex: HTTP_HEADER_VALUE,
+    strict: false
+  }];
 }
 
 message FilterConfig {

--- a/api/envoy/http/common/base.proto
+++ b/api/envoy/http/common/base.proto
@@ -47,7 +47,11 @@ message Pattern {
 
 message HttpUri {
   // The uri string including the domain and path.
-  string uri = 1 [(validate.rules).string.min_bytes = 1];
+  string uri = 1 [(validate.rules).string = {
+    min_bytes: 1,
+    well_known_regex: HTTP_HEADER_VALUE,
+    strict: false
+  }];
 
   // The Envoy cluster name required for Envoy to make a remote call.
   string cluster = 2 [(validate.rules).string.min_bytes = 1];

--- a/src/envoy/http/service_control/handler_utils_test.cc
+++ b/src/envoy/http/service_control/handler_utils_test.cc
@@ -153,7 +153,8 @@ TEST(ServiceControlUtils, FillLoggedHeader) {
   std::string service_proto = R"(log_request_headers: "log-this")";
   ASSERT_TRUE(TextFormat::ParseFromString(service_proto, &service));
 
-  Http::TestRequestHeaderMapImpl headers{{"log-this", "foo"}, {"log-this", "bar"}};
+  Http::TestRequestHeaderMapImpl headers{{"log-this", "foo"},
+                                         {"log-this", "bar"}};
   fillLoggedHeader(&headers, service.log_request_headers(), output);
   EXPECT_TRUE(output == "log-this=foo;" || output == "log-this=bar;");
 }

--- a/src/envoy/token/iam_token_info_fuzz_test.cc
+++ b/src/envoy/token/iam_token_info_fuzz_test.cc
@@ -38,8 +38,7 @@ DEFINE_PROTO_FUZZER(const tests::fuzz::protos::IamTokenInfoInput& input) {
 
     // Call functions under test.
     TokenResult ret;
-    (void)token_info.prepareRequest(
-        Envoy::Fuzz::replaceInvalidHostCharacters(input.token_url()));
+    (void)token_info.prepareRequest(input.token_url());
     (void)token_info.parseAccessToken(input.resp_body(), &ret);
     (void)token_info.parseIdentityToken(input.resp_body(), &ret);
 

--- a/src/envoy/token/imds_token_info_fuzz_test.cc
+++ b/src/envoy/token/imds_token_info_fuzz_test.cc
@@ -33,8 +33,7 @@ DEFINE_PROTO_FUZZER(const tests::fuzz::protos::ImdsTokenInfoInput& input) {
 
     // Call functions under test.
     TokenResult ret;
-    (void)token_info.prepareRequest(
-        Envoy::Fuzz::replaceInvalidHostCharacters(input.token_url()));
+    (void)token_info.prepareRequest(input.token_url());
     (void)token_info.parseAccessToken(input.resp_body(), &ret);
     (void)token_info.parseIdentityToken(input.resp_body(), &ret);
 

--- a/tests/fuzz/corpus/service_control_filter/crash-bad-service-control-uri.prototxt
+++ b/tests/fuzz/corpus/service_control_filter/crash-bad-service-control-uri.prototxt
@@ -1,0 +1,42 @@
+config {
+  services {
+    service_name: "echo-api.endpoints.cloudesf-testing.cloud.goog"
+    service_config_id: "test-config-id"
+    producer_project_id: "producer-project"
+    backend_protocol: "http1"
+    jwt_payload_metadata_name: "jwt_payloads"
+  }
+  requirements {
+    service_name: "echo-api.endpoints.cloudesf-testing.cloud.goog"
+    operation_name: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo"
+  }
+  imds_token {
+    uri: "http://127.0.0.1:42761/v1/instance/service-accounts/default/token"
+    cluster: "/protocol"
+    timeout {
+      seconds: 5
+    }
+  }
+  service_control_uri {
+    uri: "http://127.0.0.\001\000\000\000/services/"
+    cluster: "service-control-cluster"
+    timeout {
+      seconds: 5
+    }
+  }
+}
+downstream_request {
+}
+upstream_response {
+}
+stream_info {
+}
+sidestream_response {
+  headers {
+    headers {
+      key: ":status"
+      value: "200"
+    }
+  }
+  data: "{ \"access_token\": \"fuzz-access-token\", \"expires_in\": 60000 }"
+}

--- a/tests/fuzz/structured_inputs/iam_token_info.proto
+++ b/tests/fuzz/structured_inputs/iam_token_info.proto
@@ -13,7 +13,11 @@ message IamTokenInfoInput {
 
   // Arguments for starting the request.
   string access_token = 4;
-  string token_url = 5 [(validate.rules).string = {min_bytes: 1, well_known_regex: HTTP_HEADER_VALUE, strict: false}];
+  string token_url = 5 [(validate.rules).string = {
+    min_bytes: 1,
+    well_known_regex: HTTP_HEADER_VALUE,
+    strict: false
+  }];
 
   // Arguments for parsing the tokens.
   string resp_body = 6;

--- a/tests/fuzz/structured_inputs/iam_token_info.proto
+++ b/tests/fuzz/structured_inputs/iam_token_info.proto
@@ -13,7 +13,7 @@ message IamTokenInfoInput {
 
   // Arguments for starting the request.
   string access_token = 4;
-  string token_url = 5 [(validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_VALUE}];
+  string token_url = 5 [(validate.rules).string = {min_bytes: 1, well_known_regex: HTTP_HEADER_VALUE, strict: false}];
 
   // Arguments for parsing the tokens.
   string resp_body = 6;

--- a/tests/fuzz/structured_inputs/imds_token_info.proto
+++ b/tests/fuzz/structured_inputs/imds_token_info.proto
@@ -6,7 +6,7 @@ import "validate/validate.proto";
 
 message ImdsTokenInfoInput {
   // Arguments for starting the request.
-  string token_url = 1 [(validate.rules).string = {min_bytes: 1 well_known_regex: HTTP_HEADER_VALUE}];
+  string token_url = 1 [(validate.rules).string = {min_bytes: 1, well_known_regex: HTTP_HEADER_VALUE, strict: false}];
 
   // Arguments for parsing the tokens.
   string resp_body = 2;

--- a/tests/fuzz/structured_inputs/imds_token_info.proto
+++ b/tests/fuzz/structured_inputs/imds_token_info.proto
@@ -6,7 +6,11 @@ import "validate/validate.proto";
 
 message ImdsTokenInfoInput {
   // Arguments for starting the request.
-  string token_url = 1 [(validate.rules).string = {min_bytes: 1, well_known_regex: HTTP_HEADER_VALUE, strict: false}];
+  string token_url = 1 [(validate.rules).string = {
+    min_bytes: 1,
+    well_known_regex: HTTP_HEADER_VALUE,
+    strict: false
+  }];
 
   // Arguments for parsing the tokens.
   string resp_body = 2;


### PR DESCRIPTION
Bug type: Tech Debt

Use new `protoc-gen-validate` well-known type to validate all URIs don't cause assertion failures in Envoy. This makes fuzz testing a lot simpler and maintains consistency with upstream Envoy config validation.

By setting `strict = false`, this validation just prevents `\r`, `\n`, and `\0` characters in URIs. Note this validation is not compliant with RFC 7230 (all other characters are allowed). This is not a breaking change, as `\r\n\0` characters cause envoy assertion failures anyways.

Added a reproducer test-case for service control URI.

Ref: https://github.com/envoyproxy/protoc-gen-validate/pull/323
Ref: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=21172

Signed-off-by: Teju Nareddy <nareddyt@google.com>