### PR TITLE
Covert non-5xx sidestream errors to 500 Internal Server Error

### DIFF
--- a/src/envoy/http/service_control/client_cache.cc
+++ b/src/envoy/http/service_control/client_cache.cc
@@ -320,7 +320,12 @@ CancelFunc ClientCache::callCheck(
                       "due to network_fail_open policy.");
             on_done(Status::OK, response_info);
           } else {
-            on_done(status, response_info);
+            // This is not a client request error, so translate non-5xx error
+            // codes to 500 Internal Server Error. Error message contains
+            // details on the original error (including the original HTTP status
+            // code).
+            Status converted(Code::INTERNAL, status.error_message());
+            on_done(converted, response_info);
           }
         }
         delete response;

--- a/tests/integration_test/service_control_check_server_fail_test.go
+++ b/tests/integration_test/service_control_check_server_fail_test.go
@@ -58,22 +58,22 @@ func TestServiceControlCheckServerFailFlag(t *testing.T) {
 		wantError       string
 	}{
 		{
-			desc:            "Failed, 403 check error should not retry and fail_open is false.",
+			desc:            "Failed, 403 check error should not retry and fail_open is false. Non-5xx is translated to 500.",
 			networkFailOpen: false,
 			method:          "/v1/shelves/100/books?key=api-key",
 			respCode:        403,
 			respBody:        "service control service is not enabled",
 			wantRetry:       1,
-			wantError:       "403 Forbidden, PERMISSION_DENIED:Calling Google Service Control API failed with: 403 and body: service control service is not enabled",
+			wantError:       "500 Internal Server Error, PERMISSION_DENIED:Calling Google Service Control API failed with: 403 and body: service control service is not enabled",
 		},
 		{
-			desc:            "Failed, 403 check error should not retry and fail_open should not apply.",
+			desc:            "Failed, 403 check error should not retry and fail_open should not apply. Non-5xx is translated to 500.",
 			networkFailOpen: true,
 			method:          "/v1/shelves/100/books?key=api-key",
 			respCode:        403,
 			respBody:        "service control service is not enabled",
 			wantRetry:       1,
-			wantError:       "403 Forbidden, PERMISSION_DENIED:Calling Google Service Control API failed with: 403 and body: service control service is not enabled",
+			wantError:       "500 Internal Server Error, PERMISSION_DENIED:Calling Google Service Control API failed with: 403 and body: service control service is not enabled",
 		},
 		{
 			desc:            "Failed, 503 check error should retry and fail_open is false.",

--- a/tests/integration_test/service_control_check_server_fail_test.go
+++ b/tests/integration_test/service_control_check_server_fail_test.go
@@ -64,7 +64,7 @@ func TestServiceControlCheckServerFailFlag(t *testing.T) {
 			respCode:        403,
 			respBody:        "service control service is not enabled",
 			wantRetry:       1,
-			wantError:       "500 Internal Server Error, PERMISSION_DENIED:Calling Google Service Control API failed with: 403 and body: service control service is not enabled",
+			wantError:       "500 Internal Server Error, INTERNAL:Calling Google Service Control API failed with: 403 and body: service control service is not enabled",
 		},
 		{
 			desc:            "Failed, 403 check error should not retry and fail_open should not apply. Non-5xx is translated to 500.",
@@ -73,7 +73,7 @@ func TestServiceControlCheckServerFailFlag(t *testing.T) {
 			respCode:        403,
 			respBody:        "service control service is not enabled",
 			wantRetry:       1,
-			wantError:       "500 Internal Server Error, PERMISSION_DENIED:Calling Google Service Control API failed with: 403 and body: service control service is not enabled",
+			wantError:       "500 Internal Server Error, INTERNAL:Calling Google Service Control API failed with: 403 and body: service control service is not enabled",
 		},
 		{
 			desc:            "Failed, 503 check error should retry and fail_open is false.",


### PR DESCRIPTION
This makes it clear that deployment errors (ie: SC Check fail due to permissions) are not caused by the client request.

Signed-off-by: Teju Nareddy <nareddyt@google.com>