### PR TITLE
b/151344434:  Suppress envoy debug headers when `--enable_debug=false`

### DIFF
--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -464,7 +464,7 @@ environment variable or by passing "-k" flag to this script.
         Enables a variety of debug features in both Config Manager and Envoy, such as:
         - Debug level per-request application logs in Envoy
         - Debug level service configuration logs in Config Manager
-        - Admin interface in Envoy
+        - Debug HTTP response headers
         ''')
 
     # Start Deprecated Flags Section
@@ -806,6 +806,10 @@ def gen_proxy_config(args):
         proxy_conf.extend(["--service_account_key", args.service_account_key])
     if args.non_gcp:
         proxy_conf.append("--non_gcp")
+
+    if args.enable_debug:
+        proxy_conf.append("--suppress_envoy_headers=false")
+
     return proxy_conf
 
 def gen_envoy_args(args):

--- a/examples/auth/envoy_config.json
+++ b/examples/auth/envoy_config.json
@@ -169,7 +169,8 @@
                     {
                       "name": "envoy.router",
                       "typedConfig": {
-                        "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                        "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router",
+                        "suppressEnvoyHeaders": true
                       }
                     }
                   ],

--- a/examples/dynamic_routing/envoy_config.json
+++ b/examples/dynamic_routing/envoy_config.json
@@ -274,7 +274,8 @@
                                         {
                                             "name": "envoy.router",
                                             "typedConfig": {
-                                                "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                                                "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router",
+                                                "suppressEnvoyHeaders": true
                                             }
                                         }
                                     ],

--- a/examples/grpc_dynamic_routing/envoy_config.json
+++ b/examples/grpc_dynamic_routing/envoy_config.json
@@ -1113,7 +1113,8 @@
                                         {
                                             "name": "envoy.router",
                                             "typedConfig": {
-                                                "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                                                "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router",
+                                                "suppressEnvoyHeaders": true
                                             }
                                         }
                                     ],

--- a/examples/service_control/envoy_config.json
+++ b/examples/service_control/envoy_config.json
@@ -673,7 +673,8 @@
                     {
                       "name": "envoy.router",
                       "typedConfig": {
-                        "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                        "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router",
+                        "suppressEnvoyHeaders": true
                       }
                     }
                   ],

--- a/src/go/bootstrap/static/testdata/path_matcher/envoy_config.json
+++ b/src/go/bootstrap/static/testdata/path_matcher/envoy_config.json
@@ -129,7 +129,8 @@
                     {
                       "name": "envoy.router",
                       "typedConfig": {
-                        "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                        "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router",
+                        "suppressEnvoyHeaders": true
                       }
                     }
                   ],

--- a/src/go/configgenerator/listener_generator_test.go
+++ b/src/go/configgenerator/listener_generator_test.go
@@ -1450,7 +1450,8 @@ func TestMakeListeners(t *testing.T) {
 												"name":"envoy.router",
 												"typedConfig":{
 													"@type":"type.googleapis.com/envoy.config.filter.http.router.v2.Router",
-													"startChildSpan":true
+													"startChildSpan":true,
+													"suppressEnvoyHeaders":true
 												}
 											}
 										],

--- a/src/go/configmanager/config_manager_test.go
+++ b/src/go/configmanager/config_manager_test.go
@@ -69,6 +69,7 @@ func TestFetchListeners(t *testing.T) {
 	testData := []struct {
 		desc              string
 		enableTracing     bool
+		enableDebug       bool
 		BackendAddress    string
 		fakeServiceConfig string
 		wantedListeners   string
@@ -165,7 +166,8 @@ func TestFetchListeners(t *testing.T) {
                      {
                         "name":"envoy.router",
                         "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                           "@type":"type.googleapis.com/envoy.config.filter.http.router.v2.Router",
+                       		 "suppressEnvoyHeaders": true
                         }
                      }
                   ],
@@ -341,7 +343,8 @@ func TestFetchListeners(t *testing.T) {
                      {
                         "name":"envoy.router",
                         "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                           "@type":"type.googleapis.com/envoy.config.filter.http.router.v2.Router",
+                       		 "suppressEnvoyHeaders": true
                         }
                      }
                   ],
@@ -550,7 +553,8 @@ func TestFetchListeners(t *testing.T) {
                      {
                         "name":"envoy.router",
                         "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                           "@type":"type.googleapis.com/envoy.config.filter.http.router.v2.Router",
+                       		 "suppressEnvoyHeaders": true
                         }
                      }
                   ],
@@ -795,7 +799,8 @@ func TestFetchListeners(t *testing.T) {
                      {
                         "name":"envoy.router",
                         "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                           "@type":"type.googleapis.com/envoy.config.filter.http.router.v2.Router",
+                       		 "suppressEnvoyHeaders": true
                         }
                      }
                   ],
@@ -1016,7 +1021,8 @@ func TestFetchListeners(t *testing.T) {
                      {
                         "name":"envoy.router",
                         "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                           "@type":"type.googleapis.com/envoy.config.filter.http.router.v2.Router",
+                       		 "suppressEnvoyHeaders": true
                         }
                      }
                   ],
@@ -1201,7 +1207,8 @@ func TestFetchListeners(t *testing.T) {
                      {
                         "name":"envoy.router",
                         "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                           "@type":"type.googleapis.com/envoy.config.filter.http.router.v2.Router",
+                       		 "suppressEnvoyHeaders": true
                         }
                      }
                   ],
@@ -1238,8 +1245,9 @@ func TestFetchListeners(t *testing.T) {
 }`, testBackendClusterName),
 		},
 		{
-			desc:           "Success for backend that allow CORS, with tracing enabled",
+			desc:           "Success for backend that allow CORS, with tracing and debug enabled",
 			enableTracing:  true,
+			enableDebug:    true,
 			BackendAddress: "http://127.0.0.1:80",
 			fakeServiceConfig: fmt.Sprintf(`{
                 "name":"%s",
@@ -1415,6 +1423,7 @@ func TestFetchListeners(t *testing.T) {
 		opts := options.DefaultConfigGeneratorOptions()
 		opts.BackendAddress = tc.BackendAddress
 		opts.DisableTracing = !tc.enableTracing
+		opts.SuppressEnvoyHeaders = !tc.enableDebug
 
 		flag.Set("service", testProjectName)
 		flag.Set("service_config_id", testConfigID)

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -77,7 +77,7 @@ var (
 	foo,bar,endpoint log will have response_headers: foo=foo_value;bar=bar_value if values are available.`)
 	MinStreamReportIntervalMs = flag.Uint64("min_stream_report_interval_ms", 0, `Minimum amount of time (milliseconds) between sending intermediate reports on a stream and the default is 10000 if not set.`)
 
-	SuppressEnvoyHeaders = flag.Bool("suppress_envoy_headers", false, `Do not add any additional x-envoy- headers to requests or responses. This only affects the router filter
+	SuppressEnvoyHeaders = flag.Bool("suppress_envoy_headers", true, `Do not add any additional x-envoy- headers to requests or responses. This only affects the router filter
 	generated *x-envoy-* headers, other Envoy filters and the HTTP connection manager may continue to set x-envoy- headers.`)
 
 	ServiceControlNetworkFailOpen = flag.Bool("service_control_network_fail_open", true, ` In case of network failures when connecting to Google service control,

--- a/src/go/configmanager/testdata/fake_data_for_dynamic_routing.go
+++ b/src/go/configmanager/testdata/fake_data_for_dynamic_routing.go
@@ -356,7 +356,8 @@ var (
                      {
                         "name":"envoy.router",
                         "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.config.filter.http.router.v2.Router"
+                           "@type":"type.googleapis.com/envoy.config.filter.http.router.v2.Router",
+                           "suppressEnvoyHeaders": true
                         }
                      }
                   ],

--- a/src/go/options/configgenerator.go
+++ b/src/go/options/configgenerator.go
@@ -109,6 +109,7 @@ func DefaultConfigGeneratorOptions() ConfigGeneratorOptions {
 		ListenerAddress:               "0.0.0.0",
 		ListenerPort:                  8080,
 		RootCertsPath:                 util.DefaultRootCAPaths,
+		SuppressEnvoyHeaders:          true,
 		ServiceControlNetworkFailOpen: true,
 		ServiceManagementURL:          "https://servicemanagement.googleapis.com",
 		ScCheckRetries:                -1,

--- a/tests/start_proxy/start_proxy_test.py
+++ b/tests/start_proxy/start_proxy_test.py
@@ -284,6 +284,18 @@ class TestStartProxy(unittest.TestCase):
               '--service', 'test_bookstore.gloud.run',
               '--transcoding_ignore_unknown_query_parameters'
               ]),
+            # --enable_debug
+            (['--service=test_bookstore.gloud.run',
+              '--backend=grpc://127.0.0.1:8000',
+              '--enable_debug',
+              ],
+             ['bin/configmanager', '--logtostderr',
+              '--backend_address', 'grpc://127.0.0.1:8000',
+              '--rollout_strategy', 'fixed',
+              '--v', '1',
+              '--service', 'test_bookstore.gloud.run',
+              '--suppress_envoy_headers=false'
+              ]),
         ]
 
         for flags, wantedArgs in testcases:


### PR DESCRIPTION
Option in config manager already exists, just set it appropriately via `start_proxy.py`. By default, suppress debug headers.

Testing done:
- Adjust tests to align with default option.
- Add unit tests for enable debug.

Signed-off-by: Teju Nareddy <nareddyt@google.com>