### PR TITLE
support generate_self_signed_certificate

### DIFF
--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -190,6 +190,14 @@ environment variable or by passing "-k" flag to this script.
         with value "max-age=31536000; includeSubdomains;" is added for all responses from local backend.
         Not valid for remote backends.''')
 
+    parser.add_argument('--generate_self_signed_cert', action='store_true',
+        help='''Generate a self-signed certificate and key at start, then
+        store them in /etc/ssl/endpoints/server.crt and /etc/ssl/endponts/server.key.
+        This is useful when only a random self-sign cert is needed to serve
+        HTTPS requests. Generated certificate will have Common Name
+        "localhost" and valid for 10 years.
+        ''')
+
     parser.add_argument('-z', '--healthz', default=None, help='''Define a
         health checking endpoint on the same ports as the application backend.
         For example, "-z healthz" makes ESPv2 return code 200 for location
@@ -623,6 +631,8 @@ def enforce_conflict_args(args):
         return "Flag --tls_mutual_auth is going to be deprecated, please use --ssl_client_cert_path only."
     if args.ssl_client_root_certs_file and args.enable_grpc_backend_ssl:
         return "Flag --enable_grpc_backend_ssl are going to be deprecated, please use --ssl_client_root_certs_file only."
+    if args.generate_self_signed_cert and args.ssl_server_cert_path:
+         return "Flag --generate_self_signed_cert and --ssl_server_cert_path cannot be used simutaneously."
 
     port_flags = []
     if args.http_port:
@@ -712,6 +722,17 @@ def gen_proxy_config(args):
         proxy_conf.extend(["--ssl_minimum_protocol", args.ssl_protocols[0]])
         proxy_conf.extend(["--ssl_maximum_protocol", args.ssl_protocols[-1]])
 
+    # Generate self-signed cert if needed
+    if args.generate_self_signed_cert:
+        if not os.path.exists("/tmp/ssl/endpoints"):
+            os.makedirs("/tmp/ssl/endpoints")
+        logging.info("Generating self-signed certificate...")
+        os.system(("openssl req -x509 -newkey rsa:2048"
+                   " -keyout /tmp/ssl/endpoints/server.key -nodes"
+                   " -out /tmp/ssl/endpoints/server.crt"
+                   ' -days 3650 -subj "/CN=localhost"'))
+        proxy_conf.extend(["--ssl_server_cert_path", "/tmp/ssl/endpoints"])
+
     if args.enable_strict_transport_security:
             proxy_conf.append("--enable_strict_transport_security")
 
@@ -781,8 +802,6 @@ def gen_proxy_config(args):
 
     if args.transcoding_preserve_proto_field_names:
         proxy_conf.append("--transcoding_preserve_proto_field_names")
-
-
 
     if args.transcoding_ignore_query_parameters:
         proxy_conf.extend(["--transcoding_ignore_query_parameters",
@@ -893,3 +912,4 @@ if __name__ == '__main__':
             if cm_proc:
                os.kill(cm_proc.pid, signal.SIGKILL)
             sys.exit(1)
+

--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -192,7 +192,7 @@ environment variable or by passing "-k" flag to this script.
 
     parser.add_argument('--generate_self_signed_cert', action='store_true',
         help='''Generate a self-signed certificate and key at start, then
-        store them in /etc/ssl/endpoints/server.crt and /etc/ssl/endponts/server.key.
+        store them in /tmp/ssl/endpoints/server.crt and /tmp/ssl/endponts/server.key.
         This is useful when only a random self-sign cert is needed to serve
         HTTPS requests. Generated certificate will have Common Name
         "localhost" and valid for 10 years.

--- a/src/go/configinfo/service_info_test.go
+++ b/src/go/configinfo/service_info_test.go
@@ -487,7 +487,7 @@ func TestProcessTranscodingIgnoredQueryParams(t *testing.T) {
 		fakeServiceConfig                      *confpb.Service
 		transcodingIgnoredQueryParamsFlag      string
 		wantedAllTranscodingIgnoredQueryParams map[string]bool
-		wantedErrorPrefix                            string
+		wantedErrorPrefix                      string
 	}{
 		{
 			desc: "Success. Default jwt locations with transcoding_ignore_query_params flag",

--- a/tests/start_proxy/start_proxy_test.py
+++ b/tests/start_proxy/start_proxy_test.py
@@ -192,6 +192,14 @@ class TestStartProxy(unittest.TestCase):
               '--listener_port', '8080', '--ssl_minimum_protocol',
               'TLSv1.2','--ssl_maximum_protocol','TLSv1.2', '--disable_tracing'
               ]),
+            (['-R=managed','--listener_port=8080',  '--disable_tracing',
+              '--generate_self_signed_cert'],
+             ['bin/configmanager', '--logtostderr',
+              '--backend_address', 'http://127.0.0.1:8082',
+              '--rollout_strategy', 'managed', '--v', '0',
+              '--listener_port', '8080', '--ssl_server_cert_path',
+              '/tmp/ssl/endpoints', '--disable_tracing'
+              ]),
             # http2_port specified.
             (['-R=managed',
               '--http2_port=8079', '--service_control_quota_retries=3',
@@ -336,6 +344,7 @@ class TestStartProxy(unittest.TestCase):
             ['--http_port=80', '--http2_port=80'],
             ['--http_port=80', '--listener_port=80'],
             ['--ssl_server_cert_path=/etc/endpoint/ssl', '--ssl_port=443'],
+            ['--ssl_server_cert_path=/etc/endpoint/ssl', '--generate_self_signed_cert'],
             ['--ssl_client_cert_path=/etc/endpoint/ssl', '--tls_mutual_auth'],
             ['--ssl_protocols=TLSv1.3',  '--ssl_minimum_protocol=TLSv1.1'],
             ['--ssl_minimum_protocol=TLSv11'],
@@ -377,3 +386,4 @@ class TestStartProxy(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+


### PR DESCRIPTION
1,   Put the cert/key under /tmp/, since /etc/ usually requires permission
2,  Don't install openssl by default, which may increase image size