### PR TITLE
Only pass Interupt and SIGTERM signals to GCS Runner.

### DIFF
--- a/src/go/gcsrunner/main/runner.go
+++ b/src/go/gcsrunner/main/runner.go
@@ -35,6 +35,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/gcsrunner"
@@ -94,7 +95,7 @@ func main() {
 	}
 
 	signalChan := make(chan os.Signal, 1)
-	signal.Notify(signalChan)
+	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
 
 	if err := gcsrunner.FetchConfigFromGCS(gcsrunner.FetchConfigOptions{
 		BucketName:                    bucketName,


### PR DESCRIPTION
GCS Runner shuts down too much. Cloud Run sends periodic signals to the container, which GCS Runner always interprets as a terminator. This causes Envoy to shut down and the container to restart very often. Instead, only shut down when the container receives an actual termination signal.

TESTED=Manual testing. Feature not covered by automated testing.