### PR TITLE
Add missing tests and validation for Path Matcher filter

### DIFF
--- a/api/envoy/http/common/base.proto
+++ b/api/envoy/http/common/base.proto
@@ -37,12 +37,16 @@ message Pattern {
   //     /dictionary/{term:1}/{term}
   //     /search{?q*,lang}
   //
-  string uri_template = 1;
+  string uri_template = 1 [(validate.rules).string = {
+    well_known_regex: HTTP_HEADER_VALUE,
+    strict: false
+  }];
 
   // HTTP request method to match against as defined by
   // [rfc7231](https://tools.ietf.org/html/rfc7231#page-21). For
   // example: GET, HEAD, POST, PUT, DELETE.
-  string http_method = 2;
+  string http_method = 2
+      [(validate.rules).string.well_known_regex = HTTP_HEADER_NAME];
 }
 
 message HttpUri {

--- a/src/api_proxy/path_matcher/variable_binding_utils_test.cc
+++ b/src/api_proxy/path_matcher/variable_binding_utils_test.cc
@@ -35,6 +35,14 @@ TEST(VariableBindingsToQueryParameters, WithoutSnakeToJsonNameConversion) {
   EXPECT_EQ(VariableBindingsToQueryParameters(
                 /*variable_bindings=*/
                 {
+                    {{"foo_bar"}, "42"},
+                },
+                /*snake_to_json=*/
+                {}),
+            "foo_bar=42");
+  EXPECT_EQ(VariableBindingsToQueryParameters(
+                /*variable_bindings=*/
+                {
                     {{"id"}, "42"},
                     {{"foo", "bar", "baz"}, "value"},
                     {{"x", "y"}, "abc"},

--- a/src/envoy/http/path_matcher/filter_config.cc
+++ b/src/envoy/http/path_matcher/filter_config.cc
@@ -31,7 +31,8 @@ FilterConfig::FilterConfig(
     if (!pmb.Register(rule.pattern().http_method(),
                       rule.pattern().uri_template(),
                       /*body_field_path=*/EMPTY_STRING, &rule.operation())) {
-      throw ProtoValidationException("Duplicated pattern", rule.pattern());
+      throw ProtoValidationException("Duplicated pattern or invalid pattern",
+                                     rule.pattern());
     }
     if (rule.extract_path_parameters()) {
       path_params_operations_.insert(rule.operation());

--- a/src/envoy/http/path_matcher/filter_test.cc
+++ b/src/envoy/http/path_matcher/filter_test.cc
@@ -99,7 +99,7 @@ TEST_F(PathMatcherFilterTest, DecodeHeadersWithOperation) {
             filter_->decodeTrailers(trailers));
 }
 
-TEST_F(PathMatcherFilterTest, DecodeHeadersWithMethodOveride) {
+TEST_F(PathMatcherFilterTest, DecodeHeadersWithMethodOverride) {
   // Test: a request with a method override matches a operation
   Http::TestRequestHeaderMapImpl headers{{":method", "POST"},
                                          {":path", "/bar"},


### PR DESCRIPTION
Based on comments for path matcher envoy security review and current C++ unit test coverage.

Signed-off-by: Teju Nareddy <nareddyt@google.com>