### PR TITLE
Remove dead code in `path_matcher`

### DIFF
--- a/src/api_proxy/path_matcher/http_template_test.cc
+++ b/src/api_proxy/path_matcher/http_template_test.cc
@@ -455,7 +455,11 @@ TEST(HttpTemplate, ErrorTests) {
   ASSERT_EQ(nullptr, HttpTemplate::Parse("/:"));
   ASSERT_EQ(nullptr, HttpTemplate::Parse("/*:"));
   ASSERT_EQ(nullptr, HttpTemplate::Parse("/**:"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/{{"));
   ASSERT_EQ(nullptr, HttpTemplate::Parse("/{var}:"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/{var}::"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/{var/a"));
+  ASSERT_EQ(nullptr, HttpTemplate::Parse("/{{var}}"));
 
   ASSERT_EQ(nullptr, HttpTemplate::Parse("/a/b/:"));
   ASSERT_EQ(nullptr, HttpTemplate::Parse("/a/b/*:"));

--- a/src/api_proxy/path_matcher/path_matcher.cc
+++ b/src/api_proxy/path_matcher/path_matcher.cc
@@ -20,37 +20,6 @@ namespace espv2 {
 namespace api_proxy {
 namespace path_matcher {
 
-namespace {
-
-inline bool IsReservedChar(char c) {
-  // Reserved characters according to RFC 6570
-  switch (c) {
-    case '!':
-    case '#':
-    case '$':
-    case '&':
-    case '\'':
-    case '(':
-    case ')':
-    case '*':
-    case '+':
-    case ',':
-    case '/':
-    case ':':
-    case ';':
-    case '=':
-    case '?':
-    case '@':
-    case '[':
-    case ']':
-      return true;
-    default:
-      return false;
-  }
-}
-
-}  // namespace
-
 void ExtractBindingsFromPath(const std::vector<HttpTemplate::Variable>& vars,
                              const std::vector<std::string>& parts,
                              std::vector<VariableBinding>* bindings) {
@@ -66,11 +35,6 @@ void ExtractBindingsFromPath(const std::vector<HttpTemplate::Variable>& vars,
     size_t end_segment = (var.end_segment >= 0)
                              ? var.end_segment
                              : parts.size() + var.end_segment + 1;
-    // It is multi-part match if we have more than one segment. We also make
-    // sure that a single URL segment match with ** is also considered a
-    // multi-part match by checking if it->second.end_segment is negative.
-    bool is_multipart =
-        (end_segment - var.start_segment) > 1 || var.end_segment < 0;
     // Joins parts with "/"  to form a path string.
     for (size_t i = var.start_segment; i < end_segment; ++i) {
       binding.value += parts[i];

--- a/src/api_proxy/path_matcher/path_matcher.h
+++ b/src/api_proxy/path_matcher/path_matcher.h
@@ -141,8 +141,7 @@ class PathMatcherBuilder {
 
 void ExtractBindingsFromPath(const std::vector<HttpTemplate::Variable>& vars,
                              const std::vector<std::string>& parts,
-                             std::vector<VariableBinding>* bindings,
-                             bool keep_binding_escaped);
+                             std::vector<VariableBinding>* bindings);
 
 // Converts a request path into a format that can be used to perform a request
 // lookup in the PathMatcher trie. This utility method sanitizes the request
@@ -195,8 +194,7 @@ Method PathMatcher<Method>::Lookup(
   MethodData* method_data = reinterpret_cast<MethodData*>(lookup_result.data);
   if (variable_bindings != nullptr) {
     variable_bindings->clear();
-    ExtractBindingsFromPath(method_data->variables, parts, variable_bindings,
-                            /*keep_binding_escaped=*/true);
+    ExtractBindingsFromPath(method_data->variables, parts, variable_bindings);
   }
   return method_data->method;
 }


### PR DESCRIPTION
As detected by test coverage reports, these code is never used. Also add a few negative tests.

Signed-off-by: Teju Nareddy <nareddyt@google.com>