### PR TITLE
[Cleanup] Minor lint changes to unblock google3 copybara

### DIFF
--- a/api/envoy/http/backend_auth/BUILD
+++ b/api/envoy/http/backend_auth/BUILD
@@ -1,13 +1,14 @@
 load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
-package()
+package(default_visibility = ["//visibility:public"])
 
 api_cc_py_proto_library(
     name = "config_proto",
     srcs = [
         "config.proto",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         "//api/envoy/http/common:base_proto",
     ],

--- a/api/envoy/http/backend_auth/BUILD
+++ b/api/envoy/http/backend_auth/BUILD
@@ -1,21 +1,13 @@
 load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
-BACKEND_AUTH_VISIBILITY = [
-    "//api/envoy/http/backend_auth:__subpackages__",
-    "//src/envoy/http/backend_auth:__subpackages__",
-    "//src/go:__subpackages__",
-    "//tests/utils:__subpackages__",
-]
-
-package(default_visibility = BACKEND_AUTH_VISIBILITY)
+package()
 
 api_cc_py_proto_library(
     name = "config_proto",
     srcs = [
         "config.proto",
     ],
-    visibility = BACKEND_AUTH_VISIBILITY,
     deps = [
         "//api/envoy/http/common:base_proto",
     ],

--- a/api/envoy/http/backend_routing/BUILD
+++ b/api/envoy/http/backend_routing/BUILD
@@ -1,13 +1,14 @@
 load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
-package()
+package(default_visibility = ["//visibility:public"])
 
 api_cc_py_proto_library(
     name = "config_proto",
     srcs = [
         "config.proto",
     ],
+    visibility = ["//visibility:public"],
 )
 
 go_proto_library(

--- a/api/envoy/http/backend_routing/BUILD
+++ b/api/envoy/http/backend_routing/BUILD
@@ -1,22 +1,13 @@
 load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
-BACKEND_ROUTING_VISIBILITY = [
-    "//api/envoy/http/backend_routing:__subpackages__",
-    "//src/envoy/http/backend_routing:__subpackages__",
-    "//src/go:__subpackages__",
-    "//tests/utils:__subpackages__",
-    "//tests/fuzz/structured_inputs:__subpackages__",
-]
-
-package(default_visibility = BACKEND_ROUTING_VISIBILITY)
+package()
 
 api_cc_py_proto_library(
     name = "config_proto",
     srcs = [
         "config.proto",
     ],
-    visibility = BACKEND_ROUTING_VISIBILITY,
 )
 
 go_proto_library(

--- a/api/envoy/http/common/BUILD
+++ b/api/envoy/http/common/BUILD
@@ -1,6 +1,8 @@
 load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
+package(default_visibility = ["//visibility:public"])
+
 api_cc_py_proto_library(
     name = "base_proto",
     srcs = [

--- a/api/envoy/http/common/BUILD
+++ b/api/envoy/http/common/BUILD
@@ -1,13 +1,12 @@
 load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
-package()
-
 api_cc_py_proto_library(
     name = "base_proto",
     srcs = [
         "base.proto",
     ],
+    visibility = ["//visibility:public"],
 )
 
 go_proto_library(

--- a/api/envoy/http/common/BUILD
+++ b/api/envoy/http/common/BUILD
@@ -1,21 +1,13 @@
 load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
-DEFAULT_VISIBILITY = [
-    "//api/envoy/http:__subpackages__",
-    "//src/envoy/http:__subpackages__",
-    "//src/go:__subpackages__",
-    "//tests/utils:__subpackages__",
-]
-
-package(default_visibility = DEFAULT_VISIBILITY)
+package()
 
 api_cc_py_proto_library(
     name = "base_proto",
     srcs = [
         "base.proto",
     ],
-    visibility = DEFAULT_VISIBILITY,
 )
 
 go_proto_library(

--- a/api/envoy/http/path_matcher/BUILD
+++ b/api/envoy/http/path_matcher/BUILD
@@ -1,22 +1,13 @@
 load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
-PATH_MATCHER_VISIBILITY = [
-    "//api/envoy/http/path_matcher:__subpackages__",
-    "//src/envoy/http/path_matcher:__subpackages__",
-    "//src/go:__subpackages__",
-    "//tests/utils:__subpackages__",
-    "//tests/fuzz/structured_inputs:__subpackages__",
-]
-
-package(default_visibility = PATH_MATCHER_VISIBILITY)
+package()
 
 api_cc_py_proto_library(
     name = "config_proto",
     srcs = [
         "config.proto",
     ],
-    visibility = PATH_MATCHER_VISIBILITY,
     deps = [
         "//api/envoy/http/common:base_proto",
     ],

--- a/api/envoy/http/path_matcher/BUILD
+++ b/api/envoy/http/path_matcher/BUILD
@@ -1,13 +1,14 @@
 load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
-package()
+package(default_visibility = ["//visibility:public"])
 
 api_cc_py_proto_library(
     name = "config_proto",
     srcs = [
         "config.proto",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         "//api/envoy/http/common:base_proto",
     ],

--- a/api/envoy/http/service_control/BUILD
+++ b/api/envoy/http/service_control/BUILD
@@ -1,15 +1,7 @@
 load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
-SERVICE_CONTROL_VISIBILITY = [
-    "//api/envoy/http/service_control:__subpackages__",
-    "//src/envoy/http/service_control:__subpackages__",
-    "//src/go:__subpackages__",
-    "//tests/utils:__subpackages__",
-    "//tests/fuzz/structured_inputs:__subpackages__",
-]
-
-package(default_visibility = SERVICE_CONTROL_VISIBILITY)
+package()
 
 api_cc_py_proto_library(
     name = "config_proto",
@@ -17,7 +9,6 @@ api_cc_py_proto_library(
         "config.proto",
         "requirement.proto",
     ],
-    visibility = SERVICE_CONTROL_VISIBILITY,
     deps = [
         "//api/envoy/http/common:base_proto",
     ],

--- a/api/envoy/http/service_control/BUILD
+++ b/api/envoy/http/service_control/BUILD
@@ -1,7 +1,7 @@
 load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
-package()
+package(default_visibility = ["//visibility:public"])
 
 api_cc_py_proto_library(
     name = "config_proto",
@@ -9,6 +9,7 @@ api_cc_py_proto_library(
         "config.proto",
         "requirement.proto",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         "//api/envoy/http/common:base_proto",
     ],

--- a/src/go/configinfo/service_info_test.go
+++ b/src/go/configinfo/service_info_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	"github.com/gorilla/mux"
-	"google.golang.org/genproto/protobuf/ptype"
 
 	commonpb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/http/common"
 	pmpb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/http/path_matcher"
@@ -38,6 +37,7 @@ import (
 	annotationspb "google.golang.org/genproto/googleapis/api/annotations"
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
 	apipb "google.golang.org/genproto/protobuf/api"
+	ptypepb "google.golang.org/genproto/protobuf/ptype"
 )
 
 var (
@@ -1939,9 +1939,9 @@ func TestProcessTypes(t *testing.T) {
 		{
 			desc: "Success for distinct names",
 			fakeServiceConfig: &confpb.Service{
-				Types: []*ptype.Type{
+				Types: []*ptypepb.Type{
 					{
-						Fields: []*ptype.Field{
+						Fields: []*ptypepb.Field{
 							{
 								Name:     "foo_bar",
 								JsonName: "fooBar",
@@ -1968,9 +1968,9 @@ func TestProcessTypes(t *testing.T) {
 		{
 			desc: "Success for fully duplicated names, which are de-duped",
 			fakeServiceConfig: &confpb.Service{
-				Types: []*ptype.Type{
+				Types: []*ptypepb.Type{
 					{
-						Fields: []*ptype.Field{
+						Fields: []*ptypepb.Field{
 							{
 								Name:     "foo_bar",
 								JsonName: "fooBar",
@@ -1993,9 +1993,9 @@ func TestProcessTypes(t *testing.T) {
 		{
 			desc: "Success for duplicated json_name with mismatching snake_name",
 			fakeServiceConfig: &confpb.Service{
-				Types: []*ptype.Type{
+				Types: []*ptypepb.Type{
 					{
-						Fields: []*ptype.Field{
+						Fields: []*ptypepb.Field{
 							{
 								Name:     "foo_bar",
 								JsonName: "fooBar",
@@ -2022,9 +2022,9 @@ func TestProcessTypes(t *testing.T) {
 		{
 			desc: "Failure for duplicated snake_name with mismatching json_name",
 			fakeServiceConfig: &confpb.Service{
-				Types: []*ptype.Type{
+				Types: []*ptypepb.Type{
 					{
-						Fields: []*ptype.Field{
+						Fields: []*ptypepb.Field{
 							{
 								Name:     "foo_bar",
 								JsonName: "fooBar",

--- a/src/go/configmanager/config_manager_test.go
+++ b/src/go/configmanager/config_manager_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/options"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/v2"
+	"github.com/envoyproxy/go-control-plane/pkg/resource/v2"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
 
@@ -43,8 +45,6 @@ import (
 	routerpb "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/router/v2"
 	transcoderpb "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/transcoder/v2"
 	hcmpb "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
-	cache "github.com/envoyproxy/go-control-plane/pkg/cache/v2"
-	rspb "github.com/envoyproxy/go-control-plane/pkg/resource/v2"
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 	annotationspb "google.golang.org/genproto/googleapis/api/annotations"
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
@@ -1460,7 +1460,7 @@ func TestFetchListeners(t *testing.T) {
 				Node: &corepb.Node{
 					Id: opts.Node,
 				},
-				TypeUrl: rspb.ListenerType,
+				TypeUrl: resource.ListenerType,
 			}
 			resp, err := env.configManager.cache.Fetch(ctx, req)
 			if err != nil {
@@ -1523,7 +1523,7 @@ func TestDynamicBackendRouting(t *testing.T) {
 			Node: &corepb.Node{
 				Id: opts.Node,
 			},
-			TypeUrl: rspb.ClusterType,
+			TypeUrl: resource.ClusterType,
 		}
 
 		respForClusters, err := manager.cache.Fetch(ctx, reqForClusters)
@@ -1560,7 +1560,7 @@ func TestDynamicBackendRouting(t *testing.T) {
 			Node: &corepb.Node{
 				Id: opts.Node,
 			},
-			TypeUrl: rspb.ListenerType,
+			TypeUrl: resource.ListenerType,
 		}
 
 		respForListener, err := manager.cache.Fetch(ctx, reqForListener)
@@ -1729,7 +1729,7 @@ func TestServiceConfigAutoUpdate(t *testing.T) {
 			Node: &corepb.Node{
 				Id: opts.Node,
 			},
-			TypeUrl: rspb.ListenerType,
+			TypeUrl: resource.ListenerType,
 		}
 		resp, err = env.configManager.cache.Fetch(ctx, req)
 		if err != nil {


### PR DESCRIPTION
Some copybara transformations depend on variable naming or BUILD file structure:
- Visibility rules are a pain to modify and is very hacky in copybara. Just delete them, it doesn't give us much benefit.
- `ptype` should be `ptypepb`, as it's a proto.
- `rspb` should be `resource`, as it's plain old golang code (not a proto).

Signed-off-by: Teju Nareddy <nareddyt@google.com>