### PR TITLE
Destruct invalid json keys in grpc auth lib

### DIFF
--- a/src/api_proxy/auth/auth_token.cc
+++ b/src/api_proxy/auth/auth_token.cc
@@ -39,7 +39,8 @@ absl::optional<std::string> get_auth_token(const std::string& json_secret,
       grpc_auth_json_key_create_from_string(json_secret.c_str());
 
   if (grpc_auth_json_key_is_valid(&json_key) == 0) {
-    grpc_auth_json_key_destruct(&json_key);
+    // No need to destruct `json_key`, the create function automatically
+    // destructs it if it's invalid.
     return absl::nullopt;
   }
 

--- a/src/api_proxy/auth/auth_token.cc
+++ b/src/api_proxy/auth/auth_token.cc
@@ -39,6 +39,7 @@ absl::optional<std::string> get_auth_token(const std::string& json_secret,
       grpc_auth_json_key_create_from_string(json_secret.c_str());
 
   if (grpc_auth_json_key_is_valid(&json_key) == 0) {
+    grpc_auth_json_key_destruct(&json_key);
     return absl::nullopt;
   }
 


### PR DESCRIPTION
This is actually not needed, as `grpc_auth_json_key_create` will call `grpc_auth_json_key_destruct` if the key is invalid. But this improves readability (was confusing during security review). Calling it twice is safe.

Signed-off-by: Teju Nareddy <nareddyt@google.com>