### PR TITLE
Support strict transport security

### DIFF
--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -177,6 +177,11 @@ environment variable or by passing "-k" flag to this script.
         help=''' Maximum TLS protocol version for client side connection.
         Please refer to https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/auth/cert.proto#common-tls-configuration.
         ''')
+    
+    parser.add_argument('--enable_strict_transport_security', action='store_true',
+        help='''Enable HSTS (HTTP Strict Transport Security). "Strict-Transport-Security" response header
+        with value "max-age=31536000; includeSubdomains;" is added for all responses from local backend.
+        Not valid for remote backends.''')
 
     parser.add_argument('-z', '--healthz', default=None, help='''Define a
         health checking endpoint on the same ports as the application backend.
@@ -649,6 +654,9 @@ def gen_proxy_config(args):
         args.ssl_protocols.sort()
         proxy_conf.extend(["--ssl_minimum_protocol", args.ssl_protocols[0]])
         proxy_conf.extend(["--ssl_maximum_protocol", args.ssl_protocols[-1]])
+
+    if args.enable_strict_transport_security:
+            proxy_conf.append("--enable_strict_transport_security")
 
     if args.service:
         proxy_conf.extend(["--service", args.service])

--- a/src/go/configgenerator/route_generator.go
+++ b/src/go/configgenerator/route_generator.go
@@ -26,6 +26,7 @@ import (
 
 	commonpb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/http/common"
 	v2pb "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	corepb "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	routepb "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
@@ -70,6 +71,17 @@ func MakeRouteConfig(serviceInfo *configinfo.ServiceInfo) (*v2pb.RouteConfigurat
 				},
 			},
 		}
+		if serviceInfo.Options.EnableHSTS {
+			catchAllRt.ResponseHeadersToAdd = []*corepb.HeaderValueOption{
+				{
+					Header: &corepb.HeaderValue{
+						Key:   util.HSTSHeaderKey,
+						Value: util.HSTSHeaderValue,
+					},
+				},
+			}
+		}
+
 		host.Routes = append(host.Routes, catchAllRt)
 
 		jsonStr, _ := util.ProtoToJson(catchAllRt)

--- a/src/go/configgenerator/route_generator.go
+++ b/src/go/configgenerator/route_generator.go
@@ -216,6 +216,16 @@ func makeDynamicRoutingConfig(serviceInfo *configinfo.ServiceInfo) ([]*routepb.R
 					},
 				},
 			}
+			if serviceInfo.Options.EnableHSTS {
+				r.ResponseHeadersToAdd = []*corepb.HeaderValueOption{
+					{
+						Header: &corepb.HeaderValue{
+							Key:   util.HSTSHeaderKey,
+							Value: util.HSTSHeaderValue,
+						},
+					},
+				}
+			}
 			backendRoutes = append(backendRoutes, &r)
 
 			jsonStr, _ := util.ProtoToJson(&r)

--- a/src/go/configgenerator/route_generator_test.go
+++ b/src/go/configgenerator/route_generator_test.go
@@ -27,18 +27,30 @@ import (
 	routepb "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
+	annotationspb "google.golang.org/genproto/googleapis/api/annotations"
+	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
+	apipb "google.golang.org/genproto/protobuf/api"
 )
 
 func TestMakeRouteConfig(t *testing.T) {
 	testData := []struct {
 		desc                          string
 		enableStrictTransportSecurity bool
+		fakeServiceConfig             *confpb.Service
 		wantedError                   string
 		wantRouteConfig               string
 	}{
 		{
 			desc:                          "Enable Strict Transport Security",
 			enableStrictTransportSecurity: true,
+			fakeServiceConfig: &confpb.Service{
+				Name: testProjectName,
+				Apis: []*apipb.Api{
+					{
+						Name: testApiName,
+					},
+				},
+			},
 			wantRouteConfig: `{
                              "name": "local_route",
                              "virtualHosts": [
@@ -61,7 +73,78 @@ func TestMakeRouteConfig(t *testing.T) {
                                                  }
                                              ],
                                              "route": {
-                                                 "cluster": "test-api_local",
+                                                 "cluster": "bookstore.endpoints.project123.cloud.goog_local",
+                                                 "timeout": "15s"
+                                             }
+                                         }
+                                     ]
+                                 }
+                             ]
+                       }`,
+		},
+		{
+			desc:                          "Enable Strict Transport Security for remote backend",
+			enableStrictTransportSecurity: true,
+			fakeServiceConfig: &confpb.Service{
+				Name: testProjectName,
+				Apis: []*apipb.Api{
+					{
+						Name: testApiName,
+					},
+				},
+				Backend: &confpb.Backend{
+					Rules: []*confpb.BackendRule{
+						{
+							Selector:        "endpoints.examples.bookstore.Bookstore.Foo",
+							Address:         "https://testapipb.com/foo",
+							PathTranslation: confpb.BackendRule_CONSTANT_ADDRESS,
+							Authentication: &confpb.BackendRule_JwtAudience{
+								JwtAudience: "bar.com",
+							},
+						},
+					},
+				},
+				Http: &annotationspb.Http{
+					Rules: []*annotationspb.HttpRule{
+						{
+							Selector: "endpoints.examples.bookstore.Bookstore.Foo",
+							Pattern: &annotationspb.HttpRule_Get{
+								Get: "foo",
+							},
+						},
+					},
+				},
+			},
+			wantRouteConfig: `{
+                             "name": "local_route",
+                             "virtualHosts": [
+                                 {
+                                     "domains": [
+                                         "*"
+                                     ],
+                                     "name": "backend",
+                                     "routes": [
+                                         {
+                                             "match": {
+                                                 "headers": [
+                                                     {
+                                                         "exactMatch": "GET",
+                                                         "name": ":method"
+                                                     }
+                                                 ],
+                                                 "path": "foo"
+                                             },
+                                             "responseHeadersToAdd": [
+                                                 {
+                                                     "header": {
+                                                         "key": "Strict-Transport-Security",
+                                                         "value": "max-age=31536000; includeSubdomains"
+                                                     }
+                                                 }
+                                             ],
+                                             "route": {
+                                                 "cluster": "testapipb.com:443",
+                                                 "hostRewrite": "testapipb.com",
                                                  "timeout": "15s"
                                              }
                                          }
@@ -75,11 +158,12 @@ func TestMakeRouteConfig(t *testing.T) {
 	for i, tc := range testData {
 		opts := options.DefaultConfigGeneratorOptions()
 		opts.EnableHSTS = tc.enableStrictTransportSecurity
+		fakeServiceInfo, err := configinfo.NewServiceInfoFromServiceConfig(tc.fakeServiceConfig, testConfigID, opts)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-		gotRoute, err := MakeRouteConfig(&configinfo.ServiceInfo{
-			Name:    "test-api",
-			Options: opts,
-		})
+		gotRoute, err := MakeRouteConfig(fakeServiceInfo)
 		if tc.wantedError != "" {
 			if err == nil || !strings.Contains(err.Error(), tc.wantedError) {
 				t.Errorf("Test (%s): expected err: %v, got: %v", tc.desc, tc.wantedError, err)

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -58,6 +58,7 @@ var (
 	SslMinimumProtocol = flag.String("ssl_minimum_protocol", "", "Minimum TLS protocol version for Downstream connections.")
 	SslMaximumProtocol = flag.String("ssl_maximum_protocol", "", "Maximum TLS protocol version for Downstream connections.")
 	RootCertsPath      = flag.String("root_certs_path", util.DefaultRootCAPaths, "Path to the root certificates to make TLS connection.")
+	EnableHSTS         = flag.Bool("enable_strict_transport_security", false, "Enable HSTS (HTTP Strict Transport Security).")
 
 	// Flags for non_gcp deployment.
 	ServiceAccountKey = flag.String("service_account_key", "", `Use the service account key JSON file to access the service control and the
@@ -126,6 +127,7 @@ func EnvoyConfigOptionsFromFlags() options.ConfigGeneratorOptions {
 		SslClientCertPath:                     *SslClientCertPath,
 		SslMinimumProtocol:                    *SslMinimumProtocol,
 		SslMaximumProtocol:                    *SslMaximumProtocol,
+		EnableHSTS:                            *EnableHSTS,
 		ServiceAccountKey:                     *ServiceAccountKey,
 		SkipJwtAuthnFilter:                    *SkipJwtAuthnFilter,
 		SkipServiceControlFilter:              *SkipServiceControlFilter,

--- a/src/go/options/configgenerator.go
+++ b/src/go/options/configgenerator.go
@@ -52,6 +52,7 @@ type ConfigGeneratorOptions struct {
 	SslClientCertPath    string
 	SslMinimumProtocol   string
 	SslMaximumProtocol   string
+	EnableHSTS           bool
 	RootCertsPath        string
 
 	// Flags for non_gcp deployment.

--- a/src/go/util/util.go
+++ b/src/go/util/util.go
@@ -121,6 +121,10 @@ const (
 	// Default api key locations
 	DefaultApiKeyQueryParamKey    = "key"
 	DefaultApiKeyQueryParamApiKey = "api_key"
+
+	// Strict Transport Security header key and value
+	HSTSHeaderKey   = "Strict-Transport-Security"
+	HSTSHeaderValue = "max-age=31536000; includeSubdomains"
 )
 
 type BackendProtocol int32

--- a/tests/endpoints/echo/client/client.go
+++ b/tests/endpoints/echo/client/client.go
@@ -208,11 +208,11 @@ func DoCorsPreflightRequest(url, origin, requestMethod, requestHeader, referer s
 }
 
 // DoHttpsGet performs a HTTPS Get request to a specified url
-func DoHttpsGet(url string, httpVersion int, certPath string) ([]byte, error) {
+func DoHttpsGet(url string, httpVersion int, certPath string) (http.Header, []byte, error) {
 	client := &http.Client{}
 	caCert, err := ioutil.ReadFile(certPath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM(caCert)
@@ -235,15 +235,15 @@ func DoHttpsGet(url string, httpVersion int, certPath string) ([]byte, error) {
 
 	resp, err := client.Get(url)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("http response status is not 200 OK: %s, %s", resp.Status, string(body))
+		return nil, nil, fmt.Errorf("http response status is not 200 OK: %s, %s", resp.Status, string(body))
 	}
-	return body, err
+	return resp.Header, body, err
 }

--- a/tests/integration_test/transport_security_test.go
+++ b/tests/integration_test/transport_security_test.go
@@ -247,12 +247,14 @@ func TestHSTS(t *testing.T) {
 			httpsVersion:   1,
 			certPath:       platform.GetFilePath(platform.ServerCert),
 			wantHSTSHeader: "max-age=31536000; includeSubdomains",
+			wantResp:       `simple get message`,
 		},
 		{
 			desc:           "Succcess for HTTP2 client with HSTS",
 			httpsVersion:   2,
 			certPath:       platform.GetFilePath(platform.ServerCert),
 			wantHSTSHeader: "max-age=31536000; includeSubdomains",
+			wantResp:       `simple get message`,
 		},
 	}
 

--- a/tests/start_proxy/start_proxy_test.py
+++ b/tests/start_proxy/start_proxy_test.py
@@ -91,14 +91,14 @@ class TestStartProxy(unittest.TestCase):
               '--backend_dns_lookup_family', 'v4only'
               ]),
             # Default backend
-            (['-R=managed',
+            (['-R=managed','--enable_strict_transport_security',
               '--http_port=8079', '--service_control_quota_retries=3',
               '--service_control_report_timeout_ms=300',
               '--service_control_network_fail_open', '--check_metadata',
               '--disable_tracing'],
              ['bin/configmanager', '--logtostderr','--backend_address', 'http://127.0.0.1:8082',
               '--rollout_strategy', 'managed', '--v', '0',
-              '--listener_port', '8079',
+              '--listener_port', '8079', '--enable_strict_transport_security',
               '--service_control_quota_retries', '3',
               '--service_control_report_timeout_ms', '300',
               '--check_metadata',


### PR DESCRIPTION
1.  when --enbale_strict_transport_security is enabled, add strict_transport_security in response header.  
