### PR TITLE
Token refresh logic for invalid expiry times

### DIFF
--- a/src/envoy/token/BUILD
+++ b/src/envoy/token/BUILD
@@ -52,6 +52,7 @@ envoy_cc_library(
         "@envoy//include/envoy/event:dispatcher_interface",
         "@envoy//include/envoy/server:filter_config_interface",
         "@envoy//include/envoy/upstream:cluster_manager_interface",
+        "@envoy//source/common/common:assert_lib",
         "@envoy//source/common/common:enum_to_int",
         "@envoy//source/common/http:headers_lib",
         "@envoy//source/common/http:message_lib",

--- a/src/envoy/token/imds_token_info_test.cc
+++ b/src/envoy/token/imds_token_info_test.cc
@@ -87,7 +87,18 @@ TEST_F(ImdsTokenInfoTest, InvalidJsonResponse) {
   EXPECT_FALSE(success);
 }
 
-TEST_F(ImdsTokenInfoTest, AccessTokenSuccess) {
+TEST_F(ImdsTokenInfoTest, AccessTokenInvalidExpiry) {
+  // Input.
+  std::string response =
+      R"({ "access_token": "fake-access-token", "expires_in": "invalid" })";
+  TokenResult result{};
+
+  // Test access token.
+  bool success = info_->parseAccessToken(response, &result);
+  EXPECT_FALSE(success);
+}
+
+TEST_F(ImdsTokenInfoTest, AccessTokenSuccessPostiveExpiry) {
   // Input.
   std::string response =
       R"({ "access_token": "fake-access-token", "expires_in": 434432 })";
@@ -97,7 +108,21 @@ TEST_F(ImdsTokenInfoTest, AccessTokenSuccess) {
   bool success = info_->parseAccessToken(response, &result);
   EXPECT_TRUE(success);
   EXPECT_EQ(result.token, "fake-access-token");
+  EXPECT_GT(result.expiry_duration.count(), 0);
   EXPECT_NE(result.expiry_duration, kDefaultTokenExpiry);
+}
+
+TEST_F(ImdsTokenInfoTest, AccessTokenSuccessNegativeExpiry) {
+  // Input with an expiry time in the past (should never happen in practice).
+  std::string response =
+      R"({ "access_token": "fake-access-token", "expires_in": -434432 })";
+  TokenResult result{};
+
+  // Test access token.
+  bool success = info_->parseAccessToken(response, &result);
+  EXPECT_TRUE(success);
+  EXPECT_EQ(result.token, "fake-access-token");
+  EXPECT_LT(result.expiry_duration.count(), 0);
 }
 
 }  // namespace test


### PR DESCRIPTION
- If the token has a very low refresh time, do not init ready until the retry finishes.
- Add extra unit tests for timestamp and expiry time parsing.
- Add extra unit test for retry on low refresh time.

Signed-off-by: Teju Nareddy <nareddyt@google.com>