### PR TITLE
Handle duplicated `snake_names` in filter config

### DIFF
--- a/src/envoy/http/path_matcher/filter_config.h
+++ b/src/envoy/http/path_matcher/filter_config.h
@@ -14,8 +14,8 @@
 
 #pragma once
 
-#include <unordered_map>
-
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
 #include "api/envoy/http/path_matcher/config.pb.h"
 #include "common/common/logger.h"
 #include "envoy/runtime/runtime.h"

--- a/src/envoy/http/path_matcher/filter_config_test.cc
+++ b/src/envoy/http/path_matcher/filter_config_test.cc
@@ -208,6 +208,27 @@ rules {
   EXPECT_TRUE(cfg.getSnakeToJsonMap().empty());
 }
 
+TEST(FilterConfigTest, DuplicatedSegmentSnakeNames) {
+  const char kFilterConfig[] = R"(
+segment_names {
+  json_name: "fooBar"
+  snake_name: "foo_bar"
+}
+segment_names {
+  json_name: "foobar"
+  snake_name: "foo_bar"
+})";
+
+  ::google::api::envoy::http::path_matcher::FilterConfig config_pb;
+  ASSERT_TRUE(TextFormat::ParseFromString(kFilterConfig, &config_pb));
+  ::testing::NiceMock<Envoy::Server::Configuration::MockFactoryContext>
+      mock_factory;
+
+  EXPECT_THROW_WITH_REGEX(
+      FilterConfig cfg(config_pb, Envoy::EMPTY_STRING, mock_factory),
+      Envoy::ProtoValidationException, "Duplicated snake name");
+}
+
 }  // namespace
 }  // namespace path_matcher
 }  // namespace http_filters

--- a/src/envoy/http/path_matcher/filter_config_test.cc
+++ b/src/envoy/http/path_matcher/filter_config_test.cc
@@ -208,7 +208,29 @@ rules {
   EXPECT_TRUE(cfg.getSnakeToJsonMap().empty());
 }
 
-TEST(FilterConfigTest, DuplicatedSegmentSnakeNames) {
+TEST(FilterConfigTest, DuplicatedSegmentNames) {
+  const char kFilterConfig[] = R"(
+segment_names {
+  json_name: "fooBar"
+  snake_name: "foo_bar"
+}
+segment_names {
+  json_name: "fooBar"
+  snake_name: "foo_bar"
+})";
+
+  ::google::api::envoy::http::path_matcher::FilterConfig config_pb;
+  ASSERT_TRUE(TextFormat::ParseFromString(kFilterConfig, &config_pb));
+  ::testing::NiceMock<Envoy::Server::Configuration::MockFactoryContext>
+      mock_factory;
+  FilterConfig cfg(config_pb, Envoy::EMPTY_STRING, mock_factory);
+
+  absl::flat_hash_map<std::string, std::string> expected = {
+      {"foo_bar", "fooBar"}};
+  EXPECT_EQ(cfg.getSnakeToJsonMap(), expected);
+}
+
+TEST(FilterConfigTest, DuplicatedButMismatchingSegmentSnakeNames) {
   const char kFilterConfig[] = R"(
 segment_names {
   json_name: "fooBar"

--- a/src/envoy/http/path_matcher/filter_test.cc
+++ b/src/envoy/http/path_matcher/filter_test.cc
@@ -175,15 +175,14 @@ TEST_F(PathMatcherFilterTest, DecodeHeadersMissingHeaders) {
   Envoy::Http::TestRequestHeaderMapImpl missingMethod{{":path", "/bar"}};
 
   // Filter should reject this request
-  EXPECT_CALL(
-      mock_cb_.stream_info_,
-      setResponseFlag(
-          Envoy::StreamInfo::ResponseFlag::UnauthorizedExternalService))
-          .Times(2);
+  EXPECT_CALL(mock_cb_.stream_info_,
+              setResponseFlag(
+                  Envoy::StreamInfo::ResponseFlag::UnauthorizedExternalService))
+      .Times(2);
 
   EXPECT_EQ(Envoy::Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(missingPath, true));
-    EXPECT_EQ(Envoy::Http::FilterHeadersStatus::StopIteration,
+  EXPECT_EQ(Envoy::Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(missingMethod, true));
 }
 


### PR DESCRIPTION
This should never occur in practice, but guards against users who manually edit the service config or proto JSON mapping.

Signed-off-by: Teju Nareddy <nareddyt@google.com>