### PR TITLE
Switch /src/api_proxy to envoy_build_system

### DIFF
--- a/src/api_proxy/path_matcher/BUILD
+++ b/src/api_proxy/path_matcher/BUILD
@@ -1,15 +1,17 @@
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_basic_cc_library",
+    "envoy_cc_fuzz_test",
+    "envoy_cc_test",
+)
+
 package(
     default_visibility = [
         "//src/envoy:__subpackages__",
     ],
 )
 
-load(
-    "@envoy//bazel:envoy_build_system.bzl",
-    "envoy_cc_fuzz_test",
-)
-
-cc_library(
+envoy_basic_cc_library(
     name = "path_matcher_lib",
     srcs = [
         "http_template.cc",
@@ -26,37 +28,27 @@ cc_library(
     ],
 )
 
-cc_test(
+envoy_cc_test(
     name = "http_template_test",
     size = "small",
     srcs = ["http_template_test.cc"],
-    linkopts = [
-        "-lm",
-        "-lpthread",
-    ],
-    linkstatic = 1,
+    repository = "@envoy",
     deps = [
         ":path_matcher_lib",
-        "@com_google_googletest//:gtest_main",
     ],
 )
 
-cc_test(
+envoy_cc_test(
     name = "path_matcher_test",
     size = "small",
     srcs = ["path_matcher_test.cc"],
-    linkopts = [
-        "-lm",
-        "-lpthread",
-    ],
-    linkstatic = 1,
+    repository = "@envoy",
     deps = [
         ":path_matcher_lib",
-        "@com_google_googletest//:gtest_main",
     ],
 )
 
-cc_library(
+envoy_basic_cc_library(
     name = "variable_binding_utils_lib",
     srcs = [
         "variable_binding_utils.cc",
@@ -71,20 +63,15 @@ cc_library(
     ],
 )
 
-cc_test(
+envoy_cc_test(
     name = "variable_binding_utils_test",
     size = "small",
     srcs = [
         "variable_binding_utils_test.cc",
     ],
-    linkopts = [
-        "-lm",
-        "-lpthread",
-    ],
-    linkstatic = 1,
+    repository = "@envoy",
     deps = [
         ":variable_binding_utils_lib",
-        "@com_google_googletest//:gtest_main",
     ],
 )
 

--- a/src/api_proxy/service_control/BUILD
+++ b/src/api_proxy/service_control/BUILD
@@ -1,10 +1,16 @@
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_basic_cc_library",
+    "envoy_cc_test",
+)
+
 package(
     default_visibility = [
         "//src/api_proxy/service_control:__subpackages__",
     ],
 )
 
-cc_library(
+envoy_basic_cc_library(
     name = "request_builder_lib",
     srcs = ["request_builder.cc"],
     hdrs = [
@@ -21,34 +27,32 @@ cc_library(
     ],
 )
 
-cc_test(
+envoy_cc_test(
     name = "check_response_test",
     size = "small",
     srcs = [
         "check_response_test.cc",
     ],
-    linkstatic = 1,
+    repository = "@envoy",
     deps = [
         ":request_builder_lib",
-        "@com_google_googletest//:gtest_main",
     ],
 )
 
-cc_test(
+envoy_cc_test(
     name = "request_builder_test",
     size = "small",
     srcs = [
         "request_builder_test.cc",
     ],
     data = glob(["testdata/*.golden"]),
-    linkstatic = 1,
+    repository = "@envoy",
     deps = [
         ":request_builder_lib",
-        "@com_google_googletest//:gtest_main",
     ],
 )
 
-cc_library(
+envoy_basic_cc_library(
     name = "logs_metrics_loader_lib",
     srcs = ["logs_metrics_loader.cc"],
     hdrs = ["logs_metrics_loader.h"],
@@ -60,15 +64,14 @@ cc_library(
     ],
 )
 
-cc_test(
+envoy_cc_test(
     name = "logs_metrics_loader_test",
     size = "small",
     srcs = [
         "logs_metrics_loader_test.cc",
     ],
-    linkstatic = 1,
+    repository = "@envoy",
     deps = [
         ":logs_metrics_loader_lib",
-        "@com_google_googletest//:gtest_main",
     ],
 )

--- a/src/api_proxy/service_control/request_builder.cc
+++ b/src/api_proxy/service_control/request_builder.cc
@@ -114,7 +114,7 @@ Status AddDistributionMetric(const DistributionHelperOptions& options,
 // Metrics supported by ESPv2.
 
 Status set_int64_metric_to_constant_1(const SupportedMetric& m,
-                                      const ReportRequestInfo& info,
+                                      const ReportRequestInfo&,
                                       Operation* operation) {
   AddInt64Metric(m.name, 1l, operation);
   return Status::OK;
@@ -675,14 +675,14 @@ Status set_platform(const SupportedLabel& l, const ReportRequestInfo& info,
 }
 
 // servicecontrol.googleapis.com/service_agent
-Status set_service_agent(const SupportedLabel& l, const ReportRequestInfo& info,
+Status set_service_agent(const SupportedLabel& l, const ReportRequestInfo&,
                          Map<std::string, std::string>* labels) {
   (*labels)[l.name] = get_service_agent();
   return Status::OK;
 }
 
 // serviceruntime.googleapis.com/user_agent
-Status set_user_agent(const SupportedLabel& l, const ReportRequestInfo& info,
+Status set_user_agent(const SupportedLabel& l, const ReportRequestInfo&,
                       Map<std::string, std::string>* labels) {
   (*labels)[l.name] = kUserAgent;
   return Status::OK;
@@ -963,9 +963,7 @@ Status VerifyRequiredCheckFields(const OperationInfo& info) {
   return Status::OK;
 }
 
-Status VerifyRequiredReportFields(const OperationInfo& info) {
-  return Status::OK;
-}
+Status VerifyRequiredReportFields(const OperationInfo&) { return Status::OK; }
 
 void SetOperationCommonFields(const OperationInfo& info,
                               const Timestamp& current_time, Operation* op) {
@@ -994,8 +992,8 @@ void FillLogEntry(const ReportRequestInfo& info, const std::string& name,
 
   auto* fields = log_entry->mutable_struct_payload()->mutable_fields();
   (*fields)[kLogFieldNameTimestamp].set_number_value(
-      (double)current_time.seconds() +
-      (double)current_time.nanos() / (double)1000000000.0);
+      static_cast<double>(current_time.seconds()) +
+      static_cast<double>(current_time.nanos()) / 1000000000.0);
   (*fields)[kLogFieldNameConfigId].set_string_value(config_id);
   (*fields)[kLogFieldNameServiceAgent].set_string_value(
       kServiceAgentPrefix + utils::Version::instance().get());
@@ -1315,7 +1313,7 @@ Status RequestBuilder::AppendByConsumerOperations(
 
 Status RequestBuilder::ConvertAllocateQuotaResponse(
     const ::google::api::servicecontrol::v1::AllocateQuotaResponse& response,
-    const std::string& service_name) {
+    const std::string&) {
   // response.operation_id()
   if (response.allocate_errors().empty()) {
     return Status::OK;

--- a/src/api_proxy/utils/BUILD
+++ b/src/api_proxy/utils/BUILD
@@ -1,3 +1,9 @@
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_basic_cc_library",
+    "envoy_cc_test",
+)
+
 sh_binary(
     name = "version_macro_template",
     srcs = [
@@ -19,7 +25,7 @@ genrule(
     ],
 )
 
-cc_library(
+envoy_basic_cc_library(
     name = "utils",
     srcs = [
         "version.cc",
@@ -31,17 +37,14 @@ cc_library(
     visibility = ["//:__subpackages__"],
 )
 
-cc_test(
+envoy_cc_test(
     name = "version_test",
     size = "small",
     srcs = [
         "version_test.cc",
     ],
-    linkopts = [
-        "-lpthread",
-    ],
+    repository = "@envoy",
     deps = [
         ":utils",
-        "@com_google_googletest//:gtest_main",
     ],
 )


### PR DESCRIPTION
This allows coverage charts for unit tests located in these directories.

Unfortunately, I was unable to switch over /src/api_proxy/auth:json_util_test because it directly depends on grpc_internals that do not compile with `-Wall`. This should be OK, as this is a small part of our library.

Required for envoy security review.

Signed-off-by: Teju Nareddy <nareddyt@google.com>