### PR TITLE
Handle duplicated `snake_names` in path matcher filter config

### DIFF
--- a/api/envoy/http/path_matcher/config.proto
+++ b/api/envoy/http/path_matcher/config.proto
@@ -46,5 +46,8 @@ message SegmentName {
 
 message FilterConfig {
   repeated PathMatcherRule rules = 1;
+
+  // It is invalid for multiple segments to share the same `snake_name` but have
+  // different `json_name`.
   repeated SegmentName segment_names = 2;
 }

--- a/examples/grpc_dynamic_routing/envoy_config.json
+++ b/examples/grpc_dynamic_routing/envoy_config.json
@@ -318,10 +318,6 @@
                                                         "snakeName": "num_finite_buckets"
                                                     },
                                                     {
-                                                        "jsonName": "numFiniteBuckets",
-                                                        "snakeName": "num_finite_buckets"
-                                                    },
-                                                    {
                                                         "jsonName": "growthFactor",
                                                         "snakeName": "growth_factor"
                                                     },
@@ -334,20 +330,12 @@
                                                         "snakeName": "end_time"
                                                     },
                                                     {
-                                                        "jsonName": "boolValue",
-                                                        "snakeName": "bool_value"
-                                                    },
-                                                    {
                                                         "jsonName": "int64Value",
                                                         "snakeName": "int64_value"
                                                     },
                                                     {
                                                         "jsonName": "doubleValue",
                                                         "snakeName": "double_value"
-                                                    },
-                                                    {
-                                                        "jsonName": "stringValue",
-                                                        "snakeName": "string_value"
                                                     },
                                                     {
                                                         "jsonName": "distributionValue",
@@ -372,14 +360,6 @@
                                                     {
                                                         "jsonName": "consumerId",
                                                         "snakeName": "consumer_id"
-                                                    },
-                                                    {
-                                                        "jsonName": "startTime",
-                                                        "snakeName": "start_time"
-                                                    },
-                                                    {
-                                                        "jsonName": "endTime",
-                                                        "snakeName": "end_time"
                                                     },
                                                     {
                                                         "jsonName": "metricValueSets",

--- a/src/envoy/http/path_matcher/filter_config.cc
+++ b/src/envoy/http/path_matcher/filter_config.cc
@@ -41,6 +41,8 @@ FilterConfig::FilterConfig(
   path_matcher_ = pmb.Build();
 
   for (const auto& segment_name : proto_config_.segment_names()) {
+    // Duplicate snake names with varying json names are disallowed by config
+    // manager.
     snake_to_json_map_.emplace(segment_name.snake_name(),
                                segment_name.json_name());
   }

--- a/src/go/configinfo/service_info_test.go
+++ b/src/go/configinfo/service_info_test.go
@@ -30,8 +30,10 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	"github.com/gorilla/mux"
+	"google.golang.org/genproto/protobuf/ptype"
 
 	commonpb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/http/common"
+	pmpb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/http/path_matcher"
 	scpb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/http/service_control"
 	annotationspb "google.golang.org/genproto/googleapis/api/annotations"
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
@@ -1922,6 +1924,111 @@ func TestProcessApisForGrpc(t *testing.T) {
 			wantApiName := tc.wantApiNames[idx]
 			if gotApiName != wantApiName {
 				t.Errorf("Test Desc(%d): %s,\ngot ApiName: %v,\nwant Apiname: %v", i, tc.desc, gotApiName, wantApiName)
+			}
+		}
+	}
+}
+
+func TestProcessTypes(t *testing.T) {
+	testData := []struct {
+		desc              string
+		fakeServiceConfig *confpb.Service
+		wantSegments      []*pmpb.SegmentName
+		wantErr           error
+	}{
+		{
+			desc: "Success for distinct names",
+			fakeServiceConfig: &confpb.Service{
+				Types: []*ptype.Type{
+					{
+						Fields: []*ptype.Field{
+							{
+								Name:     "foo_bar",
+								JsonName: "fooBar",
+							},
+							{
+								Name:     "x_y",
+								JsonName: "xY",
+							},
+						},
+					},
+				},
+			},
+			wantSegments: []*pmpb.SegmentName{
+				{
+					SnakeName: "foo_bar",
+					JsonName:  "fooBar",
+				},
+				{
+					SnakeName: "x_y",
+					JsonName:  "xY",
+				},
+			},
+		},
+		{
+			desc: "Success for fully duplicated names",
+			fakeServiceConfig: &confpb.Service{
+				Types: []*ptype.Type{
+					{
+						Fields: []*ptype.Field{
+							{
+								Name:     "foo_bar",
+								JsonName: "fooBar",
+							},
+							{
+								Name:     "foo_bar",
+								JsonName: "fooBar",
+							},
+						},
+					},
+				},
+			},
+			wantSegments: []*pmpb.SegmentName{
+				{
+					SnakeName: "foo_bar",
+					JsonName:  "fooBar",
+				},
+				{
+					SnakeName: "foo_bar",
+					JsonName:  "fooBar",
+				},
+			},
+		},
+		{
+			desc: "Failure for duplicated snake_name with mismatching json_name",
+			fakeServiceConfig: &confpb.Service{
+				Types: []*ptype.Type{
+					{
+						Fields: []*ptype.Field{
+							{
+								Name:     "foo_bar",
+								JsonName: "fooBar",
+							},
+							{
+								Name:     "foo_bar",
+								JsonName: "foo-bar",
+							},
+						},
+					},
+				},
+			},
+			wantErr: fmt.Errorf("detected two types with same snake_name (foo_bar) but mistmatching json_name (foo-bar, fooBar)"),
+		},
+	}
+
+	for _, tc := range testData {
+		serviceInfo := &ServiceInfo{
+			serviceConfig: tc.fakeServiceConfig,
+		}
+		err := serviceInfo.ProcessTypes()
+
+		if err != nil {
+			if tc.wantErr == nil || !strings.Contains(err.Error(), tc.wantErr.Error()) {
+				t.Errorf("Test(%v): Expected err (%v), got err (%v)", tc.desc, tc.wantErr, err)
+			}
+		} else {
+			if !reflect.DeepEqual(serviceInfo.SegmentNames, tc.wantSegments) {
+				t.Errorf("Test(%v): Expected segments (%v), got segments (%v)", tc.desc, tc.wantSegments, serviceInfo.SegmentNames)
 			}
 		}
 	}

--- a/src/go/configinfo/service_info_test.go
+++ b/src/go/configinfo/service_info_test.go
@@ -1966,7 +1966,7 @@ func TestProcessTypes(t *testing.T) {
 			},
 		},
 		{
-			desc: "Success for fully duplicated names",
+			desc: "Success for fully duplicated names, which are de-duped",
 			fakeServiceConfig: &confpb.Service{
 				Types: []*ptype.Type{
 					{
@@ -1988,8 +1988,33 @@ func TestProcessTypes(t *testing.T) {
 					SnakeName: "foo_bar",
 					JsonName:  "fooBar",
 				},
+			},
+		},
+		{
+			desc: "Success for duplicated json_name with mismatching snake_name",
+			fakeServiceConfig: &confpb.Service{
+				Types: []*ptype.Type{
+					{
+						Fields: []*ptype.Field{
+							{
+								Name:     "foo_bar",
+								JsonName: "fooBar",
+							},
+							{
+								Name:     "foo___bar",
+								JsonName: "fooBar",
+							},
+						},
+					},
+				},
+			},
+			wantSegments: []*pmpb.SegmentName{
 				{
 					SnakeName: "foo_bar",
+					JsonName:  "fooBar",
+				},
+				{
+					SnakeName: "foo___bar",
 					JsonName:  "fooBar",
 				},
 			},
@@ -2020,7 +2045,7 @@ func TestProcessTypes(t *testing.T) {
 		serviceInfo := &ServiceInfo{
 			serviceConfig: tc.fakeServiceConfig,
 		}
-		err := serviceInfo.ProcessTypes()
+		err := serviceInfo.processTypes()
 
 		if err != nil {
 			if tc.wantErr == nil || !strings.Contains(err.Error(), tc.wantErr.Error()) {

--- a/tests/e2e/scripts/cloud-run/deploy.sh
+++ b/tests/e2e/scripts/cloud-run/deploy.sh
@@ -310,7 +310,7 @@ function test() {
 
   # Wait a few minutes for service to be enabled and the permissions to propagate
   echo "Waiting for the endpoints service to be enabled"
-  sleep 3m
+  sleep 5m
 
   if [[ ${PROXY_PLATFORM} == "anthos-cloud-run" ]];
   then


### PR DESCRIPTION
This should never occur in practice, but guards against users who manually edit the service config or proto JSON mapping.

IMO, the implementation in #111 is cleaner. But this will surface the error message to users quicker.

Also increase wait time on flaky test.

Signed-off-by: Teju Nareddy <nareddyt@google.com>