### PR TITLE
support websocket

### DIFF
--- a/examples/auth/envoy_config.json
+++ b/examples/auth/envoy_config.json
@@ -196,11 +196,7 @@
                       }
                     ]
                   },
-                  "upgradeConfigs": [
-		    {
-		      "upgradeType": "websocket"
-		    }
-		  ],
+                  "upgradeConfigs": [{"upgradeType": "websocket"}],
                   "statPrefix": "ingress_http",
                   "useRemoteAddress": false,
                   "xffNumTrustedHops": 2

--- a/examples/auth/envoy_config.json
+++ b/examples/auth/envoy_config.json
@@ -196,6 +196,7 @@
                       }
                     ]
                   },
+                  "upgradeConfigs":[{"upgradeType":"websocket"}],
                   "statPrefix": "ingress_http",
                   "useRemoteAddress": false,
                   "xffNumTrustedHops": 2

--- a/examples/auth/envoy_config.json
+++ b/examples/auth/envoy_config.json
@@ -196,7 +196,11 @@
                       }
                     ]
                   },
-                  "upgradeConfigs":[{"upgradeType":"websocket"}],
+                  "upgradeConfigs": [
+		    {
+		      "upgradeType": "websocket"
+		    }
+		  ],
                   "statPrefix": "ingress_http",
                   "useRemoteAddress": false,
                   "xffNumTrustedHops": 2

--- a/examples/dynamic_routing/envoy_config.json
+++ b/examples/dynamic_routing/envoy_config.json
@@ -48,7 +48,7 @@
                                     }
                                 }
                             ]
-                        }
+                       }
                     ]
                 },
                 "name": "metadata-cluster",
@@ -324,7 +324,8 @@
                                             }
                                         ]
                                     },
-                                    "statPrefix": "ingress_http",
+                                    "upgradeConfigs":[{"upgradeType":"websocket"}],
+		                    "statPrefix": "ingress_http",
                                     "useRemoteAddress": false,
                                     "xffNumTrustedHops": 2
                                 }

--- a/examples/dynamic_routing/envoy_config.json
+++ b/examples/dynamic_routing/envoy_config.json
@@ -324,12 +324,8 @@
                                             }
                                         ]
                                     },
-                                    "upgradeConfigs": [
-					{
-					    "upgradeType": "websocket"
-					}
-				    ],
-		                    "statPrefix": "ingress_http",
+                                    "upgradeConfigs": [{"upgradeType": "websocket"}],
+                                    "statPrefix": "ingress_http",
                                     "useRemoteAddress": false,
                                     "xffNumTrustedHops": 2
                                 }

--- a/examples/dynamic_routing/envoy_config.json
+++ b/examples/dynamic_routing/envoy_config.json
@@ -48,7 +48,7 @@
                                     }
                                 }
                             ]
-                       }
+                        }
                     ]
                 },
                 "name": "metadata-cluster",

--- a/examples/dynamic_routing/envoy_config.json
+++ b/examples/dynamic_routing/envoy_config.json
@@ -324,7 +324,11 @@
                                             }
                                         ]
                                     },
-                                    "upgradeConfigs":[{"upgradeType":"websocket"}],
+                                    "upgradeConfigs": [
+					{
+					    "upgradeType": "websocket"
+					}
+				    ],
 		                    "statPrefix": "ingress_http",
                                     "useRemoteAddress": false,
                                     "xffNumTrustedHops": 2

--- a/examples/grpc_dynamic_routing/envoy_config.json
+++ b/examples/grpc_dynamic_routing/envoy_config.json
@@ -1243,7 +1243,11 @@
                                             }
                                         ]
                                     },
-                                    "upgradeConfigs":[{"upgradeType":"websocket"}],
+                                    "upgradeConfigs": [
+					{
+					    "upgradeType": "websocket"
+					}
+				    ],
 		                    "statPrefix": "ingress_http",
                                     "useRemoteAddress": false,
                                     "xffNumTrustedHops": 2

--- a/examples/grpc_dynamic_routing/envoy_config.json
+++ b/examples/grpc_dynamic_routing/envoy_config.json
@@ -1243,12 +1243,8 @@
                                             }
                                         ]
                                     },
-                                    "upgradeConfigs": [
-					{
-					    "upgradeType": "websocket"
-					}
-				    ],
-		                    "statPrefix": "ingress_http",
+                                    "upgradeConfigs": [{"upgradeType": "websocket"}],
+                                    "statPrefix": "ingress_http",
                                     "useRemoteAddress": false,
                                     "xffNumTrustedHops": 2
                                 }

--- a/examples/grpc_dynamic_routing/envoy_config.json
+++ b/examples/grpc_dynamic_routing/envoy_config.json
@@ -1243,7 +1243,8 @@
                                             }
                                         ]
                                     },
-                                    "statPrefix": "ingress_http",
+                                    "upgradeConfigs":[{"upgradeType":"websocket"}],
+		                    "statPrefix": "ingress_http",
                                     "useRemoteAddress": false,
                                     "xffNumTrustedHops": 2
                                 }

--- a/examples/service_control/envoy_config.json
+++ b/examples/service_control/envoy_config.json
@@ -22,7 +22,7 @@
                   "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
                   "upgradeConfigs":[{"upgradeType":"websocket"}],
 		  "statPrefix": "ingress_http",
-                  "routeConfig": {
+		  "routeConfig": {
                     "name": "local_route",
                     "virtualHosts": [
                       {

--- a/examples/service_control/envoy_config.json
+++ b/examples/service_control/envoy_config.json
@@ -20,7 +20,11 @@
                 "name": "envoy.filters.network.http_connection_manager",
 		"typedConfig": {
                   "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
-                  "upgradeConfigs":[{"upgradeType":"websocket"}],
+                  "upgradeConfigs": [
+		    {
+		      "upgradeType": "websocket"
+		    }
+		  ],
 		  "statPrefix": "ingress_http",
 		  "routeConfig": {
                     "name": "local_route",

--- a/examples/service_control/envoy_config.json
+++ b/examples/service_control/envoy_config.json
@@ -18,9 +18,10 @@
             "filters": [
               {
                 "name": "envoy.filters.network.http_connection_manager",
-                "typedConfig": {
+		"typedConfig": {
                   "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
-                  "statPrefix": "ingress_http",
+                  "upgradeConfigs":[{"upgradeType":"websocket"}],
+		  "statPrefix": "ingress_http",
                   "routeConfig": {
                     "name": "local_route",
                     "virtualHosts": [

--- a/examples/service_control/envoy_config.json
+++ b/examples/service_control/envoy_config.json
@@ -18,15 +18,11 @@
             "filters": [
               {
                 "name": "envoy.filters.network.http_connection_manager",
-		"typedConfig": {
+                "typedConfig": {
                   "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
-                  "upgradeConfigs": [
-		    {
-		      "upgradeType": "websocket"
-		    }
-		  ],
-		  "statPrefix": "ingress_http",
-		  "routeConfig": {
+                  "upgradeConfigs": [{"upgradeType": "websocket"}],
+                  "statPrefix": "ingress_http",
+                  "routeConfig": {
                     "name": "local_route",
                     "virtualHosts": [
                       {

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/golang/protobuf v1.3.3
 	github.com/google/go-cmp v0.3.0
 	github.com/gorilla/mux v1.6.3-0.20181030152528-3d80bc801bb0
+	github.com/gorilla/websocket v1.4.2
 	golang.org/x/net v0.0.0-20190628185345-da137c7871d7
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	google.golang.org/api v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gorilla/mux v1.6.3-0.20181030152528-3d80bc801bb0 h1:lkoCFKD1IVH+yARHTUkCerTOqKkwVVO+IyGWld86voc=
 github.com/gorilla/mux v1.6.3-0.20181030152528-3d80bc801bb0/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/src/go/bootstrap/static/testdata/path_matcher/envoy_config.json
+++ b/src/go/bootstrap/static/testdata/path_matcher/envoy_config.json
@@ -156,7 +156,11 @@
                       }
                     ]
                   },
-                  "upgradeConfigs":[{"upgradeType":"websocket"}],
+                  "upgradeConfigs": [
+		    {
+		      "upgradeType": "websocket"
+		    }
+		  ],
 		  "statPrefix": "ingress_http",
                   "useRemoteAddress": false,
                   "xffNumTrustedHops": 2

--- a/src/go/bootstrap/static/testdata/path_matcher/envoy_config.json
+++ b/src/go/bootstrap/static/testdata/path_matcher/envoy_config.json
@@ -156,12 +156,8 @@
                       }
                     ]
                   },
-                  "upgradeConfigs": [
-		    {
-		      "upgradeType": "websocket"
-		    }
-		  ],
-		  "statPrefix": "ingress_http",
+                  "upgradeConfigs": [{"upgradeType": "websocket"}],
+                  "statPrefix": "ingress_http",
                   "useRemoteAddress": false,
                   "xffNumTrustedHops": 2
                 }

--- a/src/go/bootstrap/static/testdata/path_matcher/envoy_config.json
+++ b/src/go/bootstrap/static/testdata/path_matcher/envoy_config.json
@@ -156,7 +156,8 @@
                       }
                     ]
                   },
-                  "statPrefix": "ingress_http",
+                  "upgradeConfigs":[{"upgradeType":"websocket"}],
+		  "statPrefix": "ingress_http",
                   "useRemoteAddress": false,
                   "xffNumTrustedHops": 2
                 }

--- a/src/go/configgenerator/listener_generator.go
+++ b/src/go/configgenerator/listener_generator.go
@@ -169,6 +169,11 @@ func makeListener(serviceInfo *sc.ServiceInfo) (*v2pb.Listener, error) {
 	}
 
 	httpConMgr := &hcmpb.HttpConnectionManager{
+		UpgradeConfigs: []*hcmpb.HttpConnectionManager_UpgradeConfig{
+			{
+				UpgradeType: "websocket",
+			},
+		},
 		CodecType:  hcmpb.HttpConnectionManager_AUTO,
 		StatPrefix: statPrefix,
 		RouteSpecifier: &hcmpb.HttpConnectionManager_RouteConfig{

--- a/src/go/configgenerator/listener_generator_test.go
+++ b/src/go/configgenerator/listener_generator_test.go
@@ -1475,7 +1475,7 @@ func TestMakeListeners(t *testing.T) {
 												}
 											]
 										},
-								                "upgradeConfigs":[{"upgradeType":"websocket"}],
+										"upgradeConfigs":[{"upgradeType":"websocket"}],
 										"statPrefix":"ingress_http",
 										"tracing":{},
 										"useRemoteAddress":false,

--- a/src/go/configgenerator/listener_generator_test.go
+++ b/src/go/configgenerator/listener_generator_test.go
@@ -1475,6 +1475,7 @@ func TestMakeListeners(t *testing.T) {
 												}
 											]
 										},
+								                "upgradeConfigs":[{"upgradeType":"websocket"}],
 										"statPrefix":"ingress_http",
 										"tracing":{},
 										"useRemoteAddress":false,

--- a/src/go/configmanager/config_manager_test.go
+++ b/src/go/configmanager/config_manager_test.go
@@ -194,7 +194,11 @@ func TestFetchListeners(t *testing.T) {
                         }
                      ]
                   },
-		  "upgradeConfigs":[{"upgradeType":"websocket"}],
+		  "upgradeConfigs": [
+		     {
+		       "upgradeType": "websocket"
+	             }
+		  ],
 		  "statPrefix":"ingress_http",
                   "useRemoteAddress":false,
                   "xffNumTrustedHops":2
@@ -372,7 +376,11 @@ func TestFetchListeners(t *testing.T) {
                         }
                      ]
                   },
-                  "upgradeConfigs":[{"upgradeType":"websocket"}],
+                  "upgradeConfigs": [
+		     {
+			"upgradeType": "websocket"
+		     }
+		  ],
 		  "statPrefix":"ingress_http",
                   "useRemoteAddress":false,
                   "xffNumTrustedHops":2
@@ -583,7 +591,11 @@ func TestFetchListeners(t *testing.T) {
                         }
                      ]
                   },
-                  "upgradeConfigs":[{"upgradeType":"websocket"}],
+                  "upgradeConfigs": [
+		     {
+			"upgradeType": "websocket"
+		     }
+		  ],
 		  "statPrefix":"ingress_http",
                   "useRemoteAddress":false,
                   "xffNumTrustedHops":2
@@ -830,7 +842,11 @@ func TestFetchListeners(t *testing.T) {
                         }
                      ]
                   },
-                  "upgradeConfigs":[{"upgradeType":"websocket"}],
+                  "upgradeConfigs": [
+		     {
+			"upgradeType": "websocket"
+		     }
+		  ],
 		  "statPrefix":"ingress_http",
                   "useRemoteAddress":false,
                   "xffNumTrustedHops":2
@@ -1053,7 +1069,11 @@ func TestFetchListeners(t *testing.T) {
                         }
                      ]
                   },
-                  "upgradeConfigs":[{"upgradeType":"websocket"}],
+                  "upgradeConfigs": [
+		     {
+			"upgradeType": "websocket"
+		     }
+		  ],
 		  "statPrefix":"ingress_http",
                   "useRemoteAddress":false,
                   "xffNumTrustedHops":2
@@ -1240,7 +1260,11 @@ func TestFetchListeners(t *testing.T) {
                         }
                      ]
                   },
-                  "upgradeConfigs":[{"upgradeType":"websocket"}],
+                  "upgradeConfigs": [
+		     {
+			"upgradeType": "websocket"
+		     }
+		  ],
 		  "statPrefix":"ingress_http",
                   "useRemoteAddress":false,
                   "xffNumTrustedHops":2
@@ -1405,7 +1429,11 @@ func TestFetchListeners(t *testing.T) {
                         }
                      ]
                   },
-                  "upgradeConfigs":[{"upgradeType":"websocket"}],
+                  "upgradeConfigs": [
+		     {
+			"upgradeType": "websocket"
+		     }
+		  ],
 		  "statPrefix":"ingress_http",
                   "tracing":{
 

--- a/src/go/configmanager/config_manager_test.go
+++ b/src/go/configmanager/config_manager_test.go
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-//
+///
 //     http://www.apache.org/licenses/LICENSE-2.0 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -194,7 +194,8 @@ func TestFetchListeners(t *testing.T) {
                         }
                      ]
                   },
-                  "statPrefix":"ingress_http",
+		  "upgradeConfigs":[{"upgradeType":"websocket"}],
+		  "statPrefix":"ingress_http",
                   "useRemoteAddress":false,
                   "xffNumTrustedHops":2
                }
@@ -371,7 +372,8 @@ func TestFetchListeners(t *testing.T) {
                         }
                      ]
                   },
-                  "statPrefix":"ingress_http",
+                  "upgradeConfigs":[{"upgradeType":"websocket"}],
+		  "statPrefix":"ingress_http",
                   "useRemoteAddress":false,
                   "xffNumTrustedHops":2
                }
@@ -581,7 +583,8 @@ func TestFetchListeners(t *testing.T) {
                         }
                      ]
                   },
-                  "statPrefix":"ingress_http",
+                  "upgradeConfigs":[{"upgradeType":"websocket"}],
+		  "statPrefix":"ingress_http",
                   "useRemoteAddress":false,
                   "xffNumTrustedHops":2
                }
@@ -827,7 +830,8 @@ func TestFetchListeners(t *testing.T) {
                         }
                      ]
                   },
-                  "statPrefix":"ingress_http",
+                  "upgradeConfigs":[{"upgradeType":"websocket"}],
+		  "statPrefix":"ingress_http",
                   "useRemoteAddress":false,
                   "xffNumTrustedHops":2
                }
@@ -1049,7 +1053,8 @@ func TestFetchListeners(t *testing.T) {
                         }
                      ]
                   },
-                  "statPrefix":"ingress_http",
+                  "upgradeConfigs":[{"upgradeType":"websocket"}],
+		  "statPrefix":"ingress_http",
                   "useRemoteAddress":false,
                   "xffNumTrustedHops":2
                }
@@ -1235,7 +1240,8 @@ func TestFetchListeners(t *testing.T) {
                         }
                      ]
                   },
-                  "statPrefix":"ingress_http",
+                  "upgradeConfigs":[{"upgradeType":"websocket"}],
+		  "statPrefix":"ingress_http",
                   "useRemoteAddress":false,
                   "xffNumTrustedHops":2
                }
@@ -1399,7 +1405,8 @@ func TestFetchListeners(t *testing.T) {
                         }
                      ]
                   },
-                  "statPrefix":"ingress_http",
+                  "upgradeConfigs":[{"upgradeType":"websocket"}],
+		  "statPrefix":"ingress_http",
                   "tracing":{
 
                   },

--- a/src/go/configmanager/config_manager_test.go
+++ b/src/go/configmanager/config_manager_test.go
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-///
+//
 //     http://www.apache.org/licenses/LICENSE-2.0 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/go/configmanager/config_manager_test.go
+++ b/src/go/configmanager/config_manager_test.go
@@ -194,12 +194,8 @@ func TestFetchListeners(t *testing.T) {
                         }
                      ]
                   },
-		  "upgradeConfigs": [
-		     {
-		       "upgradeType": "websocket"
-	             }
-		  ],
-		  "statPrefix":"ingress_http",
+                  "upgradeConfigs": [{"upgradeType": "websocket"}],
+                  "statPrefix":"ingress_http",
                   "useRemoteAddress":false,
                   "xffNumTrustedHops":2
                }
@@ -376,12 +372,8 @@ func TestFetchListeners(t *testing.T) {
                         }
                      ]
                   },
-                  "upgradeConfigs": [
-		     {
-			"upgradeType": "websocket"
-		     }
-		  ],
-		  "statPrefix":"ingress_http",
+                  "upgradeConfigs": [{"upgradeType": "websocket"}],
+                  "statPrefix":"ingress_http",
                   "useRemoteAddress":false,
                   "xffNumTrustedHops":2
                }
@@ -591,12 +583,8 @@ func TestFetchListeners(t *testing.T) {
                         }
                      ]
                   },
-                  "upgradeConfigs": [
-		     {
-			"upgradeType": "websocket"
-		     }
-		  ],
-		  "statPrefix":"ingress_http",
+                  "upgradeConfigs": [{"upgradeType": "websocket"}],
+                  "statPrefix":"ingress_http",
                   "useRemoteAddress":false,
                   "xffNumTrustedHops":2
                }
@@ -842,12 +830,8 @@ func TestFetchListeners(t *testing.T) {
                         }
                      ]
                   },
-                  "upgradeConfigs": [
-		     {
-			"upgradeType": "websocket"
-		     }
-		  ],
-		  "statPrefix":"ingress_http",
+                  "upgradeConfigs": [{"upgradeType": "websocket"}],
+                  "statPrefix":"ingress_http",
                   "useRemoteAddress":false,
                   "xffNumTrustedHops":2
                }
@@ -1069,12 +1053,8 @@ func TestFetchListeners(t *testing.T) {
                         }
                      ]
                   },
-                  "upgradeConfigs": [
-		     {
-			"upgradeType": "websocket"
-		     }
-		  ],
-		  "statPrefix":"ingress_http",
+                  "upgradeConfigs": [{"upgradeType": "websocket"}],
+                  "statPrefix":"ingress_http",
                   "useRemoteAddress":false,
                   "xffNumTrustedHops":2
                }
@@ -1260,12 +1240,8 @@ func TestFetchListeners(t *testing.T) {
                         }
                      ]
                   },
-                  "upgradeConfigs": [
-		     {
-			"upgradeType": "websocket"
-		     }
-		  ],
-		  "statPrefix":"ingress_http",
+                  "upgradeConfigs": [{"upgradeType": "websocket"}],
+                  "statPrefix":"ingress_http",
                   "useRemoteAddress":false,
                   "xffNumTrustedHops":2
                }
@@ -1429,12 +1405,8 @@ func TestFetchListeners(t *testing.T) {
                         }
                      ]
                   },
-                  "upgradeConfigs": [
-		     {
-			"upgradeType": "websocket"
-		     }
-		  ],
-		  "statPrefix":"ingress_http",
+                  "upgradeConfigs": [{"upgradeType": "websocket"}],
+                  "statPrefix":"ingress_http",
                   "tracing":{
 
                   },

--- a/src/go/configmanager/testdata/fake_data_for_dynamic_routing.go
+++ b/src/go/configmanager/testdata/fake_data_for_dynamic_routing.go
@@ -459,7 +459,8 @@ var (
                         }
                      ]
                   },
-                  "statPrefix":"ingress_http",
+                  "upgradeConfigs":[{"upgradeType":"websocket"}],
+		  "statPrefix":"ingress_http",
                   "useRemoteAddress":false,
                   "xffNumTrustedHops":2
                }

--- a/src/go/configmanager/testdata/fake_data_for_dynamic_routing.go
+++ b/src/go/configmanager/testdata/fake_data_for_dynamic_routing.go
@@ -459,12 +459,8 @@ var (
                         }
                      ]
                   },
-                  "upgradeConfigs": [
-		     {
-			"upgradeType": "websocket"
-		     }
-		  ],
-		  "statPrefix":"ingress_http",
+                  "upgradeConfigs": [{"upgradeType": "websocket"}],
+                  "statPrefix":"ingress_http",
                   "useRemoteAddress":false,
                   "xffNumTrustedHops":2
                }

--- a/src/go/configmanager/testdata/fake_data_for_dynamic_routing.go
+++ b/src/go/configmanager/testdata/fake_data_for_dynamic_routing.go
@@ -459,7 +459,11 @@ var (
                         }
                      ]
                   },
-                  "upgradeConfigs":[{"upgradeType":"websocket"}],
+                  "upgradeConfigs": [
+		     {
+			"upgradeType": "websocket"
+		     }
+		  ],
 		  "statPrefix":"ingress_http",
                   "useRemoteAddress":false,
                   "xffNumTrustedHops":2

--- a/tests/endpoints/echo/client/client.go
+++ b/tests/endpoints/echo/client/client.go
@@ -263,11 +263,11 @@ func DoWS(address, path, reqMsg string) ([]byte, error) {
 	for i := 0; i < messageCount; i++ {
 		err = c.WriteMessage(websocket.TextMessage, []byte(reqMsg))
 		if err != nil {
-			return nil, fmt.Errorf("write error :", err)
+			return nil, err
 		}
 		_, respMsg, err := c.ReadMessage()
 		if err != nil {
-			return nil, fmt.Errorf("read error :", err)
+			return nil, err
 		}
 		resp = append(resp, respMsg...)
 	}

--- a/tests/endpoints/echo/client/client.go
+++ b/tests/endpoints/echo/client/client.go
@@ -250,8 +250,7 @@ func DoHttpsGet(url string, httpVersion int, certPath string) (http.Header, []by
 	return resp.Header, body, err
 }
 
-func DoWS(address, path, reqMsg string) ([]byte, error) {
-	messageCount := 5
+func DoWS(address, path, reqMsg string, messageCount int) ([]byte, error) {
 	var resp []byte
 	u := url.URL{Scheme: "ws", Host: address, Path: path}
 	c, _, err := websocket.DefaultDialer.Dial(u.String(), nil)

--- a/tests/endpoints/echo/client/client.go
+++ b/tests/endpoints/echo/client/client.go
@@ -22,9 +22,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/testdata"
+	"github.com/gorilla/websocket"
 	"golang.org/x/net/http2"
 	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/jws"
@@ -246,4 +248,29 @@ func DoHttpsGet(url string, httpVersion int, certPath string) (http.Header, []by
 		return nil, nil, fmt.Errorf("http response status is not 200 OK: %s, %s", resp.Status, string(body))
 	}
 	return resp.Header, body, err
+}
+
+func DoWS(address, path, reqMsg string) ([]byte, error) {
+	messageCount := 5
+	var resp []byte
+	u := url.URL{Scheme: "ws", Host: address, Path: path}
+	c, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer c.Close()
+
+	for i := 0; i < messageCount; i++ {
+		err = c.WriteMessage(websocket.TextMessage, []byte(reqMsg))
+		if err != nil {
+			return nil, fmt.Errorf("write error :", err)
+		}
+		_, respMsg, err := c.ReadMessage()
+		if err != nil {
+			return nil, fmt.Errorf("read error :", err)
+		}
+		resp = append(resp, respMsg...)
+	}
+
+	return resp, nil
 }

--- a/tests/endpoints/echo/server/app.go
+++ b/tests/endpoints/echo/server/app.go
@@ -51,7 +51,7 @@ func main() {
 
 	r.Path("/echo").Methods("POST").
 		HandlerFunc(echoHandler)
-	r.Path("/duplexecho").HandlerFunc(duplexEchoHandler)
+	r.Path("/websocketecho").HandlerFunc(websocketEchoHandler)
 	r.Path("/echo/nokey").Methods("POST").
 		HandlerFunc(echoHandler)
 	r.Path("/echo/nokey/OverrideAsGet").Methods("POST").
@@ -179,8 +179,8 @@ func echoHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(b)
 }
 
-// duplexEchoHandler handles duplex echo request through webstocket
-func duplexEchoHandler(w http.ResponseWriter, r *http.Request) {
+// websocketEchoHandler handles echo request through webstocket
+func websocketEchoHandler(w http.ResponseWriter, r *http.Request) {
 	c, err := webSocketUpgrader.Upgrade(w, r, nil)
 	if err != nil {
 		errorf(w, http.StatusInternalServerError, "websocket upgrade failed: %v", err)

--- a/tests/endpoints/echo/server/app.go
+++ b/tests/endpoints/echo/server/app.go
@@ -30,6 +30,7 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/golang/glog"
 	"github.com/gorilla/mux"
+	"github.com/gorilla/websocket"
 )
 
 var (
@@ -40,6 +41,7 @@ var (
 	enableRootPathHandler = flag.Bool("enable_root_path_handler", false, "true for adding root path for dynamic routing handler")
 	httpsCertPath         = flag.String("https_cert_path", "", "path for HTTPS cert path")
 	httpsKeyPath          = flag.String("https_key_path", "", "path for HTTPS key path")
+	webSocketUpgrader     = websocket.Upgrader{}
 )
 
 func main() {
@@ -49,6 +51,7 @@ func main() {
 
 	r.Path("/echo").Methods("POST").
 		HandlerFunc(echoHandler)
+	r.Path("/duplexecho").HandlerFunc(duplexEchoHandler)
 	r.Path("/echo/nokey").Methods("POST").
 		HandlerFunc(echoHandler)
 	r.Path("/echo/nokey/OverrideAsGet").Methods("POST").
@@ -174,6 +177,29 @@ func echoHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	w.Write(b)
+}
+
+// duplexEchoHandler handles duplex echo request through webstocket
+func duplexEchoHandler(w http.ResponseWriter, r *http.Request) {
+	c, err := webSocketUpgrader.Upgrade(w, r, nil)
+	if err != nil {
+		errorf(w, http.StatusInternalServerError, "websocket upgrade failed: %v", err)
+		return
+	}
+	defer c.Close()
+	for {
+		mt, message, err := c.ReadMessage()
+		if err != nil {
+			errorf(w, http.StatusInternalServerError, "websocket read failed: %v", err)
+			break
+		}
+		log.Printf("recv: %s", message)
+		err = c.WriteMessage(mt, message)
+		if err != nil {
+			errorf(w, http.StatusInternalServerError, "websocket write failed: %v", err)
+			break
+		}
+	}
 }
 
 // dynamicEoutingHandler reads URL from request header, and writes it back out.

--- a/tests/env/components/ports.go
+++ b/tests/env/components/ports.go
@@ -121,6 +121,7 @@ const (
 	TestTranscodingPrintOptions
 	TestTranscodingErrors
 	TestTranscodingServiceUnavailableError
+	TestWebsocket
 	// The number of total tests. has to be the last one.
 	maxTestNum
 )

--- a/tests/env/testdata/fake_echo_service_config.go
+++ b/tests/env/testdata/fake_echo_service_config.go
@@ -42,7 +42,7 @@ var (
 						ResponseTypeUrl: "type.googleapis.com/EchoMessage",
 					},
 					{
-						Name:            "DuplexEcho",
+						Name:            "WebsocketEcho",
 						RequestTypeUrl:  "type.googleapis.com/EchoRequest",
 						ResponseTypeUrl: "type.googleapis.com/EchoMessage",
 					},
@@ -82,9 +82,9 @@ var (
 					Body: "message",
 				},
 				{
-					Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.DuplexEcho",
+					Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.WebsocketEcho",
 					Pattern: &annotationspb.HttpRule_Get{
-						Get: "/duplexecho",
+						Get: "/websocketecho",
 					},
 				},
 				{
@@ -197,7 +197,7 @@ var (
 					AllowUnregisteredCalls: true,
 				},
 				{
-					Selector:               "1.echo_api_endpoints_cloudesf_testing_cloud_goog.DuplexEcho",
+					Selector:               "1.echo_api_endpoints_cloudesf_testing_cloud_goog.WebsocketEcho",
 					AllowUnregisteredCalls: true,
 				},
 			},

--- a/tests/env/testdata/fake_echo_service_config.go
+++ b/tests/env/testdata/fake_echo_service_config.go
@@ -42,6 +42,11 @@ var (
 						ResponseTypeUrl: "type.googleapis.com/EchoMessage",
 					},
 					{
+						Name:            "DuplexEcho",
+						RequestTypeUrl:  "type.googleapis.com/EchoRequest",
+						ResponseTypeUrl: "type.googleapis.com/EchoMessage",
+					},
+					{
 						Name:            "Simplegetcors",
 						RequestTypeUrl:  "type.googleapis.com/google.protobuf.Empty",
 						ResponseTypeUrl: "type.googleapis.com/SimpleCorsMessage",
@@ -75,6 +80,12 @@ var (
 						Post: "/echo",
 					},
 					Body: "message",
+				},
+				{
+					Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.DuplexEcho",
+					Pattern: &annotationspb.HttpRule_Get{
+						Get: "/duplexecho",
+					},
 				},
 				{
 					Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Root",
@@ -183,6 +194,10 @@ var (
 				},
 				{
 					Selector:               "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Sleep",
+					AllowUnregisteredCalls: true,
+				},
+				{
+					Selector:               "1.echo_api_endpoints_cloudesf_testing_cloud_goog.DuplexEcho",
 					AllowUnregisteredCalls: true,
 				},
 			},

--- a/tests/integration_test/websocket_test.go
+++ b/tests/integration_test/websocket_test.go
@@ -36,16 +36,18 @@ func TestWebsocket(t *testing.T) {
 	}
 
 	testData := []struct {
-		desc     string
-		path     string
-		schema   string
-		wantResp string
+		desc         string
+		path         string
+		messageCount int
+		schema       string
+		wantResp     string
 	}{
 		{
-			desc:     "Websocket call succeed",
-			path:     "/duplexecho",
-			schema:   "ws",
-			wantResp: "hellohellohellohellohello",
+			desc:         "Websocket call succeed",
+			path:         "/websocketecho",
+			schema:       "ws",
+			messageCount: 5,
+			wantResp:     "hellohellohellohellohello",
 		},
 		{
 			desc:     "normal http call succeed, not affected by websocket config",
@@ -59,7 +61,7 @@ func TestWebsocket(t *testing.T) {
 		var resp []byte
 		var err error
 		if tc.schema == "ws" {
-			resp, err = client.DoWS(fmt.Sprintf("localhost:%v", s.Ports().ListenerPort), tc.path, "hello")
+			resp, err = client.DoWS(fmt.Sprintf("localhost:%v", s.Ports().ListenerPort), tc.path, "hello", tc.messageCount)
 		} else {
 			resp, err = client.DoPost(fmt.Sprintf("http://localhost:%v%v", s.Ports().ListenerPort, tc.path), "hello")
 		}

--- a/tests/integration_test/websocket_test.go
+++ b/tests/integration_test/websocket_test.go
@@ -1,0 +1,73 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/echo/client"
+	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
+	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
+	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
+
+	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
+)
+
+func TestWebsocket(t *testing.T) {
+	t.Parallel()
+	s := env.NewTestEnv(comp.TestWebsocket, platform.EchoSidecar)
+	defer s.TearDown()
+	if err := s.Setup(utils.CommonArgs()); err != nil {
+		t.Fatalf("fail to setup test env, %v", err)
+	}
+
+	testData := []struct {
+		desc     string
+		path     string
+		schema   string
+		wantResp string
+	}{
+		{
+			desc:     "Websocket call succeed",
+			path:     "/duplexecho",
+			schema:   "ws",
+			wantResp: "hellohellohellohellohello",
+		},
+		{
+			desc:     "normal http call succeed, not affected by websocket config",
+			path:     "/echo?key=api_key",
+			schema:   "http",
+			wantResp: `{"message":"hello"}`,
+		},
+	}
+
+	for _, tc := range testData {
+		var resp []byte
+		var err error
+		if tc.schema == "ws" {
+			resp, err = client.DoWS(fmt.Sprintf("localhost:%v", s.Ports().ListenerPort), tc.path, "hello")
+		} else {
+			resp, err = client.DoPost(fmt.Sprintf("http://localhost:%v%v", s.Ports().ListenerPort, tc.path), "hello")
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(resp), tc.wantResp) {
+			t.Errorf("expected: %s, got: %s", tc.wantResp, string(resp))
+		}
+	}
+}


### PR DESCRIPTION
Note:  
1,    ESPv1 --enable_websocket is not needed for ESPv2, which automatically enable websocket
2,   Still enable it even it has gRPC backend (since we don't know whether there is mutli backend with HTTP)