### PR TITLE
Fix network fail open for Unavailable CheckResponse errors

### DIFF
--- a/src/api_proxy/service_control/check_response_test.cc
+++ b/src/api_proxy/service_control/check_response_test.cc
@@ -141,27 +141,46 @@ TEST(CheckResponseTest, WhenResponseIsBlockedWithConsumerInvalid) {
   EXPECT_EQ(Code::PERMISSION_DENIED, result.code());
 }
 
-TEST(CheckResponseTest, FailOpenWhenResponseIsUnknownNamespaceLookup) {
-  EXPECT_TRUE(
-      ConvertCheckErrorToStatus(CheckError::NAMESPACE_LOOKUP_UNAVAILABLE).ok());
+TEST(CheckResponseTest, WhenResponseIsBlockedWithNamespaceLookup) {
+  const Status result =
+      ConvertCheckErrorToStatus(CheckError::NAMESPACE_LOOKUP_UNAVAILABLE);
+  EXPECT_EQ(Code::UNAVAILABLE, result.code());
 }
 
-TEST(CheckResponseTest, UnavailableCheckErrorStatus) {
-  EXPECT_TRUE(
-      ConvertCheckErrorToStatus(CheckError::BILLING_STATUS_UNAVAILABLE).ok());
-  EXPECT_TRUE(
-      ConvertCheckErrorToStatus(CheckError::SERVICE_STATUS_UNAVAILABLE).ok());
-  EXPECT_TRUE(
-      ConvertCheckErrorToStatus(CheckError::QUOTA_CHECK_UNAVAILABLE).ok());
-  EXPECT_TRUE(ConvertCheckErrorToStatus(
-                  CheckError::CLOUD_RESOURCE_MANAGER_BACKEND_UNAVAILABLE)
-                  .ok());
-  EXPECT_TRUE(
-      ConvertCheckErrorToStatus(CheckError::SECURITY_POLICY_BACKEND_UNAVAILABLE)
-          .ok());
-  EXPECT_TRUE(
-      ConvertCheckErrorToStatus(CheckError::LOCATION_POLICY_BACKEND_UNAVAILABLE)
-          .ok());
+TEST(CheckResponseTest, WhenResponseIsBlockedWithBillingStatus) {
+  const Status result =
+      ConvertCheckErrorToStatus(CheckError::BILLING_STATUS_UNAVAILABLE);
+  EXPECT_EQ(Code::UNAVAILABLE, result.code());
+}
+
+TEST(CheckResponseTest, WhenResponseIsBlockedWithServiceStatus) {
+  const Status result =
+      ConvertCheckErrorToStatus(CheckError::SERVICE_STATUS_UNAVAILABLE);
+  EXPECT_EQ(Code::UNAVAILABLE, result.code());
+}
+
+TEST(CheckResponseTest, WhenResponseIsBlockedWithQuotaCheck) {
+  const Status result =
+      ConvertCheckErrorToStatus(CheckError::QUOTA_CHECK_UNAVAILABLE);
+  EXPECT_EQ(Code::UNAVAILABLE, result.code());
+}
+
+TEST(CheckResponseTest, WhenResponseIsBlockedWithCloudResourceManager) {
+  const Status result = ConvertCheckErrorToStatus(
+      CheckError::CLOUD_RESOURCE_MANAGER_BACKEND_UNAVAILABLE);
+  EXPECT_EQ(Code::UNAVAILABLE, result.code());
+}
+
+TEST(CheckResponseTest, WhenResponseIsBlockedWithSecurityPolicy) {
+  const Status result = ConvertCheckErrorToStatus(
+      CheckError::SECURITY_POLICY_BACKEND_UNAVAILABLE);
+  EXPECT_EQ(Code::UNAVAILABLE, result.code());
+}
+
+TEST(CheckResponseTest, WhenResponseIsBlockedWithLocationPolicy) {
+  const Status result = ConvertCheckErrorToStatus(
+      CheckError::LOCATION_POLICY_BACKEND_UNAVAILABLE);
+  EXPECT_EQ(Code::UNAVAILABLE, result.code());
 }
 
 }  // namespace service_control

--- a/src/api_proxy/service_control/request_builder.cc
+++ b/src/api_proxy/service_control/request_builder.cc
@@ -1429,8 +1429,10 @@ Status RequestBuilder::ConvertCheckResponse(
     case CheckError::CLOUD_RESOURCE_MANAGER_BACKEND_UNAVAILABLE:
     case CheckError::SECURITY_POLICY_BACKEND_UNAVAILABLE:
     case CheckError::LOCATION_POLICY_BACKEND_UNAVAILABLE:
-      // Fail open for internal server errors per recommendation
-      return Status::OK;
+      return Status(
+          Code::UNAVAILABLE,
+          "One or more Google Service Control backends are unavailable.");
+
     default:
       return Status(
           Code::INTERNAL,

--- a/src/envoy/http/service_control/client_cache.cc
+++ b/src/envoy/http/service_control/client_cache.cc
@@ -302,34 +302,57 @@ CancelFunc ClientCache::callCheck(
   auto* response = new CheckResponse;
   client_->Check(
       request, response,
-      [this, response, on_done](const Status& status) {
+      [this, response, on_done](const Status& http_status) {
         CheckResponseInfo response_info;
-        if (status.ok()) {
-          Status converted_status = ::espv2::api_proxy::service_control::
-              RequestBuilder::ConvertCheckResponse(
+        Status final_status;
+        bool translate_non_5xx;
+
+        if (http_status.ok()) {
+          // If the http call succeeded, then use the CheckResponseInfo
+          // to retrieve the final status.
+          final_status =
+              api_proxy::service_control::RequestBuilder::ConvertCheckResponse(
                   *response, config_.service_name(), &response_info);
-          on_done(converted_status, response_info);
-        } else if (status.error_code() == Code::UNAVAILABLE) {
-          // Envoy::Grpc::httpToGrpcStatus() is called at http_call.cc at
-          // HttpCallImpl::onSuccess to map http_code to grpc_code.
-          // All 5xx server error codes have been mapped to Code::UNAVAILABLE.
-          // network_fail_open only applies to 5xx server error codes.
+          // Check errors should be displayed to the client.
+          translate_non_5xx = false;
+        } else {
+          // Otherwise, http call failed. Use that status to respond.
+          final_status = http_status;
+          // Http call errors should NOT be displayed to the client.
+          translate_non_5xx = true;
+        }
+
+        if (final_status.ok()) {
+          on_done(final_status, response_info);
+        } else if (final_status.error_code() == Code::UNAVAILABLE) {
+          // All 5xx errors are already translated to Unavailable.
           if (network_fail_open_) {
-            ENVOY_LOG(debug,
-                      "service control check fails, but the request is allowed "
-                      "due to network_fail_open policy.");
+            ENVOY_LOG(warn,
+                      "Google Service Control Check is unavailable, but the "
+                      "request is allowed due to network fail open. Original "
+                      "error: {}",
+                      final_status.error_message());
             on_done(Status::OK, response_info);
           } else {
             // Preserve the original 5xx error code in the response back.
-            on_done(status, response_info);
+            ENVOY_LOG(warn,
+                      "Google Service Control Check is unavailable, and the "
+                      "request is denied with error: {}",
+                      final_status.error_message());
+            on_done(final_status, response_info);
           }
         } else {
-          // This is not caused by a client request error, so translate non-5xx
-          // error codes to 500 Internal Server Error. Error message contains
-          // details on the original error (including the original HTTP status
-          // code).
-          Status converted(Code::INTERNAL, status.error_message());
-          on_done(converted, response_info);
+          if (translate_non_5xx) {
+            // This is not caused by a client request error, so translate
+            // non-5xx error codes to 500 Internal Server Error. Error message
+            // contains details on the original error (including the original
+            // HTTP status code).
+            Status scrubbed_status(Code::INTERNAL,
+                                   final_status.error_message());
+            on_done(scrubbed_status, response_info);
+          } else {
+            on_done(final_status, response_info);
+          }
         }
         delete response;
       },

--- a/tests/env/components/ports.go
+++ b/tests/env/components/ports.go
@@ -103,8 +103,8 @@ const (
 	TestServiceControlJwtAuthFail
 	TestServiceControlLogHeaders
 	TestServiceControlLogJwtPayloads
-	TestServiceControlNetworkFailFlagClosed
-	TestServiceControlNetworkFailFlagOpen
+	TestServiceControlNetworkFailFlagForTimeout
+	TestServiceControlNetworkFailFlagForUnavailableCheckResponse
 	TestServiceControlProtocolWithGRPCBackend
 	TestServiceControlProtocolWithHTTPBackend
 	TestServiceControlQuota

--- a/tests/integration_test/service_control_check_network_fail_test.go
+++ b/tests/integration_test/service_control_check_network_fail_test.go
@@ -27,6 +27,7 @@ import (
 
 	bsclient "github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/bookstore_grpc/client"
 	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
+	scpb "google.golang.org/genproto/googleapis/api/servicecontrol/v1"
 )
 
 func TestServiceControlCheckNetworkFail(t *testing.T) {
@@ -151,7 +152,7 @@ func (h *localServiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	w.Write([]byte(""))
 }
 
-func TestServiceControlNetworkFailFlag(t *testing.T) {
+func TestServiceControlNetworkFailFlagForTimeout(t *testing.T) {
 	t.Parallel()
 
 	serviceName := "bookstore-service"
@@ -162,7 +163,6 @@ func TestServiceControlNetworkFailFlag(t *testing.T) {
 	tests := []struct {
 		desc            string
 		networkFailOpen bool
-		port            uint16
 		clientProtocol  string
 		httpMethod      string
 		method          string
@@ -174,7 +174,6 @@ func TestServiceControlNetworkFailFlag(t *testing.T) {
 		{
 			desc:            "Successful, since service_control_network_fail_open is set as true, the timeout of service control check response will be ignored.",
 			networkFailOpen: true,
-			port:            comp.TestServiceControlNetworkFailFlagOpen,
 			clientProtocol:  "http",
 			httpMethod:      "GET",
 			method:          "/v1/shelves?key=api-key",
@@ -182,9 +181,8 @@ func TestServiceControlNetworkFailFlag(t *testing.T) {
 			wantResp:        `{"shelves":[{"id":"100","theme":"Kids"},{"id":"200","theme":"Classic"}]}`,
 		},
 		{
-			desc:            "Failed, since service_control_network_fail_open is set as true default, the timeout of service control check response won't be ignored.",
+			desc:            "Failed, since service_control_network_fail_open is set as false, the timeout of service control check response won't be ignored.",
 			networkFailOpen: false,
-			port:            comp.TestServiceControlNetworkFailFlagClosed,
 			clientProtocol:  "http",
 			httpMethod:      "GET",
 			method:          "/v1/shelves?key=api-key",
@@ -195,7 +193,7 @@ func TestServiceControlNetworkFailFlag(t *testing.T) {
 
 	for _, tc := range tests {
 		func() {
-			s := env.NewTestEnv(tc.port, platform.GrpcBookstoreSidecar)
+			s := env.NewTestEnv(comp.TestServiceControlNetworkFailFlagForTimeout, platform.GrpcBookstoreSidecar)
 			s.ServiceControlServer.OverrideCheckHandler(&localServiceHandler{
 				m: s.ServiceControlServer,
 			})
@@ -209,6 +207,101 @@ func TestServiceControlNetworkFailFlag(t *testing.T) {
 			}
 
 			s.ServiceControlServer.ResetRequestCount()
+			addr := fmt.Sprintf("localhost:%v", s.Ports().ListenerPort)
+			resp, err := bsclient.MakeCall(tc.clientProtocol, addr, tc.httpMethod, tc.method, tc.token, nil)
+
+			if tc.wantError != "" && (err == nil || !strings.Contains(err.Error(), tc.wantError)) {
+				t.Errorf("Test (%s): failed, expected err: %v, got: %v", tc.desc, tc.wantError, err)
+			} else if !strings.Contains(resp, tc.wantResp) {
+				t.Errorf("Test (%s): failed, expected: %s, got: %s", tc.desc, tc.wantResp, resp)
+			}
+		}()
+	}
+}
+
+func TestServiceControlNetworkFailFlagForUnavailableCheckResponse(t *testing.T) {
+	t.Parallel()
+
+	serviceName := "bookstore-service"
+	configID := "test-config-id"
+	args := []string{"--service=" + serviceName, "--service_config_id=" + configID,
+		"--rollout_strategy=fixed"}
+
+	tests := []struct {
+		desc            string
+		networkFailOpen bool
+		checkResponse   scpb.CheckResponse
+		clientProtocol  string
+		httpMethod      string
+		method          string
+		token           string
+		checkFailStatus int
+		wantResp        string
+		wantError       string
+	}{
+		{
+			desc:            "Successful, since service_control_network_fail_open is set as true, the unavailable check error will be ignored.",
+			networkFailOpen: true,
+			checkResponse: scpb.CheckResponse{
+				CheckErrors: []*scpb.CheckError{
+					{
+						Code: scpb.CheckError_NAMESPACE_LOOKUP_UNAVAILABLE,
+					},
+				},
+			},
+			clientProtocol: "http",
+			httpMethod:     "GET",
+			method:         "/v1/shelves?key=api-key",
+			token:          testdata.FakeCloudTokenMultiAudiences,
+			wantResp:       `{"shelves":[{"id":"100","theme":"Kids"},{"id":"200","theme":"Classic"}]}`,
+		},
+		{
+			desc:            "Failed, since service_control_network_fail_open is set as false, the unavailable check error won't be ignored.",
+			networkFailOpen: false,
+			checkResponse: scpb.CheckResponse{
+				CheckErrors: []*scpb.CheckError{
+					{
+						Code: scpb.CheckError_NAMESPACE_LOOKUP_UNAVAILABLE,
+					},
+				},
+			},
+			clientProtocol: "http",
+			httpMethod:     "GET",
+			method:         "/v1/shelves?key=api-key",
+			token:          testdata.FakeCloudTokenMultiAudiences,
+			wantError:      "503 Service Unavailable, UNAVAILABLE:One or more Google Service Control backends are unavailable.",
+		},
+		{
+			desc:            "Failed, even though service_control_network_fail_open is set as true, non-5xx check error won't be ignored.",
+			networkFailOpen: true,
+			checkResponse: scpb.CheckResponse{
+				CheckErrors: []*scpb.CheckError{
+					{
+						Code: scpb.CheckError_PROJECT_INVALID,
+					},
+				},
+			},
+			clientProtocol: "http",
+			httpMethod:     "GET",
+			method:         "/v1/shelves?key=api-key",
+			token:          testdata.FakeCloudTokenMultiAudiences,
+			wantError:      "400 Bad Request, INVALID_ARGUMENT:Client project not valid. Please pass a valid project.",
+		},
+	}
+
+	for _, tc := range tests {
+		func() {
+			s := env.NewTestEnv(comp.TestServiceControlNetworkFailFlagForUnavailableCheckResponse, platform.GrpcBookstoreSidecar)
+			s.ServiceControlServer.SetCheckResponse(&tc.checkResponse)
+			if tc.networkFailOpen {
+				s.EnableScNetworkFailOpen()
+			}
+
+			defer s.TearDown()
+			if err := s.Setup(args); err != nil {
+				t.Fatalf("fail to setup test env, %v", err)
+			}
+
 			addr := fmt.Sprintf("localhost:%v", s.Ports().ListenerPort)
 			resp, err := bsclient.MakeCall(tc.clientProtocol, addr, tc.httpMethod, tc.method, tc.token, nil)
 


### PR DESCRIPTION
If SC returns unavailable as part of the `CheckResponse` proto (not the HTTP call), then we always network fail open. Modify the logic so we only network fail open when the option is true. While we don't expect many customers to disable network fail open, it gives us a chance to log warnings and fixes a bug.

Also refactor the callback a little. This should make it easier to track stats for check responses (#151, b/155209585, etc.).

Testing: Add integration test for `network_fail_open` with 5xx vs non-5xx `CheckResponse` errors.

Signed-off-by: Teju Nareddy <nareddyt@google.com>