### PR TITLE
Apply retry and network_fail_open for failed server response properly

### DIFF
--- a/src/envoy/http/service_control/client_cache.cc
+++ b/src/envoy/http/service_control/client_cache.cc
@@ -315,6 +315,9 @@ CancelFunc ClientCache::callCheck(
           // All 5xx server error codes have been mapped to Code::UNAVAILABLE.
           // network_fail_open only applies to 5xx server error codes.
           if (network_fail_open_ && status.error_code() == Code::UNAVAILABLE) {
+            ENVOY_LOG(debug,
+                      "service control check fails, but the request is allowed "
+                      "due to network_fail_open policy.");
             on_done(Status::OK, response_info);
           } else {
             on_done(status, response_info);

--- a/src/envoy/http/service_control/client_cache.cc
+++ b/src/envoy/http/service_control/client_cache.cc
@@ -300,24 +300,29 @@ CancelFunc ClientCache::callCheck(
                   "Service Control cache query: Check");
 
   auto* response = new CheckResponse;
-  client_->Check(request, response,
-                 [this, response, on_done](const Status& status) {
-                   CheckResponseInfo response_info;
-                   if (status.ok()) {
-                     Status converted_status = ::espv2::api_proxy::
-                         service_control::RequestBuilder::ConvertCheckResponse(
-                             *response, config_.service_name(), &response_info);
-                     on_done(converted_status, response_info);
-                   } else {
-                     if (network_fail_open_) {
-                       on_done(Status::OK, response_info);
-                     } else {
-                       on_done(status, response_info);
-                     }
-                   }
-                   delete response;
-                 },
-                 check_transport);
+  client_->Check(
+      request, response,
+      [this, response, on_done](const Status& status) {
+        CheckResponseInfo response_info;
+        if (status.ok()) {
+          Status converted_status = ::espv2::api_proxy::service_control::
+              RequestBuilder::ConvertCheckResponse(
+                  *response, config_.service_name(), &response_info);
+          on_done(converted_status, response_info);
+        } else {
+          // Envoy::Grpc::httpToGrpcStatus() is called at http_call.cc at
+          // HttpCallImpl::onSuccess to map http_code to grpc_code.
+          // All 5xx server error codes have been mapped to Code::UNAVAILABLE.
+          // network_fail_open only applies to 5xx server error codes.
+          if (network_fail_open_ && status.error_code() == Code::UNAVAILABLE) {
+            on_done(Status::OK, response_info);
+          } else {
+            on_done(status, response_info);
+          }
+        }
+        delete response;
+      },
+      check_transport);
   return cancel_fn;
 }
 

--- a/src/envoy/http/service_control/http_call.cc
+++ b/src/envoy/http/service_control/http_call.cc
@@ -96,14 +96,15 @@ class HttpCallImpl : public HttpCall,
                   body);
         on_done_(Status::OK, body);
       } else {
+        ENVOY_LOG(debug, "http call response status code: {}, body: {}",
+                  status_code, body);
+
         if (attemptRetry(status_code)) {
           return;
         }
 
-        ENVOY_LOG(debug, "http call response status code: {}, body: {}",
-                  status_code, body);
-        std::string error_msg =
-            absl::StrCat("Calling ServiceControl failed with: ", status_code);
+        std::string error_msg = absl::StrCat(
+            "Calling Google Service Control API failed with: ", status_code);
         if (!body.empty()) {
           error_msg += absl::StrCat(" and body: " + body);
         }

--- a/src/envoy/http/service_control/http_call_test.cc
+++ b/src/envoy/http/service_control/http_call_test.cc
@@ -196,7 +196,8 @@ TEST_F(HttpCallTest, TestSingleCallSuccessHttpNotFound) {
   EXPECT_CALL(*mock_child_span, finishSpan()).Times(1);
   EXPECT_CALL(
       mock_done_fn_,
-      Call(Status(Code::UNAVAILABLE, "Calling ServiceControl failed with: 503"),
+      Call(Status(Code::UNAVAILABLE,
+                  "Calling Google Service Control API failed with: 503"),
            _))
       .Times(1);
 
@@ -353,7 +354,8 @@ TEST_F(HttpCallTest, TestThreeRetriesWithLastFailure) {
   EXPECT_CALL(*mock_child_span_3, finishSpan()).Times(1);
   EXPECT_CALL(
       mock_done_fn_,
-      Call(Status(Code::UNAVAILABLE, "Calling ServiceControl failed with: 504"),
+      Call(Status(Code::UNAVAILABLE,
+                  "Calling Google Service Control API failed with: 504"),
            _))
       .Times(1);
   async_callbacks_[2]->onSuccess(makeResponseWithStatus(504));

--- a/src/envoy/http/service_control/http_call_test.cc
+++ b/src/envoy/http/service_control/http_call_test.cc
@@ -194,8 +194,10 @@ TEST_F(HttpCallTest, TestSingleCallSuccessHttpNotFound) {
 
   // Phase 2: Emulate successful http response, but a bad status code
   EXPECT_CALL(*mock_child_span, finishSpan()).Times(1);
-  EXPECT_CALL(mock_done_fn_,
-              Call(Status(Code::INTERNAL, "Failed to call service control"), _))
+  EXPECT_CALL(
+      mock_done_fn_,
+      Call(Status(Code::UNAVAILABLE, "Calling ServiceControl failed with: 503"),
+           _))
       .Times(1);
 
   async_callbacks_[0]->onSuccess(makeResponseWithStatus(503));
@@ -349,8 +351,10 @@ TEST_F(HttpCallTest, TestThreeRetriesWithLastFailure) {
 
   // Phase 4: Emulate successful http response on last retry
   EXPECT_CALL(*mock_child_span_3, finishSpan()).Times(1);
-  EXPECT_CALL(mock_done_fn_,
-              Call(Status(Code::INTERNAL, "Failed to call service control"), _))
+  EXPECT_CALL(
+      mock_done_fn_,
+      Call(Status(Code::UNAVAILABLE, "Calling ServiceControl failed with: 504"),
+           _))
       .Times(1);
   async_callbacks_[2]->onSuccess(makeResponseWithStatus(504));
 }

--- a/tests/env/components/ports.go
+++ b/tests/env/components/ports.go
@@ -87,6 +87,7 @@ const (
 	TestServiceControlCache
 	TestServiceControlCheckError
 	TestServiceControlCheckRetry
+	TestServiceControlCheckServerFail
 	TestServiceControlCheckTimeout
 	TestServiceControlCheckTracesWithRetry
 	TestServiceControlCheckWrongServerName

--- a/tests/integration_test/service_control_check_network_fail_test.go
+++ b/tests/integration_test/service_control_check_network_fail_test.go
@@ -52,7 +52,7 @@ func TestServiceControlCheckNetworkFail(t *testing.T) {
 			method:            "/v1/shelves/100?key=api-key-1",
 			serviceControlURL: "http://unavaliable_service_control_server_name",
 			allocatedPort:     comp.TestServiceControlCheckWrongServerName,
-			wantError:         "503 Service Unavailable, UNAVAILABLE:Calling ServiceControl failed with: 503",
+			wantError:         "503 Service Unavailable, UNAVAILABLE:Calling Google Service Control API failed with: 503",
 		},
 		{
 			desc:              "Failed. When the service control is not set up, the request will be rejected by 500 Internal Server Error",
@@ -61,7 +61,7 @@ func TestServiceControlCheckNetworkFail(t *testing.T) {
 			method:            "/v1/shelves/100?key=api-key-2",
 			serviceControlURL: "http://localhost:28753",
 			allocatedPort:     comp.TestServiceControlCheckWrongServerName,
-			wantError:         "503 Service Unavailable, UNAVAILABLE:Calling ServiceControl failed with: 503",
+			wantError:         "503 Service Unavailable, UNAVAILABLE:Calling Google Service Control API failed with: 503",
 		},
 	}
 
@@ -128,7 +128,7 @@ func TestServiceControlCheckTimeout(t *testing.T) {
 		clientProtocol: "http",
 		httpMethod:     "GET",
 		method:         "/v1/shelves/100?key=api-key-2",
-		wantError:      "503 Service Unavailable, UNAVAILABLE:Calling ServiceControl failed with: 503",
+		wantError:      "503 Service Unavailable, UNAVAILABLE:Calling Google Service Control API failed with: 503",
 	}
 
 	s.ServiceControlServer.ResetRequestCount()
@@ -189,7 +189,7 @@ func TestServiceControlNetworkFailFlag(t *testing.T) {
 			httpMethod:      "GET",
 			method:          "/v1/shelves?key=api-key",
 			token:           testdata.FakeCloudTokenMultiAudiences,
-			wantError:       "503 Service Unavailable, UNAVAILABLE:Calling ServiceControl failed with: 504",
+			wantError:       "503 Service Unavailable, UNAVAILABLE:Calling Google Service Control API failed with: 504",
 		},
 	}
 

--- a/tests/integration_test/service_control_check_network_fail_test.go
+++ b/tests/integration_test/service_control_check_network_fail_test.go
@@ -52,7 +52,7 @@ func TestServiceControlCheckNetworkFail(t *testing.T) {
 			method:            "/v1/shelves/100?key=api-key-1",
 			serviceControlURL: "http://unavaliable_service_control_server_name",
 			allocatedPort:     comp.TestServiceControlCheckWrongServerName,
-			wantError:         "500 Internal Server Error, INTERNAL:Failed to call service control",
+			wantError:         "503 Service Unavailable, UNAVAILABLE:Calling ServiceControl failed with: 503",
 		},
 		{
 			desc:              "Failed. When the service control is not set up, the request will be rejected by 500 Internal Server Error",
@@ -61,7 +61,7 @@ func TestServiceControlCheckNetworkFail(t *testing.T) {
 			method:            "/v1/shelves/100?key=api-key-2",
 			serviceControlURL: "http://localhost:28753",
 			allocatedPort:     comp.TestServiceControlCheckWrongServerName,
-			wantError:         "500 Internal Server Error, INTERNAL:Failed to call service control",
+			wantError:         "503 Service Unavailable, UNAVAILABLE:Calling ServiceControl failed with: 503",
 		},
 	}
 
@@ -128,7 +128,7 @@ func TestServiceControlCheckTimeout(t *testing.T) {
 		clientProtocol: "http",
 		httpMethod:     "GET",
 		method:         "/v1/shelves/100?key=api-key-2",
-		wantError:      "500 Internal Server Error, INTERNAL:Failed to call service control",
+		wantError:      "503 Service Unavailable, UNAVAILABLE:Calling ServiceControl failed with: 503",
 	}
 
 	s.ServiceControlServer.ResetRequestCount()
@@ -189,7 +189,7 @@ func TestServiceControlNetworkFailFlag(t *testing.T) {
 			httpMethod:      "GET",
 			method:          "/v1/shelves?key=api-key",
 			token:           testdata.FakeCloudTokenMultiAudiences,
-			wantError:       "500 Internal Server Error, INTERNAL:Failed to call service control",
+			wantError:       "503 Service Unavailable, UNAVAILABLE:Calling ServiceControl failed with: 504",
 		},
 	}
 

--- a/tests/integration_test/service_control_check_server_fail_test.go
+++ b/tests/integration_test/service_control_check_server_fail_test.go
@@ -1,0 +1,130 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
+	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
+
+	bsclient "github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/bookstore_grpc/client"
+	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
+)
+
+type localServiceHandler struct {
+	m          *comp.MockServiceCtrl
+	retryCount int
+	respCode   int
+	respBody   string
+}
+
+func (h *localServiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.retryCount++
+	http.Error(w, h.respBody, h.respCode)
+}
+
+func TestServiceControlNetworkFailFlag(t *testing.T) {
+	t.Parallel()
+
+	serviceName := "bookstore-service"
+	configID := "test-config-id"
+	args := []string{"--service=" + serviceName, "--service_config_id=" + configID,
+		"--rollout_strategy=fixed"}
+
+	tests := []struct {
+		desc            string
+		networkFailOpen bool
+		method          string
+		respCode        int
+		respBody        string
+		wantRetry       int
+		wantResp        string
+		wantError       string
+	}{
+		{
+			desc:            "Failed, 403 check error should not retry and fail_open is false.",
+			networkFailOpen: false,
+			method:          "/v1/shelves/100/books?key=api-key",
+			respCode:        403,
+			respBody:        "service control service is not enabled",
+			wantRetry:       1,
+			wantError:       "403 Forbidden, PERMISSION_DENIED:Calling ServiceControl failed with: 403 and body: service control service is not enabled",
+		},
+		{
+			desc:            "Failed, 403 check error should not retry and fail_open should not apply.",
+			networkFailOpen: true,
+			method:          "/v1/shelves/100/books?key=api-key",
+			respCode:        403,
+			respBody:        "service control service is not enabled",
+			wantRetry:       1,
+			wantError:       "403 Forbidden, PERMISSION_DENIED:Calling ServiceControl failed with: 403 and body: service control service is not enabled",
+		},
+		{
+			desc:            "Failed, 503 check error should retry and fail_open is false.",
+			networkFailOpen: false,
+			method:          "/v1/shelves/100/books?key=api-key",
+			respCode:        503,
+			respBody:        "gateway error",
+			wantRetry:       4,
+			wantError:       "503 Service Unavailable, UNAVAILABLE:Calling ServiceControl failed with: 503 and body: gateway error",
+		},
+		{
+			desc:            "Success, 503 check error should retry and fail_open should apply.",
+			networkFailOpen: true,
+			method:          "/v1/shelves/100/books?key=api-key",
+			respCode:        503,
+			respBody:        "gateway error",
+			wantRetry:       4,
+			wantResp:        `{"books":[{"id":"1001","title":"Alphabet"}]}`,
+		},
+	}
+
+	for _, tc := range tests {
+		func() {
+			s := env.NewTestEnv(comp.TestServiceControlCheckServerFail, platform.GrpcBookstoreSidecar)
+			handler := &localServiceHandler{
+				m:        s.ServiceControlServer,
+				respCode: tc.respCode,
+				respBody: tc.respBody,
+			}
+			s.ServiceControlServer.OverrideCheckHandler(handler)
+			if tc.networkFailOpen {
+				s.EnableScNetworkFailOpen()
+			}
+
+			defer s.TearDown()
+			if err := s.Setup(args); err != nil {
+				t.Fatalf("fail to setup test env, %v", err)
+			}
+
+			addr := fmt.Sprintf("localhost:%v", s.Ports().ListenerPort)
+			resp, err := bsclient.MakeCall("http", addr, "GET", tc.method, "", nil)
+
+			if tc.wantRetry != handler.retryCount {
+				t.Errorf("Test (%s): failed, expected retry count: %d, got: %d", tc.desc, tc.wantRetry, handler.retryCount)
+			}
+
+			if tc.wantError != "" && (err == nil || !strings.Contains(err.Error(), tc.wantError)) {
+				t.Errorf("Test (%s): failed, expected err: %v, got: %v", tc.desc, tc.wantError, err)
+			} else if !strings.Contains(resp, tc.wantResp) {
+				t.Errorf("Test (%s): failed, expected: %s, got: %s", tc.desc, tc.wantResp, resp)
+			}
+		}()
+	}
+}

--- a/tests/integration_test/service_control_check_server_fail_test.go
+++ b/tests/integration_test/service_control_check_server_fail_test.go
@@ -27,19 +27,19 @@ import (
 	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 )
 
-type localServiceHandler struct {
+type serverFailCheckHandler struct {
 	m          *comp.MockServiceCtrl
 	retryCount int
 	respCode   int
 	respBody   string
 }
 
-func (h *localServiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (h *serverFailCheckHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.retryCount++
 	http.Error(w, h.respBody, h.respCode)
 }
 
-func TestServiceControlNetworkFailFlag(t *testing.T) {
+func TestServiceControlCheckServerFailFlag(t *testing.T) {
 	t.Parallel()
 
 	serviceName := "bookstore-service"
@@ -98,7 +98,7 @@ func TestServiceControlNetworkFailFlag(t *testing.T) {
 	for _, tc := range tests {
 		func() {
 			s := env.NewTestEnv(comp.TestServiceControlCheckServerFail, platform.GrpcBookstoreSidecar)
-			handler := &localServiceHandler{
+			handler := &serverFailCheckHandler{
 				m:        s.ServiceControlServer,
 				respCode: tc.respCode,
 				respBody: tc.respBody,

--- a/tests/integration_test/service_control_check_server_fail_test.go
+++ b/tests/integration_test/service_control_check_server_fail_test.go
@@ -64,7 +64,7 @@ func TestServiceControlNetworkFailFlag(t *testing.T) {
 			respCode:        403,
 			respBody:        "service control service is not enabled",
 			wantRetry:       1,
-			wantError:       "403 Forbidden, PERMISSION_DENIED:Calling ServiceControl failed with: 403 and body: service control service is not enabled",
+			wantError:       "403 Forbidden, PERMISSION_DENIED:Calling Google Service Control API failed with: 403 and body: service control service is not enabled",
 		},
 		{
 			desc:            "Failed, 403 check error should not retry and fail_open should not apply.",
@@ -73,7 +73,7 @@ func TestServiceControlNetworkFailFlag(t *testing.T) {
 			respCode:        403,
 			respBody:        "service control service is not enabled",
 			wantRetry:       1,
-			wantError:       "403 Forbidden, PERMISSION_DENIED:Calling ServiceControl failed with: 403 and body: service control service is not enabled",
+			wantError:       "403 Forbidden, PERMISSION_DENIED:Calling Google Service Control API failed with: 403 and body: service control service is not enabled",
 		},
 		{
 			desc:            "Failed, 503 check error should retry and fail_open is false.",
@@ -82,7 +82,7 @@ func TestServiceControlNetworkFailFlag(t *testing.T) {
 			respCode:        503,
 			respBody:        "gateway error",
 			wantRetry:       4,
-			wantError:       "503 Service Unavailable, UNAVAILABLE:Calling ServiceControl failed with: 503 and body: gateway error",
+			wantError:       "503 Service Unavailable, UNAVAILABLE:Calling Google Service Control API failed with: 503 and body: gateway error",
 		},
 		{
 			desc:            "Success, 503 check error should retry and fail_open should apply.",

--- a/tests/integration_test/service_control_retry_timeout_test.go
+++ b/tests/integration_test/service_control_retry_timeout_test.go
@@ -67,7 +67,7 @@ func TestServiceControlCheckRetry(t *testing.T) {
 			method:                  "/v1/shelves?key=api-key-0",
 			token:                   testdata.FakeCloudTokenMultiAudiences,
 			wantHandlerRequestCount: 3,
-			wantError:               `500 Internal Server Error, INTERNAL:Failed to call service control`,
+			wantError:               `503 Service Unavailable, UNAVAILABLE:Calling ServiceControl failed with: 504`,
 		},
 		{
 			desc:                    "Backend responsive, the proxy will retry the check request 3 times and get the response in the last request",

--- a/tests/integration_test/service_control_retry_timeout_test.go
+++ b/tests/integration_test/service_control_retry_timeout_test.go
@@ -67,7 +67,7 @@ func TestServiceControlCheckRetry(t *testing.T) {
 			method:                  "/v1/shelves?key=api-key-0",
 			token:                   testdata.FakeCloudTokenMultiAudiences,
 			wantHandlerRequestCount: 3,
-			wantError:               `503 Service Unavailable, UNAVAILABLE:Calling ServiceControl failed with: 504`,
+			wantError:               `503 Service Unavailable, UNAVAILABLE:Calling Google Service Control API failed with: 504`,
 		},
 		{
 			desc:                    "Backend responsive, the proxy will retry the check request 3 times and get the response in the last request",

--- a/tests/integration_test/transport_security_test.go
+++ b/tests/integration_test/transport_security_test.go
@@ -112,7 +112,7 @@ func TestServiceControlWithTLS(t *testing.T) {
 			port:      comp.TestServiceControlTLSWithValidCert,
 			certPath:  platform.GetFilePath(platform.ServerCert),
 			keyPath:   platform.GetFilePath(platform.ServerKey),
-			wantError: "503 Service Unavailable, UNAVAILABLE:Calling ServiceControl failed with: 503",
+			wantError: "503 Service Unavailable, UNAVAILABLE:Calling Google Service Control API failed with: 503",
 		},
 	}
 

--- a/tests/integration_test/transport_security_test.go
+++ b/tests/integration_test/transport_security_test.go
@@ -112,7 +112,7 @@ func TestServiceControlWithTLS(t *testing.T) {
 			port:      comp.TestServiceControlTLSWithValidCert,
 			certPath:  platform.GetFilePath(platform.ServerCert),
 			keyPath:   platform.GetFilePath(platform.ServerKey),
-			wantError: "500 Internal Server Error, INTERNAL:Failed to call service control",
+			wantError: "503 Service Unavailable, UNAVAILABLE:Calling ServiceControl failed with: 503",
 		},
 	}
 


### PR DESCRIPTION
Specifically:
4xx response:  not retry and not to apply network_fail_open policy
5xx response:  apply retry and network_fail_open policy

for b/152387957: 