### PR TITLE
Treat status code in report as an unsigned int

### DIFF
--- a/src/api_proxy/service_control/request_info.h
+++ b/src/api_proxy/service_control/request_info.h
@@ -126,7 +126,7 @@ struct QuotaRequestInfo : public OperationInfo {
 // Information to fill Report request protobuf.
 struct ReportRequestInfo : public OperationInfo {
   // The HTTP response code.
-  int response_code;
+  unsigned int response_code;
 
   // The response status.
   ::google::protobuf::util::Status status;

--- a/tests/fuzz/corpus/service_control_filter/crash-response-code-overflow.prototxt
+++ b/tests/fuzz/corpus/service_control_filter/crash-response-code-overflow.prototxt
@@ -1,0 +1,136 @@
+config {
+  services {
+    service_name: "echo-api.endpoints.cloudesf-testing.cloud.goog"
+    service_config_id: "test-config-id"
+    producer_project_id: "producer-project"
+    backend_protocol: "http1"
+    min_stream_report_interval_ms: 125754226507776
+    jwt_payload_metadata_name: "200"
+  }
+  requirements {
+    service_name: "echo-api.endpoints.cloudesf-testing.cloud.goog"
+    operation_name: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo"
+    metric_costs {
+      name: "metrics_first"
+      cost: 2
+    }
+  }
+  gcp_attributes {
+    project_id: "test-project-id"
+    zone: "test-zone"
+    platform: "GCE-ESPv2"
+  }
+  imds_token {
+    uri: "http://127.0.0.1:42761/v1/instance/service-accounts/default/token"
+    cluster: "metadata-cluster"
+    timeout {
+      seconds: 281474976710658
+    }
+  }
+  sc_calling_config {
+    network_fail_open {
+    }
+    check_timeout_ms {
+      value: 16383744
+    }
+    check_retries {
+      value: 200
+    }
+    report_retries {
+      value: 200
+    }
+  }
+  service_control_uri {
+    uri: "http://127.0.0.1/v1/services/"
+    cluster: "service-conXrol-cluster"
+    timeout {
+      seconds: 5
+    }
+  }
+}
+downstream_request {
+  headers {
+    headers {
+      key: ":path"
+      value: "/echo?key=test-api-key"
+    }
+    headers {
+      key: ":method"
+      value: "GET"
+    }
+  }
+  data: "Some data to test the metrics such as request_sizes."
+  data: "echo-api.endpoints.cloudesf-testing.cloud.goog"
+}
+upstream_response {
+  headers {
+    headers {
+      key: ":status"
+      value: "200"
+    }
+  }
+  data: "Some data to test the metrics such as response_sizes."
+}
+stream_info {
+  response_code {
+    value: 3368558592
+  }
+  upstream_metadata {
+  }
+}
+sidestream_response {
+  headers {
+    headers {
+      key: ":status"
+      value: "200"
+    }
+  }
+  data: "{ \"access_token\": \"fuzz-access-token\", \"expires_in\": 60000 }"
+}
+sidestream_response {
+  headers {
+    headers {
+      key: ":status"
+      value: "504"
+    }
+  }
+}
+sidestream_response {
+  headers {
+    headers {
+      key: ":status"
+      value: "504"
+    }
+  }
+}
+sidestream_response {
+  headers {
+  }
+  data: "\000\000\000\000\000\000\000\000"
+  data: "2\006\022\004\010\300\304\007"
+}
+sidestream_response {
+  headers {
+    headers {
+      key: "!"
+      value: "504"
+    }
+  }
+}
+sidestream_response {
+  headers {
+    headers {
+      key: ":status"
+      value: "200"
+    }
+  }
+}
+sidestream_response {
+  headers {
+    headers {
+      key: ":status"
+      value: "200"
+    }
+  }
+  data: ""
+}


### PR DESCRIPTION
Bug type: Tech debt

Status code should never be negative. Although this will not occur in practice, we should enforce it via compile time checks. This also prevents overflows when reading the code from `StreamInfo`.

Ref: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=21192
Signed-off-by: Teju Nareddy <nareddyt@google.com>