### PR TITLE
Use `EMPTY_STRING` envoy constant

### DIFF
--- a/api/envoy/http/service_control/requirement.proto
+++ b/api/envoy/http/service_control/requirement.proto
@@ -46,9 +46,8 @@ message ApiKeyLocation {
     //     GET /something HTTP/1.1
     //     X-API-Key: abcdef12345
     //
-    string header = 2 [(validate.rules).string = {
-      well_known_regex: HTTP_HEADER_NAME
-    }];
+    string header = 2
+        [(validate.rules).string = { well_known_regex: HTTP_HEADER_NAME }];
 
     // API key is sent in a
     // [cookie](https://swagger.io/docs/specification/authentication/cookie-authentication),
@@ -59,9 +58,8 @@ message ApiKeyLocation {
     //     GET /something HTTP/1.1
     //     Cookie: API-KEY=abcdef12345
     //
-    string cookie = 3 [(validate.rules).string = {
-      well_known_regex: HTTP_HEADER_VALUE
-    }];
+    string cookie = 3
+        [(validate.rules).string = { well_known_regex: HTTP_HEADER_VALUE }];
   }
 }
 

--- a/src/envoy/http/backend_auth/BUILD
+++ b/src/envoy/http/backend_auth/BUILD
@@ -81,6 +81,9 @@ envoy_cc_library(
     name = "config_parser_interface",
     hdrs = ["config_parser.h"],
     repository = "@envoy",
+    deps = [
+        "@envoy//source/common/common:empty_string",
+    ],
 )
 
 envoy_cc_library(
@@ -103,6 +106,7 @@ envoy_cc_test(
     deps = [
         ":filter_lib",
         ":mocks_lib",
+        "@envoy//source/common/common:empty_string",
         "@envoy//test/mocks/http:http_mocks",
         "@envoy//test/mocks/server:server_mocks",
         "@envoy//test/test_common:utility_lib",

--- a/src/envoy/http/backend_auth/config_parser_impl.h
+++ b/src/envoy/http/backend_auth/config_parser_impl.h
@@ -18,6 +18,7 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/strings/str_cat.h"
 #include "api/envoy/http/backend_auth/config.pb.h"
+#include "common/common/empty_string.h"
 #include "envoy/thread_local/thread_local.h"
 #include "src/envoy/http/backend_auth/config_parser.h"
 #include "src/envoy/token/token_subscriber_factory_impl.h"
@@ -66,10 +67,9 @@ class FilterConfigParserImpl
       const Token::TokenSubscriberFactory& token_subscriber_factory);
 
   absl::string_view getAudience(absl::string_view operation) const override {
-    static const std::string empty = "";
     auto operation_it = operation_map_.find(operation);
     if (operation_it == operation_map_.end()) {
-      return empty;
+      return EMPTY_STRING;
     }
     return operation_it->second;
   }

--- a/src/envoy/http/backend_auth/filter_test.cc
+++ b/src/envoy/http/backend_auth/filter_test.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "src/envoy/http/backend_auth/filter.h"
+
+#include "common/common/empty_string.h"
 #include "envoy/http/header_map.h"
 #include "gmock/gmock.h"
 #include "google/protobuf/text_format.h"
@@ -22,6 +24,7 @@
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/server/mocks.h"
 #include "test/test_common/utility.h"
+
 using ::testing::_;
 namespace Envoy {
 namespace Extensions {
@@ -114,7 +117,7 @@ TEST_F(BackendAuthFilterTest, SucceedAppendToken) {
       *mock_decoder_callbacks_.stream_info_.filter_state_, Utils::kOperation,
       "operation-with-audience");
   testing::NiceMock<Stats::MockStore> scope;
-  const std::string prefix = "";
+  const std::string prefix = EMPTY_STRING;
   FilterStats filter_stats{
       ALL_BACKEND_AUTH_FILTER_STATS(POOL_COUNTER_PREFIX(scope, prefix))};
 

--- a/src/envoy/http/backend_routing/BUILD
+++ b/src/envoy/http/backend_routing/BUILD
@@ -50,6 +50,7 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         ":filter_lib",
+        "@envoy//source/common/common:empty_string",
         "@envoy//test/mocks/http:http_mocks",
         "@envoy//test/mocks/server:server_mocks",
         "@envoy//test/test_common:utility_lib",

--- a/src/envoy/http/backend_routing/filter_test.cc
+++ b/src/envoy/http/backend_routing/filter_test.cc
@@ -12,16 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "src/envoy/http/backend_routing/filter.h"
+
+#include "common/common/empty_string.h"
 #include "envoy/http/header_map.h"
 #include "gmock/gmock.h"
 #include "google/protobuf/text_format.h"
 #include "gtest/gtest.h"
+#include "src/envoy/utils/filter_state_utils.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/server/mocks.h"
 #include "test/test_common/utility.h"
-
-#include "src/envoy/http/backend_routing/filter.h"
-#include "src/envoy/utils/filter_state_utils.h"
 
 using ::testing::_;
 using ::testing::Invoke;
@@ -165,7 +166,7 @@ TEST_F(BackendRoutingFilterTest, ConstantAddressWithBadPrefix) {
   // URL here. This is problematic in practice, since it doesn't have a '/'.
   // Config manager will ensure that this configuration is never passed to
   // Envoy.
-  ASSERT_EQ(headers.Path()->value().getStringView(), "");
+  ASSERT_EQ(headers.Path()->value().getStringView(), EMPTY_STRING);
   ASSERT_EQ(status, Envoy::Http::FilterHeadersStatus::Continue);
 }
 

--- a/src/envoy/http/path_matcher/BUILD
+++ b/src/envoy/http/path_matcher/BUILD
@@ -48,6 +48,7 @@ envoy_cc_library(
         "//api/envoy/http/path_matcher:config_proto_cc_proto",
         "//src/api_proxy/path_matcher:path_matcher_lib",
         "//src/api_proxy/path_matcher:variable_binding_utils_lib",
+        "@envoy//source/common/common:empty_string",
         "@envoy//source/exe:envoy_common_lib",
     ],
 )
@@ -61,6 +62,7 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         ":filter_config_lib",
+        "@envoy//source/common/common:empty_string",
         "@envoy//test/mocks/server:server_mocks",
         "@envoy//test/test_common:utility_lib",
     ],
@@ -75,6 +77,7 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         ":filter_lib",
+        "@envoy//source/common/common:empty_string",
         "@envoy//test/mocks/server:server_mocks",
         "@envoy//test/test_common:utility_lib",
     ],

--- a/src/envoy/http/path_matcher/filter_config.cc
+++ b/src/envoy/http/path_matcher/filter_config.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "src/envoy/http/path_matcher/filter_config.h"
+#include "common/common/empty_string.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -29,7 +30,7 @@ FilterConfig::FilterConfig(
   for (const auto& rule : proto_config_.rules()) {
     if (!pmb.Register(rule.pattern().http_method(),
                       rule.pattern().uri_template(),
-                      /*body_field_path=*/"", &rule.operation())) {
+                      /*body_field_path=*/EMPTY_STRING, &rule.operation())) {
       throw ProtoValidationException("Duplicated pattern", rule.pattern());
     }
     if (rule.extract_path_parameters()) {

--- a/src/envoy/http/path_matcher/filter_config_test.cc
+++ b/src/envoy/http/path_matcher/filter_config_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "src/envoy/http/path_matcher/filter_config.h"
+#include "common/common/empty_string.h"
 #include "test/mocks/server/mocks.h"
 #include "test/test_common/utility.h"
 
@@ -34,7 +35,7 @@ typedef std::vector<std::string> FieldPath;
 TEST(FilterConfigTest, EmptyConfig) {
   ::google::api::envoy::http::path_matcher::FilterConfig config_pb;
   ::testing::NiceMock<Server::Configuration::MockFactoryContext> mock_factory;
-  FilterConfig cfg(config_pb, "", mock_factory);
+  FilterConfig cfg(config_pb, EMPTY_STRING, mock_factory);
 
   EXPECT_TRUE(cfg.findOperation("GET", "/foo") == nullptr);
   EXPECT_TRUE(cfg.getSnakeToJsonMap().empty());
@@ -61,7 +62,7 @@ rules {
   ::google::api::envoy::http::path_matcher::FilterConfig config_pb;
   ASSERT_TRUE(TextFormat::ParseFromString(kFilterConfigBasic, &config_pb));
   ::testing::NiceMock<Server::Configuration::MockFactoryContext> mock_factory;
-  FilterConfig cfg(config_pb, "", mock_factory);
+  FilterConfig cfg(config_pb, EMPTY_STRING, mock_factory);
 
   EXPECT_EQ("1.cloudesf_testing_cloud_goog.Bar",
             *cfg.findOperation("GET", "/bar"));
@@ -92,7 +93,7 @@ rules {
   ::google::api::envoy::http::path_matcher::FilterConfig config_pb;
   ASSERT_TRUE(TextFormat::ParseFromString(kFilterConfigBasic, &config_pb));
   ::testing::NiceMock<Server::Configuration::MockFactoryContext> mock_factory;
-  FilterConfig cfg(config_pb, "", mock_factory);
+  FilterConfig cfg(config_pb, EMPTY_STRING, mock_factory);
 
   VariableBindings bindings;
   EXPECT_EQ("1.cloudesf_testing_cloud_goog.Foo",
@@ -125,7 +126,7 @@ segment_names {
   ::google::api::envoy::http::path_matcher::FilterConfig config_pb;
   ASSERT_TRUE(TextFormat::ParseFromString(kFilterConfig, &config_pb));
   ::testing::NiceMock<Server::Configuration::MockFactoryContext> mock_factory;
-  FilterConfig cfg(config_pb, "", mock_factory);
+  FilterConfig cfg(config_pb, EMPTY_STRING, mock_factory);
 
   absl::flat_hash_map<std::string, std::string> expected = {
       {"foo_bar", "fooBar"}, {"x_y_z", "xYZ"}};
@@ -153,8 +154,9 @@ rules {
   ASSERT_TRUE(TextFormat::ParseFromString(kFilterConfig, &config_pb));
   ::testing::NiceMock<Server::Configuration::MockFactoryContext> mock_factory;
 
-  EXPECT_THROW_WITH_REGEX(FilterConfig cfg(config_pb, "", mock_factory),
-                          ProtoValidationException, "Duplicated pattern");
+  EXPECT_THROW_WITH_REGEX(
+      FilterConfig cfg(config_pb, EMPTY_STRING, mock_factory),
+      ProtoValidationException, "Duplicated pattern");
 }
 
 }  // namespace

--- a/src/envoy/http/path_matcher/filter_test.cc
+++ b/src/envoy/http/path_matcher/filter_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "src/envoy/http/path_matcher/filter.h"
+#include "common/common/empty_string.h"
 #include "src/envoy/utils/filter_state_utils.h"
 #include "test/mocks/server/mocks.h"
 #include "test/test_common/utility.h"
@@ -57,8 +58,8 @@ class PathMatcherFilterTest : public ::testing::Test {
   void SetUp() override {
     ::google::api::envoy::http::path_matcher::FilterConfig config_pb;
     ASSERT_TRUE(TextFormat::ParseFromString(kFilterConfig, &config_pb));
-    config_ =
-        std::make_shared<FilterConfig>(config_pb, "", mock_factory_context_);
+    config_ = std::make_shared<FilterConfig>(config_pb, EMPTY_STRING,
+                                             mock_factory_context_);
 
     filter_ = std::make_unique<Filter>(config_);
     filter_->setDecoderFilterCallbacks(mock_cb_);
@@ -81,7 +82,7 @@ TEST_F(PathMatcherFilterTest, DecodeHeadersWithOperation) {
             "1.cloudesf_testing_cloud_goog.Bar");
   EXPECT_EQ(Utils::getStringFilterState(*mock_cb_.stream_info_.filter_state_,
                                         Utils::kQueryParams),
-            "");
+            EMPTY_STRING);
 
   EXPECT_EQ(1L, TestUtility::findCounter(mock_factory_context_.scope_,
                                          "path_matcher.allowed")
@@ -90,7 +91,7 @@ TEST_F(PathMatcherFilterTest, DecodeHeadersWithOperation) {
                                          "path_matcher.denied")
                     ->value());
 
-  Buffer::OwnedImpl data("");
+  Buffer::OwnedImpl data(EMPTY_STRING);
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
 
   Http::TestRequestTrailerMapImpl trailers;
@@ -155,7 +156,7 @@ TEST_F(PathMatcherFilterTest, DecodeHeadersNoMatch) {
 
   EXPECT_EQ(Utils::getStringFilterState(*mock_cb_.stream_info_.filter_state_,
                                         Utils::kOperation),
-            "");
+            EMPTY_STRING);
 
   EXPECT_EQ(0L, TestUtility::findCounter(mock_factory_context_.scope_,
                                          "path_matcher.allowed")

--- a/src/envoy/http/service_control/BUILD
+++ b/src/envoy/http/service_control/BUILD
@@ -62,6 +62,7 @@ envoy_cc_library(
         "//api/envoy/http/common:base_proto_cc_proto",
         "@envoy//include/envoy/event:deferred_deletable",
         "@envoy//include/envoy/upstream:cluster_manager_interface",
+        "@envoy//source/common/common:empty_string",
         "@envoy//source/common/common:enum_to_int",
         "@envoy//source/common/http:headers_lib",
         "@envoy//source/common/http:message_lib",
@@ -218,6 +219,7 @@ envoy_cc_test(
     deps = [
         ":filter_lib",
         ":mocks_lib",
+        "@envoy//source/common/common:empty_string",
         "@envoy//test/mocks/server:server_mocks",
         "@envoy//test/mocks/stats:stats_mocks",
         "@envoy//test/mocks/tracing:tracing_mocks",
@@ -237,6 +239,7 @@ envoy_cc_test(
         ":config_parser_lib",
         ":handler_impl_lib",
         ":mocks_lib",
+        "@envoy//source/common/common:empty_string",
         "@envoy//test/mocks/server:server_mocks",
         "@envoy//test/mocks/stats:stats_mocks",
         "@envoy//test/mocks/tracing:tracing_mocks",

--- a/src/envoy/http/service_control/filter_test.cc
+++ b/src/envoy/http/service_control/filter_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "common/common/empty_string.h"
 #include "envoy/http/header_map.h"
 #include "gmock/gmock.h"
 #include "google/protobuf/text_format.h"
@@ -44,7 +45,7 @@ const Status kBadStatus(Code::UNAUTHENTICATED, "test");
 
 class ServiceControlFilterTest : public ::testing::Test {
  protected:
-  ServiceControlFilterTest() : stats_base_("", mock_stats_scope_) {}
+  ServiceControlFilterTest() : stats_base_(EMPTY_STRING, mock_stats_scope_) {}
 
   void SetUp() override {
     filter_ = std::make_unique<ServiceControlFilter>(stats_base_.stats(),

--- a/src/envoy/http/service_control/handler_impl_test.cc
+++ b/src/envoy/http/service_control/handler_impl_test.cc
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "common/common/empty_string.h"
 #include "envoy/http/header_map.h"
 #include "extensions/filters/http/grpc_stats/grpc_stats_filter.h"
 #include "gmock/gmock.h"
@@ -215,7 +216,7 @@ class HandlerTest : public ::testing::Test {
     return false;                                                \
   }
 
-MATCHER_P(MatchesCheckInfo, expect, "") {
+MATCHER_P(MatchesCheckInfo, expect, EMPTY_STRING) {
   // These must match. If not provided in expect, arg should be empty too
   MATCH(api_key);
   MATCH(ios_bundle_id);
@@ -232,7 +233,7 @@ MATCHER_P(MatchesCheckInfo, expect, "") {
   return true;
 }
 
-MATCHER_P(MatchesQuotaInfo, expect, "") {
+MATCHER_P(MatchesQuotaInfo, expect, EMPTY_STRING) {
   MATCH(method_name);
   //  if (arg.metric_cost_vector != expect.metric_cost_vector) return false;
   MATCH(metric_cost_vector);
@@ -263,7 +264,7 @@ MATCHER_P(MatchesQuotaInfo, expect, "") {
   MATCH(streaming_durations);
 
 MATCHER_P4(MatchesReportInfo, expect, request_headers, response_headers,
-           response_trailers, "") {
+           response_trailers, EMPTY_STRING) {
   std::string operation_name =
       (expect.operation_name.empty() ? "get_header_key"
                                      : expect.operation_name);
@@ -283,7 +284,7 @@ MATCHER_P4(MatchesReportInfo, expect, request_headers, response_headers,
   return true;
 }
 
-MATCHER_P(MatchesSimpleReportInfo, expect, "") {
+MATCHER_P(MatchesSimpleReportInfo, expect, EMPTY_STRING) {
   std::string operation_name =
       (expect.operation_name.empty() ? "get_header_key"
                                      : expect.operation_name);
@@ -291,7 +292,7 @@ MATCHER_P(MatchesSimpleReportInfo, expect, "") {
   return true;
 }
 
-MATCHER_P(MatchesDataReportInfo, expect, "") {
+MATCHER_P(MatchesDataReportInfo, expect, EMPTY_STRING) {
   std::string operation_name =
       (expect.operation_name.empty() ? "get_header_key"
                                      : expect.operation_name);
@@ -321,8 +322,8 @@ TEST_F(HandlerTest, HandlerNoOperationFound) {
 
   ReportRequestInfo expected_report_info;
   initExpectedReportInfo(expected_report_info);
-  expected_report_info.api_name = "";
-  expected_report_info.api_version = "";
+  expected_report_info.api_name = EMPTY_STRING;
+  expected_report_info.api_version = EMPTY_STRING;
   expected_report_info.status = Status::OK;
   expected_report_info.operation_name = "<Unknown Operation Name>";
 
@@ -347,12 +348,12 @@ TEST_F(HandlerTest, HandlerMissingHeaders) {
 
   ReportRequestInfo expected_report_info;
   initExpectedReportInfo(expected_report_info);
-  expected_report_info.api_name = "";
-  expected_report_info.api_version = "";
+  expected_report_info.api_name = EMPTY_STRING;
+  expected_report_info.api_version = EMPTY_STRING;
   expected_report_info.status = Status::OK;
   expected_report_info.operation_name = "<Unknown Operation Name>";
-  expected_report_info.url = "";
-  expected_report_info.method = "";
+  expected_report_info.url = EMPTY_STRING;
+  expected_report_info.method = EMPTY_STRING;
 
   EXPECT_CALL(*mock_call_,
               callReport(MatchesSimpleReportInfo(expected_report_info)));
@@ -374,8 +375,8 @@ TEST_F(HandlerTest, HandlerNoRequirementMatched) {
 
   ReportRequestInfo expected_report_info;
   initExpectedReportInfo(expected_report_info);
-  expected_report_info.api_name = "";
-  expected_report_info.api_version = "";
+  expected_report_info.api_name = EMPTY_STRING;
+  expected_report_info.api_version = EMPTY_STRING;
   expected_report_info.status = Status::OK;
   expected_report_info.operation_name = "<Unknown Operation Name>";
   EXPECT_CALL(*mock_call_,

--- a/src/envoy/http/service_control/handler_utils_test.cc
+++ b/src/envoy/http/service_control/handler_utils_test.cc
@@ -14,7 +14,9 @@
 // limitations under the License.
 
 #include "src/envoy/http/service_control/handler_utils.h"
+
 #include "api/envoy/http/service_control/config.pb.h"
+#include "common/common/empty_string.h"
 #include "envoy/http/header_map.h"
 #include "gmock/gmock.h"
 #include "google/protobuf/text_format.h"
@@ -46,22 +48,23 @@ TEST(ServiceControlUtils, FillGCPInfo) {
 
   const TestCase test_cases[] = {
       // Test: No gcp_attributes found
-      {"", "", "UNKNOWN(ESPv2)"},
+      {EMPTY_STRING, EMPTY_STRING, "UNKNOWN(ESPv2)"},
 
       // Test: gcp_attributes found but empty
-      {R"(gcp_attributes {})", "", "UNKNOWN(ESPv2)"},
+      {R"(gcp_attributes {})", EMPTY_STRING, "UNKNOWN(ESPv2)"},
 
       // Test: bad platform provided should default to unknown
-      {R"(gcp_attributes { platform: "bad-platform"})", "", "bad-platform"},
+      {R"(gcp_attributes { platform: "bad-platform"})", EMPTY_STRING,
+       "bad-platform"},
 
       // Test: GAE_FLEX platform is passed through
-      {R"(gcp_attributes { platform: "GAE_FLEX"})", "", "GAE_FLEX"},
+      {R"(gcp_attributes { platform: "GAE_FLEX"})", EMPTY_STRING, "GAE_FLEX"},
 
       // Test: GCE platform is set
-      {R"(gcp_attributes { platform: "GCE"})", "", "GCE"},
+      {R"(gcp_attributes { platform: "GCE"})", EMPTY_STRING, "GCE"},
 
       // Test: GKE platform is set
-      {R"(gcp_attributes { platform: "GKE"})", "", "GKE"},
+      {R"(gcp_attributes { platform: "GKE"})", EMPTY_STRING, "GKE"},
 
       // Test: Provided zone is set
       {R"(gcp_attributes { zone: "test-zone"})", "test-zone", "UNKNOWN(ESPv2)"},
@@ -104,7 +107,7 @@ TEST(ServiceControlUtils, FillLoggedHeader) {
       {
           {{"ignore-this", "foo"}},
           R"(log_request_headers: "log-this")",
-          "",
+          EMPTY_STRING,
       },
 
       // Test: Search for one header when there are others
@@ -168,13 +171,13 @@ TEST(ServiceControlUtils, ExtractApiKey) {
 
   const TestCase test_cases[] = {
       // Test: No locations provided does nothing
-      {"", {}, ""},
+      {EMPTY_STRING, {}, EMPTY_STRING},
 
       // Test: cookie location expected but not provided
       {
           R"(locations: { cookie: "apikey" } )",
           {},
-          "",
+          EMPTY_STRING,
       },
 
       // Test: find apikey in cookie location
@@ -197,7 +200,7 @@ TEST(ServiceControlUtils, ExtractApiKey) {
       {
           R"(locations: { header: "apikey" } )",
           {},
-          "",
+          EMPTY_STRING,
       },
 
       // Test: find apikey in header location
@@ -220,7 +223,7 @@ TEST(ServiceControlUtils, ExtractApiKey) {
       {
           R"(locations: { query: "apikey" } )",
           {{":path", "/echo"}},
-          "",
+          EMPTY_STRING,
       },
 
       // Test: find apikey in query location
@@ -245,7 +248,7 @@ TEST(ServiceControlUtils, ExtractApiKey) {
             locations: { header: "apikey" }
             locations: { query: "apikey" } )",
           {{"cookie", "apikey=foobar"}, {":path", "/echo"}},
-          ""},
+          EMPTY_STRING},
 
       // Test: apikey is in header but header location is not expected
       {
@@ -253,7 +256,7 @@ TEST(ServiceControlUtils, ExtractApiKey) {
             locations: { cookie: "apikey" }
             locations: { query: "apikey" } )",
           {{"apikey", "foobar"}, {":path", "/echo"}},
-          ""},
+          EMPTY_STRING},
 
       // Test: apikey is in query but query location is not expected
       {
@@ -261,7 +264,7 @@ TEST(ServiceControlUtils, ExtractApiKey) {
             locations: { cookie: "apikey" }
             locations: { header: "apikey" } )",
           {{":path", "/echo?apikey=foobar"}},
-          "",
+          EMPTY_STRING,
       }};
 
   for (const auto& test : test_cases) {

--- a/src/envoy/http/service_control/http_call.cc
+++ b/src/envoy/http/service_control/http_call.cc
@@ -12,15 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "src/envoy/http/service_control/http_call.h"
+
 #include <memory>
 
+#include "common/common/empty_string.h"
 #include "common/common/enum_to_int.h"
 #include "common/http/headers.h"
 #include "common/http/message_impl.h"
 #include "common/http/utility.h"
 #include "common/tracing/http_tracer_impl.h"
 #include "envoy/event/deferred_deletable.h"
-#include "src/envoy/http/service_control/http_call.h"
 
 using ::google::api::envoy::http::common::HttpUri;
 using ::google::protobuf::util::Status;
@@ -162,7 +164,7 @@ class HttpCallImpl : public HttpCall,
     if (token.empty()) {
       on_done_(Status(Code::INTERNAL,
                       "Missing access token for service control call"),
-               "");
+               EMPTY_STRING);
       deferredDelete();
       return;
     }
@@ -207,7 +209,8 @@ class HttpCallImpl : public HttpCall,
       ENVOY_LOG(debug, "Http call [uri = {}]: canceled", uri_);
       reset();
     }
-    on_done_(Status(Code::CANCELLED, std::string("Request cancelled")), "");
+    on_done_(Status(Code::CANCELLED, std::string("Request cancelled")),
+             EMPTY_STRING);
     deferredDelete();
   }
 

--- a/src/envoy/token/BUILD
+++ b/src/envoy/token/BUILD
@@ -20,6 +20,7 @@ envoy_cc_library(
         ":token_info_lib",
         "//external:protobuf",
         "//src/envoy/utils:json_struct_lib",
+        "@envoy//source/common/common:empty_string",
         "@envoy//source/common/http:headers_lib",
         "@envoy//source/common/http:message_lib",
         "@envoy//source/common/http:utility_lib",
@@ -161,6 +162,7 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         ":iam_token_info_lib",
+        "@envoy//source/common/common:empty_string",
         "@envoy//test/test_common:utility_lib",
     ],
 )

--- a/src/envoy/token/iam_token_info.cc
+++ b/src/envoy/token/iam_token_info.cc
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 #include "src/envoy/token/iam_token_info.h"
+
 #include "absl/strings/str_cat.h"
+#include "common/common/empty_string.h"
 #include "common/http/headers.h"
 #include "common/http/message_impl.h"
 #include "src/envoy/utils/json_struct.h"
@@ -84,7 +86,7 @@ Envoy::Http::RequestMessagePtr IamTokenInfo::prepareRequest(
   }
 
   if (!scopes_.empty()) {
-    insertStrListToProto(body, kScopesField, scopes_, "");
+    insertStrListToProto(body, kScopesField, scopes_, EMPTY_STRING);
   }
 
   if (include_email_) {

--- a/src/envoy/token/iam_token_info_test.cc
+++ b/src/envoy/token/iam_token_info_test.cc
@@ -15,6 +15,7 @@
 #include "src/envoy/token/iam_token_info.h"
 
 #include "absl/strings/str_cat.h"
+#include "common/common/empty_string.h"
 #include "common/http/message_impl.h"
 #include "gtest/gtest.h"
 #include "test/test_common/utility.h"
@@ -39,7 +40,7 @@ TEST_F(IamTokenInfoTest, FailPreconditions) {
   // Create info that fails preconditions.
   ::google::protobuf::RepeatedPtrField<std::string> delegates;
   ::google::protobuf::RepeatedPtrField<std::string> scopes;
-  Token::GetTokenFunc access_token_fn = []() { return ""; };
+  Token::GetTokenFunc access_token_fn = []() { return EMPTY_STRING; };
   info_ =
       std::make_unique<IamTokenInfo>(delegates, scopes, false, access_token_fn);
 

--- a/src/envoy/utils/BUILD
+++ b/src/envoy/utils/BUILD
@@ -58,6 +58,7 @@ envoy_cc_library(
     ],
     repository = "@envoy",
     deps = [
+        "@envoy//source/common/common:empty_string",
         "@envoy//source/common/router:string_accessor_lib",
         "@envoy//source/exe:envoy_common_lib",
     ],
@@ -70,6 +71,7 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         ":filter_state_utils_lib",
+        "@envoy//source/common/common:empty_string",
         "@envoy//source/common/stream_info:filter_state_lib",
         "@envoy//test/test_common:utility_lib",
     ],
@@ -81,6 +83,7 @@ envoy_cc_library(
     hdrs = ["http_header_utils.h"],
     repository = "@envoy",
     deps = [
+        "@envoy//source/common/common:empty_string",
         "@envoy//source/exe:envoy_common_lib",
     ],
 )

--- a/src/envoy/utils/filter_state_utils.cc
+++ b/src/envoy/utils/filter_state_utils.cc
@@ -14,6 +14,7 @@
 
 #include "src/envoy/utils/filter_state_utils.h"
 
+#include "common/common/empty_string.h"
 #include "common/router/string_accessor_impl.h"
 
 namespace Envoy {
@@ -23,10 +24,6 @@ namespace Utils {
 using ::Envoy::Router::StringAccessor;
 using ::Envoy::Router::StringAccessorImpl;
 using ::Envoy::StreamInfo::FilterState;
-
-namespace {
-constexpr char kEmpty[] = "";
-}  // namespace
 
 void setStringFilterState(FilterState& filter_state,
                           absl::string_view data_name,
@@ -41,7 +38,7 @@ absl::string_view getStringFilterState(
     const Envoy::StreamInfo::FilterState& filter_state,
     absl::string_view data_name) {
   if (!filter_state.hasData<StringAccessor>(data_name)) {
-    return kEmpty;
+    return EMPTY_STRING;
   }
 
   return filter_state.getDataReadOnly<StringAccessor>(data_name).asString();

--- a/src/envoy/utils/filter_state_utils_test.cc
+++ b/src/envoy/utils/filter_state_utils_test.cc
@@ -14,6 +14,7 @@
 
 #include "src/envoy/utils/filter_state_utils.h"
 
+#include "common/common/empty_string.h"
 #include "common/stream_info/filter_state_impl.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -38,7 +39,8 @@ TEST(FilterStateUtilsTest, SetAndGetStringValueFromFilterState) {
 TEST(FilterStateUtilsTest, ReturnEmptyStringViewForNonExistingDataName) {
   Envoy::StreamInfo::FilterStateImpl filter_state(
       Envoy::StreamInfo::FilterState::LifeSpan::FilterChain);
-  EXPECT_EQ(getStringFilterState(filter_state, "non_existing_data_name"), "");
+  EXPECT_EQ(getStringFilterState(filter_state, "non_existing_data_name"),
+            EMPTY_STRING);
 }
 
 }  // namespace

--- a/src/envoy/utils/http_header_utils.cc
+++ b/src/envoy/utils/http_header_utils.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "src/envoy/utils/http_header_utils.h"
+#include "common/common/empty_string.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -27,7 +28,7 @@ absl::string_view readHeaderEntry(const Envoy::Http::HeaderEntry* entry) {
   if (entry) {
     return entry->value().getStringView();
   }
-  return "";
+  return EMPTY_STRING;
 }
 
 absl::string_view extractHeader(const Envoy::Http::HeaderMap& headers,


### PR DESCRIPTION
As part of the security review, we were suggested to use a single constant when referring to empty strings in envoy. Update all envoy filters and utils.

Signed-off-by: Teju Nareddy <nareddyt@google.com>