### PR TITLE
Forward `Authorization` header in JWT Authn filter

### DIFF
--- a/examples/auth/envoy_config.json
+++ b/examples/auth/envoy_config.json
@@ -83,6 +83,7 @@
                             "audiences": [
                               "bookstore.endpoints.cloudesf-testing.cloud.goog"
                             ],
+                            "forward": true,
                             "forwardPayloadHeader": "X-Endpoint-API-UserInfo",
                             "fromHeaders": [
                               {
@@ -111,6 +112,7 @@
                             "audiences": [
                               "apiproxy-231719"
                             ],
+                            "forward": true,
                             "forwardPayloadHeader": "X-Endpoint-API-UserInfo",
                             "fromHeaders": [
                               {
@@ -139,6 +141,7 @@
                             "audiences": [
                               "https://auth.endpoints.apiproxy-231719.cloud.goog"
                             ],
+                            "forward": true,
                             "forwardPayloadHeader": "X-Endpoint-API-UserInfo",
                             "fromHeaders": [
                               {

--- a/examples/grpc_dynamic_routing/envoy_config.json
+++ b/examples/grpc_dynamic_routing/envoy_config.json
@@ -429,6 +429,7 @@
                                                         "audiences": [
                                                             "https://esp-grpc-echo-oxouww7xzq-uc.a.run.app"
                                                         ],
+                                                        "forward": true,
                                                         "forwardPayloadHeader": "X-Endpoint-API-UserInfo",
                                                         "fromHeaders": [
                                                             {

--- a/src/go/configgenerator/listener_generator.go
+++ b/src/go/configgenerator/listener_generator.go
@@ -402,6 +402,7 @@ func makeJwtAuthnFilter(serviceInfo *sc.ServiceInfo) *hcmpb.HttpFilter {
 			FromHeaders:          fromHeaders,
 			FromParams:           fromParams,
 			ForwardPayloadHeader: "X-Endpoint-API-UserInfo",
+			Forward:              true,
 		}
 
 		if len(provider.GetAudiences()) != 0 {

--- a/src/go/configgenerator/listener_generator_test.go
+++ b/src/go/configgenerator/listener_generator_test.go
@@ -295,6 +295,7 @@ func TestJwtAuthnFilter(t *testing.T) {
                 "audiences": [
                     "https://bookstore.endpoints.project123.cloud.goog"
                 ],
+                "forward": true,
                 "forwardPayloadHeader": "X-Endpoint-API-UserInfo",
                 "fromHeaders": [
                     {
@@ -371,6 +372,7 @@ func TestJwtAuthnFilter(t *testing.T) {
                 "audiences": [
                     "https://bookstore.endpoints.project123.cloud.goog"
                 ],
+                "forward": true,
                 "forwardPayloadHeader": "X-Endpoint-API-UserInfo",
                 "fromHeaders": [
                     {
@@ -413,7 +415,7 @@ func TestJwtAuthnFilter(t *testing.T) {
 		}
 
 		if err := util.JsonEqual(tc.wantJwtAuthnFilter, gotFilter); err != nil {
-			t.Errorf("Test Desc(%d): %s, makeTranscoderFilter failed, got: %s, want: %s", i, tc.desc, gotFilter, tc.wantJwtAuthnFilter)
+			t.Errorf("Test Desc(%d): %s, makeTranscoderFilter failed, %s", i, tc.desc, err)
 		}
 	}
 }
@@ -1572,7 +1574,7 @@ func TestMakeHttpConMgr(t *testing.T) {
 		{
 			desc: "Generate HttpConMgr when accessLog is defined",
 			opts: options.ConfigGeneratorOptions{
-				AccessLog: "/foo",
+				AccessLog:       "/foo",
 				AccessLogFormat: "/bar",
 			},
 			wantHttpConnMgr: `

--- a/src/go/configmanager/config_manager_test.go
+++ b/src/go/configmanager/config_manager_test.go
@@ -308,6 +308,7 @@ func TestFetchListeners(t *testing.T) {
                                     "test_audience1",
                                     "test_audience2"
                                  ],
+                                 "forward": true,
                                  "forwardPayloadHeader":"X-Endpoint-API-UserInfo",
                                  "fromHeaders":[
                                     {
@@ -520,6 +521,7 @@ func TestFetchListeners(t *testing.T) {
                                  "audiences": [
                                      "https://bookstore.endpoints.project123.cloud.goog"
                                  ],
+                                 "forward": true,
                                  "forwardPayloadHeader":"X-Endpoint-API-UserInfo",
                                  "fromHeaders":[
                                     {
@@ -740,6 +742,7 @@ func TestFetchListeners(t *testing.T) {
                                  "audiences": [
                                      "https://bookstore.endpoints.project123.cloud.goog"
                                  ],
+                                 "forward": true,
                                  "forwardPayloadHeader":"X-Endpoint-API-UserInfo",
                                  "fromHeaders":[
                                     {
@@ -768,6 +771,7 @@ func TestFetchListeners(t *testing.T) {
                                  "audiences": [
                                      "https://bookstore.endpoints.project123.cloud.goog"
                                  ],
+                                 "forward": true,
                                  "forwardPayloadHeader":"X-Endpoint-API-UserInfo",
                                  "fromHeaders":[
                                     {
@@ -1190,6 +1194,7 @@ func TestFetchListeners(t *testing.T) {
                                     "test_audience1",
                                     "test_audience2"
                                  ],
+                                 "forward": true,
                                  "forwardPayloadHeader":"X-Endpoint-API-UserInfo",
                                  "fromHeaders":[
                                     {
@@ -1477,7 +1482,7 @@ func TestFetchListeners(t *testing.T) {
 			}
 
 			if err := util.JsonEqual(tc.wantedListeners, gotListeners); err != nil {
-				t.Errorf("Test Desc(%d): %s, snapshot cache fetch got unexpected Listeners, \n %v", i, tc.desc, err)
+				t.Errorf("Test Desc(%d): %s, snapshot cache fetch got unexpected Listeners, %v", i, tc.desc, err)
 			}
 		})
 	}

--- a/src/go/util/httptest_util.go
+++ b/src/go/util/httptest_util.go
@@ -86,7 +86,7 @@ func JsonEqual(want, got string) error {
 		return err
 	}
 	if !strings.EqualFold(want, got) {
-		return fmt.Errorf("got: %s \n want: %s", got, want)
+		return fmt.Errorf("\n  got: %s \n want: %s", got, want)
 	}
 	return nil
 }

--- a/tests/endpoints/echo/server/app.go
+++ b/tests/endpoints/echo/server/app.go
@@ -281,11 +281,18 @@ func bearerTokenHandler(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Expose-Headers", fmt.Sprintf("X-Token: %s", bearerToken))
 	}
 	reqURI := r.URL.RequestURI()
-	xForwarded := r.Header.Get("X-Forwarded-Authorization")
 	resp := fmt.Sprintf(`{"Authorization": "%s", "RequestURI": "%s"`, bearerToken, reqURI)
+
+	xForwarded := r.Header.Get("X-Forwarded-Authorization")
 	if xForwarded != "" {
 		resp += fmt.Sprintf(`, "X-Forwarded-Authorization": "%s"`, xForwarded)
 	}
+
+	xEndpoint := r.Header.Get("X-Endpoint-API-UserInfo")
+	if xEndpoint != "" {
+		resp += fmt.Sprintf(`, "X-Endpoint-API-UserInfo": "%s"`, xEndpoint)
+	}
+
 	resp += "}"
 	w.Write([]byte(resp))
 }

--- a/tests/env/components/ports.go
+++ b/tests/env/components/ports.go
@@ -53,6 +53,7 @@ const (
 	TestDynamicRouting
 	TestDynamicRoutingCorsByEnvoy
 	TestDynamicRoutingWithAllowCors
+	TestFrontendAndBackendAuthHeaders
 	TestGRPC
 	TestGrpcBackendPreflightCors
 	TestGrpcBackendSimpleCors

--- a/tests/env/testdata/fake_jwt.go
+++ b/tests/env/testdata/fake_jwt.go
@@ -220,6 +220,9 @@ const (
 		"jZSJ9.hz9IUedX6WTbuxQSbcXBSKfvF2hK48o06CnxJn-5vyOkWfUNroJjb3JokQpweF9X" +
 		"FI8RxeMGPKFMdHb8qyIlqA"
 
+	Es256TokenPayloadBase64 = "eyJpc3MiOiJlczI1Ni1pc3N1ZXIiLCJzdWIiOiJlczI1Ni1p" +
+		"c3N1ZXIiLCJhdWQiOiJva19hdWRpZW5jZSJ9"
+
 	Rs256Token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjJiIn0.eyJpc3MiO" +
 		"iJyczI1Ni1pc3N1ZXIiLCJzdWIiOiJyczI1Ni1pc3N1ZXIiLCJhdWQiOiJva19hdWRpZW5" +
 		"jZSJ9.Idf-XyipQCoMmIkI8TT3LgHUseV5AG-tJGhGrEldto-q44oNz9ZEd3KoJ3TlZGKk" +

--- a/tests/integration_test/access_log_test.go
+++ b/tests/integration_test/access_log_test.go
@@ -73,7 +73,7 @@ func TestAccessLog(t *testing.T) {
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
-	makeOneRequest(t , s )
+	makeOneRequest(t, s)
 	s.TearDown()
 	expectAccessLog := fmt.Sprintf("\"POST /echo?key=api-key HTTP/1.1\"200"+
 		" - 20 19\"-\" \"Go-http-client/1.1\"\"localhost:%v\" \"127.0.0.1:%v\"\n",
@@ -84,7 +84,7 @@ func TestAccessLog(t *testing.T) {
 		t.Fatalf("fail to read access log file: %v", err)
 	}
 
-	if gotAccessLog := string(bytes); expectAccessLog!= gotAccessLog {
+	if gotAccessLog := string(bytes); expectAccessLog != gotAccessLog {
 		t.Errorf("expect access log: %s, get acccess log: %v", expectAccessLog, gotAccessLog)
 	}
 


### PR DESCRIPTION
Notes:
- Always forward `Authorization` header in frontend auth.
- This will work with the pre-existing backend auth `X-Forwarded-Authorization` logic.

Testing:
- Verified `Authorization` and `X-Forwarded-Authorization` headers for backend auth enabled or disabled (frontend auth always enabled).
- Also verify `X-Endpoint-API-UserInfo` header, seems we have no tests for this.

Fixes #140

Signed-off-by: Teju Nareddy <nareddyt@google.com>