### PR TITLE
Align `--disable_cloud_trace_auto_sampling` with ESPv1

### DIFF
--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -63,14 +63,17 @@ def gen_bootstrap_conf(args):
     else:
         if args.tracing_project_id:
             cmd.extend(["--tracing_project_id", args.tracing_project_id])
-        if args.tracing_sample_rate:
-            cmd.extend(["--tracing_sample_rate", str(args.tracing_sample_rate)])
         if args.tracing_incoming_context:
             cmd.extend(
                 ["--tracing_incoming_context", args.tracing_incoming_context])
         if args.tracing_outgoing_context:
             cmd.extend(
                 ["--tracing_outgoing_context", args.tracing_outgoing_context])
+
+        if args.disable_cloud_trace_auto_sampling:
+            cmd.extend(["--tracing_sample_rate", "0"])
+        elif args.tracing_sample_rate:
+            cmd.extend(["--tracing_sample_rate", str(args.tracing_sample_rate)])
 
     if args.http_request_timeout_s:
         cmd.extend(
@@ -402,7 +405,18 @@ environment variable or by passing "-k" flag to this script.
     parser.add_argument(
         '--tracing_sample_rate',
         default=0.001,
-        help="tracing sampling rate from 0.0 to 1.0")
+        help='''
+        Tracing sampling rate from 0.0 to 1.0.
+        By default, 1 out of 1000 requests are sampled.
+        Cloud trace can still be enabled from request HTTP headers with
+        trace context regardless this flag value.
+        '''
+    )
+    parser.add_argument(
+        '--disable_cloud_trace_auto_sampling',
+        action='store_true',
+        default=False,
+        help="An alias to override --tracing_sample_rate to 0")
     parser.add_argument(
         '--tracing_incoming_context',
         default="",

--- a/tests/start_proxy/start_proxy_test.py
+++ b/tests/start_proxy/start_proxy_test.py
@@ -19,7 +19,7 @@ import os, inspect
 
 currentdir = os.path.dirname(
     os.path.abspath(inspect.getfile(inspect.currentframe())))
-sys.path.append(currentdir + "/../../docker/generic")
+sys.path.insert(0, currentdir + "/../../docker/generic")
 from start_proxy import gen_bootstrap_conf, make_argparser, gen_proxy_config, gen_envoy_args
 
 
@@ -52,10 +52,18 @@ class TestStartProxy(unittest.TestCase):
              ['bin/bootstrap',
               '--logtostderr', '--admin_port', '8001',
               '--tracing_project_id',
-              '123',
-              '--tracing_sample_rate', '1', '--tracing_incoming_context',
+              '123', '--tracing_incoming_context',
               'fake-incoming-context', '--tracing_outgoing_context',
-              'fake-outgoing-context', '/tmp/bootstrap.json'])
+              'fake-outgoing-context',
+              '--tracing_sample_rate', '1',
+              '/tmp/bootstrap.json']),
+            # --disable_cloud_trace_auto_sampling overrides --tracing_sample_rate
+            (['--disable_cloud_trace_auto_sampling',
+              '--tracing_sample_rate=0.5'],
+             ['bin/bootstrap',
+              '--logtostderr', '--admin_port', '0',
+              '--tracing_sample_rate', '0',
+              '/tmp/bootstrap.json']),
         ]
 
         for flags, wantedArgs in testcases:


### PR DESCRIPTION
Note that ESPv1 does not have `--tracing_sample_rate`, but ESPv2 does.
So when `--disable_cloud_trace_auto_sampling`, just override the
tracing sample rate to 0.

Signed-off-by: Teju Nareddy <nareddyt@google.com>