### PR TITLE
b/154830645: Verify second port available in GCS Runner

### DIFF
--- a/examples/auth/envoy_config.json
+++ b/examples/auth/envoy_config.json
@@ -7,7 +7,7 @@
   "staticResources": {
     "listeners": [
       {
-        "name": "http_listener",
+        "name": "ingress_listener",
         "address": {
           "socketAddress": {
             "address": "0.0.0.0",

--- a/examples/dynamic_routing/envoy_config.json
+++ b/examples/dynamic_routing/envoy_config.json
@@ -174,7 +174,7 @@
         ],
         "listeners": [
             {
-                "name": "http_listener",
+                "name": "ingress_listener",
                 "address": {
                     "socketAddress": {
                         "address": "0.0.0.0",

--- a/examples/grpc_dynamic_routing/envoy_config.json
+++ b/examples/grpc_dynamic_routing/envoy_config.json
@@ -178,7 +178,7 @@
         ],
         "listeners": [
             {
-                "name": "http_listener",
+                "name": "ingress_listener",
                 "address": {
                     "socketAddress": {
                         "address": "0.0.0.0",

--- a/examples/service_control/envoy_config.json
+++ b/examples/service_control/envoy_config.json
@@ -6,7 +6,7 @@
   "staticResources": {
     "listeners": [
       {
-        "name": "http_listener",
+        "name": "ingress_listener",
         "address": {
           "socketAddress": {
             "address": "0.0.0.0",

--- a/src/go/bootstrap/static/testdata/path_matcher/envoy_config.json
+++ b/src/go/bootstrap/static/testdata/path_matcher/envoy_config.json
@@ -96,7 +96,7 @@
     ],
     "listeners": [
       {
-        "name": "http_listener",
+        "name": "ingress_listener",
         "address": {
           "socketAddress": {
             "address": "0.0.0.0",

--- a/src/go/configgenerator/listener_generator.go
+++ b/src/go/configgenerator/listener_generator.go
@@ -191,10 +191,7 @@ func makeListener(serviceInfo *sc.ServiceInfo) (*v2pb.Listener, error) {
 		},
 	}
 
-	listenerName := "http_listener"
-
 	if serviceInfo.Options.SslServerCertPath != "" {
-		listenerName = "https_listener"
 		transportSocket, err := util.CreateDownstreamTransportSocket(
 			serviceInfo.Options.SslServerCertPath,
 			serviceInfo.Options.SslMinimumProtocol,
@@ -207,7 +204,7 @@ func makeListener(serviceInfo *sc.ServiceInfo) (*v2pb.Listener, error) {
 	}
 
 	return &v2pb.Listener{
-		Name: listenerName,
+		Name: util.IngressListenerName,
 		Address: &corepb.Address{
 			Address: &corepb.Address_SocketAddress{
 				SocketAddress: &corepb.SocketAddress{

--- a/src/go/configgenerator/listener_generator_test.go
+++ b/src/go/configgenerator/listener_generator_test.go
@@ -1431,7 +1431,7 @@ func TestMakeListeners(t *testing.T) {
 			},
 			wantListeners: []string{
 				`{
-					"name": "https_listener",
+					"name": "ingress_listener",
 					"address":{
 						"socketAddress":{
 							"address":"0.0.0.0",
@@ -1572,7 +1572,7 @@ func TestMakeHttpConMgr(t *testing.T) {
 		{
 			desc: "Generate HttpConMgr when accessLog is defined",
 			opts: options.ConfigGeneratorOptions{
-				AccessLog: "/foo",
+				AccessLog:       "/foo",
 				AccessLogFormat: "/bar",
 			},
 			wantHttpConnMgr: `

--- a/src/go/configmanager/config_manager_test.go
+++ b/src/go/configmanager/config_manager_test.go
@@ -115,7 +115,7 @@ func TestFetchListeners(t *testing.T) {
          "portValue":8080
       }
 	 },
-	 "name": "http_listener",
+	 "name": "ingress_listener",
    "filterChains":[
       {
          "filters":[
@@ -261,7 +261,7 @@ func TestFetchListeners(t *testing.T) {
          "portValue":8080
       }
    },
-	 "name": "http_listener",
+	 "name": "ingress_listener",
    "filterChains":[
       {
          "filters":[
@@ -455,7 +455,7 @@ func TestFetchListeners(t *testing.T) {
          "portValue":8080
       }
 	 },
-	 "name": "http_listener",
+	 "name": "ingress_listener",
    "filterChains":[
       {
          "filters":[
@@ -669,7 +669,7 @@ func TestFetchListeners(t *testing.T) {
          "portValue":8080
       }
 	 },
-	 "name": "http_listener",
+	 "name": "ingress_listener",
    "filterChains":[
       {
          "filters":[
@@ -911,7 +911,7 @@ func TestFetchListeners(t *testing.T) {
          "portValue":8080
       }
 	 },
-	 "name": "http_listener",
+	 "name": "ingress_listener",
    "filterChains":[
       {
          "filters":[
@@ -1136,7 +1136,7 @@ func TestFetchListeners(t *testing.T) {
          "portValue":8080
       }
    },
-	 "name": "http_listener",
+	 "name": "ingress_listener",
    "filterChains":[
       {
          "filters":[
@@ -1303,7 +1303,7 @@ func TestFetchListeners(t *testing.T) {
          "portValue":8080
       }
 	 },
-	 "name": "http_listener",
+	 "name": "ingress_listener",
    "filterChains":[
       {
          "filters":[

--- a/src/go/configmanager/testdata/fake_data_for_dynamic_routing.go
+++ b/src/go/configmanager/testdata/fake_data_for_dynamic_routing.go
@@ -226,7 +226,7 @@ var (
 
 	FakeWantedListenerForDynamicRouting = `
 {
-	 "name": "http_listener",
+	 "name": "ingress_listener",
    "address":{
       "socketAddress":{
          "address":"0.0.0.0",

--- a/src/go/gcsrunner/fetch_config.go
+++ b/src/go/gcsrunner/fetch_config.go
@@ -37,7 +37,7 @@ type FetchConfigOptions struct {
 	BucketName                    string
 	ConfigFileName                string
 	WantPort                      uint32
-	ReplacePort                   uint32
+	LoopbackPort                  uint32
 	WriteFilePath                 string
 	FetchGCSObjectInitialInterval time.Duration
 	FetchGCSObjectTimeout         time.Duration

--- a/src/go/gcsrunner/transform_config.go
+++ b/src/go/gcsrunner/transform_config.go
@@ -107,7 +107,8 @@ func transformEnvoyConfig(bootstrap *bootstrappb.Bootstrap, opts FetchConfigOpti
 	for _, l := range listeners {
 		switch l.GetName() {
 		// The default listener created by this project's configgenerator package.
-		case util.IngressListenerName:
+		// Also include the previous names of this listener so old configs still work.
+		case util.IngressListenerName, "http_listener", "https_listener":
 			ingressListenerTransformed = true
 			if err := transformIngressListener(l, opts); err != nil {
 				return fmt.Errorf("failed to transform Ingress Listener: %v", err)
@@ -116,6 +117,7 @@ func transformEnvoyConfig(bootstrap *bootstrappb.Bootstrap, opts FetchConfigOpti
 		// those sent by Service Control and JWT Authn filters in order to utilize
 		// Envoy's built-in Access Logging features.
 		// This requires the use of another unused port.
+		// This listener is optional so old configs without this listener still work.
 		case util.LoopbackListenerName:
 			if err := transformLoopbackListener(l, opts); err != nil {
 				return fmt.Errorf("failed to transform Loopback Listener")

--- a/src/go/util/marshal.go
+++ b/src/go/util/marshal.go
@@ -26,6 +26,7 @@ import (
 	pmpb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/http/path_matcher"
 	scpb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/http/service_control"
 	authpb "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	filepb "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v2"
 	gspb "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/grpc_stats/v2alpha"
 	jwtpb "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/jwt_authn/v2alpha"
 	routerpb "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/router/v2"
@@ -93,6 +94,8 @@ var Resolver = FuncResolver(func(url string) (proto.Message, error) {
 		return new(authpb.UpstreamTlsContext), nil
 	case "type.googleapis.com/envoy.api.v2.auth.DownstreamTlsContext":
 		return new(authpb.DownstreamTlsContext), nil
+	case "type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog":
+		return new(filepb.FileAccessLog), nil
 	default:
 		return nil, fmt.Errorf("unexpected protobuf.Any with url: %s", url)
 	}

--- a/src/go/util/util.go
+++ b/src/go/util/util.go
@@ -97,6 +97,9 @@ const (
 	// The service control server cluster name.
 	ServiceControlClusterName = "service-control-cluster"
 
+	IngressListenerName  = "ingress_listener"
+	LoopbackListenerName = "loopback_listener"
+
 	// Platforms
 
 	GAEFlex = "GAE_FLEX(ESPv2)"

--- a/tests/integration_test/access_log_test.go
+++ b/tests/integration_test/access_log_test.go
@@ -73,7 +73,7 @@ func TestAccessLog(t *testing.T) {
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
-	makeOneRequest(t , s )
+	makeOneRequest(t, s)
 	s.TearDown()
 	expectAccessLog := fmt.Sprintf("\"POST /echo?key=api-key HTTP/1.1\"200"+
 		" - 20 19\"-\" \"Go-http-client/1.1\"\"localhost:%v\" \"127.0.0.1:%v\"\n",
@@ -84,7 +84,7 @@ func TestAccessLog(t *testing.T) {
 		t.Fatalf("fail to read access log file: %v", err)
 	}
 
-	if gotAccessLog := string(bytes); expectAccessLog!= gotAccessLog {
+	if gotAccessLog := string(bytes); expectAccessLog != gotAccessLog {
 		t.Errorf("expect access log: %s, get acccess log: %v", expectAccessLog, gotAccessLog)
 	}
 


### PR DESCRIPTION
A second "Loopback" Listener can be used to utilize access logs on Service Control Filter's Check and Report calls and JWT Authn Filter's async token refresh. This requires opening a second port. GCSRunner needs to verify that a second port is available. This port can be specified with the LOOPBACK_PORT variable.

Note that only the PORT variable should be opened to public traffic.

Changes in this PR:

- Add support for FileAccessLog to JSON Marshal code. **Note: this change cannot be safely downgraded due to new configs being unable to parse with the former code.**
- Added LOOPBACK_PORT environment variable.
- Updated transformation code to support multiple listeners. **Note: this change cannot be safely downgraded due to the formerly hard-coded requirement of 1 listener.**
- If `loopback_listener` is provided, set the port number. If not, do nothing (this is required to allow compatibility with previous configs). One of `http_listener` or `https_listener` is still required.

Refactoring changes:

- Removed the ReplacePort field, as it added no functionality.

TESTED=Unit tests here and manual smoke test with full stack.