### PR TITLE
Ensure access/identity token from IMDS/IAM is a valid HTTP header value

### DIFF
--- a/tests/fuzz/corpus/iam_token_info/invalid-imds-access-token.prototxt
+++ b/tests/fuzz/corpus/iam_token_info/invalid-imds-access-token.prototxt
@@ -1,0 +1,3 @@
+access_token: "{ \"accessToken\": \"faYe-acc��:��.t:�6�O�9<��T��2�\nf�{�}���p*��?��G���7� \n08:00\" }"
+token_url: "token_url"
+resp_body: "{ \"acceken_ssToken\": \"faYe-acc\", \"expireTime\": \"2020-02-ess-token\", \"expireTime\":{ \"acceken_0T&3:15:34-08:00\" }"

--- a/tests/fuzz/structured_inputs/iam_token_info.proto
+++ b/tests/fuzz/structured_inputs/iam_token_info.proto
@@ -12,7 +12,11 @@ message IamTokenInfoInput {
   bool include_email = 3;
 
   // Arguments for starting the request.
-  string access_token = 4;
+  string access_token = 4 [(validate.rules).string = {
+    well_known_regex: HTTP_HEADER_VALUE,
+    strict: false
+  }];
+
   string token_url = 5 [(validate.rules).string = {
     min_bytes: 1,
     well_known_regex: HTTP_HEADER_VALUE,


### PR DESCRIPTION
Otherwise, certain characters ('\r\n\0') may cause an assertion failure in other components when the access token or identity token are used as HTTP headers in upstream or sidestream calls.

Added a reproducer test case where this assertion failure occurs when making a sidestream call to IAM using an invalid access token from IMDS.

Ref: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=21270
Signed-off-by: Teju Nareddy <nareddyt@google.com>