### PR TITLE
[Cleanup] Replace `typedef` with `using`

### DIFF
--- a/src/api_proxy/auth/auth_token.cc
+++ b/src/api_proxy/auth/auth_token.cc
@@ -21,7 +21,7 @@
 #include "src/api_proxy/auth/grpc_internals.h"
 
 extern "C" {
-  #include "grpc/support/alloc.h"
+#include "grpc/support/alloc.h"
 };
 
 namespace espv2 {

--- a/src/api_proxy/path_matcher/http_template_test.cc
+++ b/src/api_proxy/path_matcher/http_template_test.cc
@@ -23,10 +23,10 @@ namespace espv2 {
 namespace api_proxy {
 namespace path_matcher {
 
-typedef std::vector<std::string> Segments;
-typedef HttpTemplate::Variable Variable;
-typedef std::vector<Variable> Variables;
-typedef std::vector<std::string> FieldPath;
+using Segments = std::vector<std::string>;
+using Variable = HttpTemplate::Variable;
+using Variables = std::vector<Variable>;
+using FieldPath = std::vector<std::string>;
 
 bool operator==(const Variable& v1, const Variable& v2) {
   return v1.field_path == v2.field_path &&

--- a/src/api_proxy/path_matcher/path_matcher.h
+++ b/src/api_proxy/path_matcher/path_matcher.h
@@ -133,7 +133,7 @@ class PathMatcherBuilder {
   // be multiple templates in different services on a server. Consider moving
   // this to PathMatcherNode.
   std::set<std::string> custom_verbs_;
-  typedef typename PathMatcher<Method>::MethodData MethodData;
+  using MethodData = typename PathMatcher<Method>::MethodData;
   std::vector<std::unique_ptr<MethodData>> methods_;
 
   friend class PathMatcher<Method>;

--- a/src/api_proxy/path_matcher/path_matcher_node.cc
+++ b/src/api_proxy/path_matcher/path_matcher_node.cc
@@ -59,8 +59,8 @@ template <class Collection>
 typename Collection::value_type::second_type& LookupOrInsertNew(
     Collection* const collection,
     const typename Collection::value_type::first_type& key) {
-  typedef typename Collection::value_type::second_type Mapped;
-  typedef typename Mapped::element_type Element;
+  using Mapped = typename Collection::value_type::second_type;
+  using Element = typename Mapped::element_type;
   std::pair<typename Collection::iterator, bool> ret =
       collection->insert(typename Collection::value_type(key, Mapped()));
   if (ret.second) {

--- a/src/api_proxy/path_matcher/path_matcher_node.h
+++ b/src/api_proxy/path_matcher/path_matcher_node.h
@@ -108,7 +108,7 @@ class PathMatcherNode {
     std::vector<std::string> path_;
   };  // class PathInfo
 
-  typedef std::vector<std::string> RequestPathParts;
+  using RequestPathParts = std::vector<std::string>;
 
   // Creates a Root node with an empty WrapperGraph map.
   PathMatcherNode() : result_map_(), children_(), wildcard_(false) {}

--- a/src/api_proxy/path_matcher/path_matcher_node.h
+++ b/src/api_proxy/path_matcher/path_matcher_node.h
@@ -24,7 +24,7 @@ namespace espv2 {
 namespace api_proxy {
 namespace path_matcher {
 
-typedef std::string HttpMethod;
+using HttpMethod = std::string;
 
 struct PathMatcherLookupResult {
   PathMatcherLookupResult() : data(nullptr), is_multiple(false) {}

--- a/src/api_proxy/path_matcher/path_matcher_test.cc
+++ b/src/api_proxy/path_matcher/path_matcher_test.cc
@@ -29,8 +29,8 @@ namespace api_proxy {
 namespace path_matcher {
 namespace {
 
-typedef std::vector<VariableBinding> VariableBindings;
-typedef std::vector<std::string> FieldPath;
+using VariableBindings = std::vector<VariableBinding>;
+using FieldPath = std::vector<std::string>;
 
 class MethodInfo {
  public:

--- a/src/api_proxy/service_control/logs_metrics_loader_test.cc
+++ b/src/api_proxy/service_control/logs_metrics_loader_test.cc
@@ -65,8 +65,8 @@ bool IsMetricSupported(const MetricDescriptor& md) {
                      sizeof(unsupported_prefix) - 1);
 }
 
-typedef std::map<std::string, const LabelDescriptor&> LabelMap;
-typedef std::map<std::string, const MetricDescriptor&> MetricMap;
+using LabelMap = std::map<std::string, const LabelDescriptor&>;
+using MetricMap = std::map<std::string, const MetricDescriptor&>;
 
 }  // namespace
 

--- a/src/envoy/http/backend_auth/config_parser.h
+++ b/src/envoy/http/backend_auth/config_parser.h
@@ -26,7 +26,7 @@ namespace envoy {
 namespace http_filters {
 namespace backend_auth {
 // Use shared_ptr to do atomic token update.
-typedef std::shared_ptr<std::string> TokenSharedPtr;
+using TokenSharedPtr = std::shared_ptr<std::string>;
 
 class FilterConfigParser {
  public:
@@ -38,7 +38,7 @@ class FilterConfigParser {
       absl::string_view audience) const PURE;
 };
 
-typedef std::unique_ptr<FilterConfigParser> FilterConfigParserPtr;
+using FilterConfigParserPtr = std::unique_ptr<FilterConfigParser>;
 
 }  // namespace backend_auth
 }  // namespace http_filters

--- a/src/envoy/http/backend_auth/config_parser_impl.h
+++ b/src/envoy/http/backend_auth/config_parser_impl.h
@@ -55,7 +55,7 @@ class AudienceContext {
   token::TokenSubscriberPtr imds_token_sub_ptr_;
 };
 
-typedef std::unique_ptr<AudienceContext> AudienceContextPtr;
+using AudienceContextPtr = std::unique_ptr<AudienceContext>;
 
 class FilterConfigParserImpl
     : public FilterConfigParser,

--- a/src/envoy/http/backend_auth/filter.cc
+++ b/src/envoy/http/backend_auth/filter.cc
@@ -39,7 +39,7 @@ struct RcDetailsValues {
   // The request is rejected due to missing backend auth token.
   const std::string MissingBackendToken = "missing_backend_token";
 };
-typedef Envoy::ConstSingleton<RcDetailsValues> RcDetails;
+using RcDetails = Envoy::ConstSingleton<RcDetailsValues>;
 
 // The Http header to copy the original Authorization before it is overwritten.
 const Envoy::Http::LowerCaseString kXForwardedAuthorization{

--- a/src/envoy/http/backend_auth/filter_config.h
+++ b/src/envoy/http/backend_auth/filter_config.h
@@ -49,7 +49,7 @@ class FilterConfig {
   virtual const FilterConfigParser& cfg_parser() const PURE;
 };
 
-typedef std::shared_ptr<FilterConfig> FilterConfigSharedPtr;
+using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;
 
 }  // namespace backend_auth
 }  // namespace HttpFilters

--- a/src/envoy/http/backend_routing/filter_config.h
+++ b/src/envoy/http/backend_routing/filter_config.h
@@ -83,7 +83,7 @@ class FilterConfig : public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
       backend_routing_map_;
 };
 
-typedef std::shared_ptr<FilterConfig> FilterConfigSharedPtr;
+using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;
 
 }  // namespace BackendRouting
 }  // namespace HttpFilters

--- a/src/envoy/http/path_matcher/filter.cc
+++ b/src/envoy/http/path_matcher/filter.cc
@@ -35,7 +35,7 @@ struct RcDetailsValues {
   // The path is not defined in the service config.
   const std::string PathNotDefined = "path_not_defined";
 };
-typedef Envoy::ConstSingleton<RcDetailsValues> RcDetails;
+using RcDetails = Envoy::ConstSingleton<RcDetailsValues>;
 
 }  // namespace
 

--- a/src/envoy/http/path_matcher/filter_config.h
+++ b/src/envoy/http/path_matcher/filter_config.h
@@ -97,7 +97,7 @@ class FilterConfig : public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
   FilterStats stats_;
 };
 
-typedef std::shared_ptr<FilterConfig> FilterConfigSharedPtr;
+using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;
 
 }  // namespace path_matcher
 }  // namespace http_filters

--- a/src/envoy/http/path_matcher/filter_config_test.cc
+++ b/src/envoy/http/path_matcher/filter_config_test.cc
@@ -29,8 +29,8 @@ namespace {
 
 using ::espv2::api_proxy::path_matcher::VariableBinding;
 using ::google::protobuf::TextFormat;
-typedef std::vector<VariableBinding> VariableBindings;
-typedef std::vector<std::string> FieldPath;
+using VariableBindings = std::vector<VariableBinding>;
+using FieldPath = std::vector<std::string>;
 
 TEST(FilterConfigTest, EmptyConfig) {
   ::google::api::envoy::http::path_matcher::FilterConfig config_pb;

--- a/src/envoy/http/service_control/config_parser.h
+++ b/src/envoy/http/service_control/config_parser.h
@@ -56,7 +56,7 @@ class ServiceContext {
   ServiceControlCallPtr service_control_call_;
   int64_t min_stream_report_interval_ms_;
 };
-typedef std::unique_ptr<ServiceContext> ServiceContextPtr;
+using ServiceContextPtr = std::unique_ptr<ServiceContext>;
 
 class RequirementContext {
  public:
@@ -86,7 +86,7 @@ class RequirementContext {
   const ServiceContext& service_ctx_;
   std::vector<std::pair<std::string, int>> metric_costs_;
 };
-typedef std::unique_ptr<RequirementContext> RequirementContextPtr;
+using RequirementContextPtr = std::unique_ptr<RequirementContext>;
 
 class FilterConfigParser {
  public:

--- a/src/envoy/http/service_control/filter.cc
+++ b/src/envoy/http/service_control/filter.cc
@@ -30,7 +30,7 @@ struct RcDetailsValues {
   const std::string RejectedByServiceControlCheck =
       "rejected_by_service_control_check";
 };
-typedef Envoy::ConstSingleton<RcDetailsValues> RcDetails;
+using RcDetails = Envoy::ConstSingleton<RcDetailsValues>;
 
 }  // namespace
 

--- a/src/envoy/http/service_control/filter_config.h
+++ b/src/envoy/http/service_control/filter_config.h
@@ -59,7 +59,7 @@ class ServiceControlFilterConfig
   ServiceControlHandlerFactoryImpl handler_factory_;
 };
 
-typedef std::shared_ptr<ServiceControlFilterConfig> FilterConfigSharedPtr;
+using FilterConfigSharedPtr = std::shared_ptr<ServiceControlFilterConfig>;
 
 }  // namespace service_control
 }  // namespace http_filters

--- a/src/envoy/http/service_control/handler.h
+++ b/src/envoy/http/service_control/handler.h
@@ -59,7 +59,7 @@ class ServiceControlHandler {
   // The request is about to be destroyed need to cancel all async requests.
   virtual void onDestroy() PURE;
 };
-typedef std::unique_ptr<ServiceControlHandler> ServiceControlHandlerPtr;
+using ServiceControlHandlerPtr = std::unique_ptr<ServiceControlHandler>;
 
 class ServiceControlHandlerFactory {
  public:

--- a/src/envoy/http/service_control/service_control_call.h
+++ b/src/envoy/http/service_control/service_control_call.h
@@ -41,7 +41,7 @@ class ServiceControlCall {
           request_info) PURE;
 };
 
-typedef std::unique_ptr<ServiceControlCall> ServiceControlCallPtr;
+using ServiceControlCallPtr = std::unique_ptr<ServiceControlCall>;
 
 class ServiceControlCallFactory {
  public:

--- a/src/envoy/http/service_control/service_control_call_impl.h
+++ b/src/envoy/http/service_control/service_control_call_impl.h
@@ -75,9 +75,8 @@ class ThreadLocalCache : public Envoy::ThreadLocal::ThreadLocalObject {
   ClientCache client_cache_;
 };
 
-typedef std::shared_ptr<
-    ::google::api::envoy::http::service_control::FilterConfig>
-    FilterConfigProtoSharedPtr;
+using FilterConfigProtoSharedPtr =
+    std::shared_ptr<::google::api::envoy::http::service_control::FilterConfig>;
 
 class ServiceControlCallImpl
     : public ServiceControlCall,

--- a/src/envoy/http/service_control/service_control_call_impl.h
+++ b/src/envoy/http/service_control/service_control_call_impl.h
@@ -31,7 +31,7 @@ namespace http_filters {
 namespace service_control {
 
 // Use shared_ptr to do atomic token update.
-typedef std::shared_ptr<std::string> TokenSharedPtr;
+using TokenSharedPtr = std::shared_ptr<std::string>;
 
 // The scope for Service Control API
 constexpr char kServiceControlScope[] =

--- a/src/envoy/token/iam_token_info.h
+++ b/src/envoy/token/iam_token_info.h
@@ -22,7 +22,7 @@ namespace espv2 {
 namespace envoy {
 namespace token {
 
-typedef std::function<std::string()> GetTokenFunc;
+using GetTokenFunc = std::function<std::string()>;
 
 // `IamTokenInfo` is a bridge `TokenInfo` for parsing
 // identity and access tokens from the IAM server.

--- a/src/envoy/token/mocks.h
+++ b/src/envoy/token/mocks.h
@@ -59,7 +59,7 @@ class MockTokenInfo : public TokenInfo {
               (absl::string_view response, TokenResult* ret), (const));
 };
 
-typedef std::unique_ptr<NiceMock<MockTokenInfo>> MockTokenInfoPtr;
+using MockTokenInfoPtr = std::unique_ptr<NiceMock<MockTokenInfo>>;
 
 }  // namespace test
 }  // namespace token

--- a/src/envoy/token/sa_token_generator.h
+++ b/src/envoy/token/sa_token_generator.h
@@ -47,7 +47,7 @@ class ServiceAccountTokenGenerator
   TokenUpdateFunc callback_;
   Envoy::Event::TimerPtr refresh_timer_;
 };
-typedef std::unique_ptr<ServiceAccountTokenGenerator> ServiceAccountTokenPtr;
+using ServiceAccountTokenPtr = std::unique_ptr<ServiceAccountTokenGenerator>;
 
 }  // namespace token
 }  // namespace envoy

--- a/src/envoy/token/token_info.h
+++ b/src/envoy/token/token_info.h
@@ -41,7 +41,7 @@ class TokenInfo : public Envoy::Logger::Loggable<Envoy::Logger::Id::init> {
                                   TokenResult* ret) const PURE;
 };
 
-typedef std::unique_ptr<TokenInfo> TokenInfoPtr;
+using TokenInfoPtr = std::unique_ptr<TokenInfo>;
 
 }  // namespace token
 }  // namespace envoy

--- a/src/envoy/token/token_subscriber.h
+++ b/src/envoy/token/token_subscriber.h
@@ -29,7 +29,7 @@ namespace token {
 
 enum TokenType { AccessToken, IdentityToken };
 
-typedef std::function<void(absl::string_view)> UpdateTokenCallback;
+using UpdateTokenCallback = std::function<void(absl::string_view)>;
 
 // `TokenSubscriber` class contains platform logic to initiate token refreshes
 // and callback to the clients.
@@ -87,7 +87,7 @@ class TokenSubscriber
   std::string debug_name_;
 };
 
-typedef std::unique_ptr<TokenSubscriber> TokenSubscriberPtr;
+using TokenSubscriberPtr = std::unique_ptr<TokenSubscriber>;
 
 }  // namespace token
 }  // namespace envoy


### PR DESCRIPTION
Google C++ Style Guide suggests `using` over `typedef`:

> using is preferable to typedef, because it provides a more consistent syntax with the rest of C++ and works with templates

Replaced using a simple regex:
- Find: `^typedef ([^\n]+) ([^\n]+);$`
- Replace: `using $2 = $1;`

Signed-off-by: Teju Nareddy <nareddyt@google.com>