### PR TITLE
[Cleanup] Simplify header lookup

### DIFF
--- a/src/envoy/http/backend_auth/filter_test.cc
+++ b/src/envoy/http/backend_auth/filter_test.cc
@@ -141,9 +141,7 @@ TEST_F(BackendAuthFilterTest, SucceedAppendToken) {
   Envoy::Http::FilterHeadersStatus status =
       filter_->decodeHeaders(headers, false);
 
-  EXPECT_EQ(headers.get(Envoy::Http::Headers::get().Authorization)
-                ->value()
-                .getStringView(),
+  EXPECT_EQ(headers.Authorization()->value().getStringView(),
             "Bearer this-is-token");
   EXPECT_EQ(headers.get(kXForwardedAuthorization), nullptr);
   EXPECT_EQ(status, Envoy::Http::FilterHeadersStatus::Continue);
@@ -178,9 +176,7 @@ TEST_F(BackendAuthFilterTest, SucceedTokenCopied) {
   Envoy::Http::FilterHeadersStatus status =
       filter_->decodeHeaders(headers, false);
 
-  EXPECT_EQ(headers.get(Envoy::Http::Headers::get().Authorization)
-                ->value()
-                .getStringView(),
+  EXPECT_EQ(headers.Authorization()->value().getStringView(),
             "Bearer new-id-token");
   EXPECT_EQ(headers.get(kXForwardedAuthorization)->value().getStringView(),
             "Bearer origin-token");

--- a/src/envoy/token/iam_token_info_test.cc
+++ b/src/envoy/token/iam_token_info_test.cc
@@ -66,25 +66,10 @@ TEST_F(IamTokenInfoTest, SimpleSuccess) {
   // Assert success.
   EXPECT_NE(got_msg, nullptr);
   EXPECT_EQ(got_msg->bodyAsString(), R"()");
-  EXPECT_EQ(got_msg->headers()
-                .get(Envoy::Http::Headers::get().Method)
-                ->value()
-                .getStringView(),
-            "POST");
-  EXPECT_EQ(got_msg->headers()
-                .get(Envoy::Http::Headers::get().Host)
-                ->value()
-                .getStringView(),
-            "iam-url.com");
-  EXPECT_EQ(got_msg->headers()
-                .get(Envoy::Http::Headers::get().Path)
-                ->value()
-                .getStringView(),
-            "/path1");
-  EXPECT_EQ(got_msg->headers()
-                .get(Envoy::Http::Headers::get().Authorization)
-                ->value()
-                .getStringView(),
+  EXPECT_EQ(got_msg->headers().Method()->value().getStringView(), "POST");
+  EXPECT_EQ(got_msg->headers().Host()->value().getStringView(), "iam-url.com");
+  EXPECT_EQ(got_msg->headers().Path()->value().getStringView(), "/path1");
+  EXPECT_EQ(got_msg->headers().Authorization()->value().getStringView(),
             "Bearer valid-access-token");
 }
 

--- a/src/envoy/token/imds_token_info_test.cc
+++ b/src/envoy/token/imds_token_info_test.cc
@@ -41,21 +41,9 @@ TEST_F(ImdsTokenInfoTest, SimpleSuccess) {
   // Assert success.
   EXPECT_NE(got_msg, nullptr);
   EXPECT_EQ(got_msg->bodyAsString(), R"()");
-  EXPECT_EQ(got_msg->headers()
-                .get(Envoy::Http::Headers::get().Method)
-                ->value()
-                .getStringView(),
-            "GET");
-  EXPECT_EQ(got_msg->headers()
-                .get(Envoy::Http::Headers::get().Host)
-                ->value()
-                .getStringView(),
-            "imds-url.com");
-  EXPECT_EQ(got_msg->headers()
-                .get(Envoy::Http::Headers::get().Path)
-                ->value()
-                .getStringView(),
-            "/path2");
+  EXPECT_EQ(got_msg->headers().Method()->value().getStringView(), "GET");
+  EXPECT_EQ(got_msg->headers().Host()->value().getStringView(), "imds-url.com");
+  EXPECT_EQ(got_msg->headers().Path()->value().getStringView(), "/path2");
   Envoy::Http::LowerCaseString metadata_key("Metadata-Flavor");
   EXPECT_EQ(got_msg->headers().get(metadata_key)->value().getStringView(),
             "Google");

--- a/src/envoy/token/token_subscriber_test.cc
+++ b/src/envoy/token/token_subscriber_test.cc
@@ -151,16 +151,8 @@ TEST_F(TokenSubscriberTest, VerifyRemoteRequest) {
 
   // Assert remote call matches.
   ASSERT_EQ(call_count_, 1);
-  EXPECT_EQ(message_->headers()
-                .get(Envoy::Http::Headers::get().Method)
-                ->value()
-                .getStringView(),
-            "POST");
-  EXPECT_EQ(message_->headers()
-                .get(Envoy::Http::Headers::get().Host)
-                ->value()
-                .getStringView(),
-            "TestValue");
+  EXPECT_EQ(message_->headers().Method()->value().getStringView(), "POST");
+  EXPECT_EQ(message_->headers().Host()->value().getStringView(), "TestValue");
 }
 
 TEST_F(TokenSubscriberTest, ProcessNon200Response) {


### PR DESCRIPTION
Can access headers directly (HeaderMap has a macro to generate lookup functions for each header value).

Simple find-replace to fix instances.

Signed-off-by: Teju Nareddy <nareddyt@google.com>