### PR TITLE
add integration test for gRPCs mTLS

### DIFF
--- a/tests/env/env.go
+++ b/tests/env/env.go
@@ -405,13 +405,13 @@ func (e *TestEnv) Setup(confArgs []string) error {
 			return err
 		}
 	case platform.GrpcBookstoreSidecar:
-		e.bookstoreServer, err = bookserver.NewBookstoreServer(e.ports.BackendServerPort /*enableTLS=*/, false /*useAuthorizedBackendCert*/, false)
+		e.bookstoreServer, err = bookserver.NewBookstoreServer(e.ports.BackendServerPort /*enableTLS=*/, false /*useAuthorizedBackendCert*/, false /*backendMTLSCertFile=*/, "")
 		if err != nil {
 			return err
 		}
 		e.bookstoreServer.StartServer()
 	case platform.GrpcBookstoreRemote:
-		e.bookstoreServer, err = bookserver.NewBookstoreServer(e.ports.DynamicRoutingBackendPort /*enableTLS=*/, true, e.useWrongBackendCert)
+		e.bookstoreServer, err = bookserver.NewBookstoreServer(e.ports.DynamicRoutingBackendPort /*enableTLS=*/, true, e.useWrongBackendCert, e.backendMTLSCertFile)
 		if err != nil {
 			return err
 		}

--- a/tests/integration_test/dynamic_routing_integration_test.go
+++ b/tests/integration_test/dynamic_routing_integration_test.go
@@ -773,7 +773,7 @@ func TestDynamicGrpcBackendTLS(t *testing.T) {
 			wantResp:       `{"id":"100","theme":"Kids"}`,
 		},
 		{
-			desc:           "gRPC client calling gRPCs remote backend through mTLS failed with incorrect client root cert",
+			desc:           "HTTP2 client calling gRPCs remote backend through mTLS failed with incorrect client root cert",
 			clientProtocol: "http2",
 			methodOrUrl:    "/v1/shelves/200?key=api-key",
 			mtlsCertFile:   platform.GetFilePath(platform.ProxyCert),

--- a/tests/integration_test/dynamic_routing_integration_test.go
+++ b/tests/integration_test/dynamic_routing_integration_test.go
@@ -726,13 +726,11 @@ func TestDynamicBackendRoutingMutualTLS(t *testing.T) {
 func TestDynamicGrpcBackendTLS(t *testing.T) {
 	t.Parallel()
 
-	configID := "test-config-id"
-	args := []string{"--service_config_id=" + configID, "--rollout_strategy=fixed"}
-
 	tests := []struct {
 		desc                string
 		clientProtocol      string
 		methodOrUrl         string
+		mtlsCertFile        string
 		useWrongBackendCert bool
 		header              http.Header
 		wantResp            string
@@ -766,13 +764,35 @@ func TestDynamicGrpcBackendTLS(t *testing.T) {
 			methodOrUrl:         "/v1/shelves/200?key=api-key",
 			wantError:           "503 Service Unavailable",
 		},
+		{
+			desc:           "gRPC client calling gRPCs remote backend with mTLS succeed",
+			clientProtocol: "grpc",
+			methodOrUrl:    "GetShelf",
+			mtlsCertFile:   platform.GetFilePath(platform.ServerCert),
+			header:         http.Header{"x-api-key": []string{"api-key"}},
+			wantResp:       `{"id":"100","theme":"Kids"}`,
+		},
+		{
+			desc:           "gRPC client calling gRPCs remote backend through mTLS failed with incorrect client root cert",
+			clientProtocol: "http2",
+			methodOrUrl:    "/v1/shelves/200?key=api-key",
+			mtlsCertFile:   platform.GetFilePath(platform.ProxyCert),
+			header:         http.Header{"x-api-key": []string{"api-key"}},
+			wantError:      "503 Service Unavailable",
+		},
 	}
 
 	for _, tc := range tests {
+		args := utils.CommonArgs()
 		func() {
 			s := env.NewTestEnv(comp.TestDynamicGrpcBackendTLS, platform.GrpcBookstoreRemote)
-			s.UseWrongBackendCertForDR(tc.useWrongBackendCert)
 			defer s.TearDown()
+			s.UseWrongBackendCertForDR(tc.useWrongBackendCert)
+			if tc.mtlsCertFile != "" {
+				s.SetBackendMTLSCert(tc.mtlsCertFile)
+				args = append(args, "--ssl_client_cert_path=../env/testdata/")
+			}
+
 			if err := s.Setup(args); err != nil {
 				t.Fatalf("fail to setup test env, %v", err)
 			}


### PR DESCRIPTION
Notes:
    I feel it is better that ESPv2 don't support grpc_backend_ssl_private_key_file and grpc_backend_ssl_cert_chain_file for backward compatiblity.  Two reasons:
   1,   user should just use --ssl_client_cert_path
   2,  this two are file names, but --ssl_client_cert_path is path, requires extra code changes