### PR TITLE
Assert path matcher query params are valid in fuzz test

### DIFF
--- a/src/api_proxy/service_control/check_response_test.cc
+++ b/src/api_proxy/service_control/check_response_test.cc
@@ -140,7 +140,7 @@ TEST(CheckResponseTest, WhenResponseIsBlockedWithConsumerInvalid) {
   Status result = ConvertCheckErrorToStatus(CheckError::CONSUMER_INVALID);
   EXPECT_EQ(Code::PERMISSION_DENIED, result.code());
 }
-  
+
 TEST(CheckResponseTest, WhenResponseIsBlockedWithResourceExhuasted) {
   Status result = ConvertCheckErrorToStatus(CheckError::RESOURCE_EXHAUSTED);
   EXPECT_EQ(Code::RESOURCE_EXHAUSTED, result.code());

--- a/src/envoy/http/path_matcher/BUILD
+++ b/src/envoy/http/path_matcher/BUILD
@@ -91,6 +91,7 @@ envoy_cc_fuzz_test(
     repository = "@envoy",
     deps = [
         ":filter_lib",
+        "//src/envoy/utils:filter_state_utils_lib",
         "//tests/fuzz/structured_inputs:path_matcher_filter_proto_cc_proto",
         "@envoy//test/fuzz:utility_lib",
         "@envoy//test/mocks/init:init_mocks",

--- a/src/envoy/http/path_matcher/filter_fuzz_test.cc
+++ b/src/envoy/http/path_matcher/filter_fuzz_test.cc
@@ -4,6 +4,7 @@
 #include "test/mocks/server/mocks.h"
 
 #include "src/envoy/http/path_matcher/filter.h"
+#include "src/envoy/utils/filter_state_utils.h"
 #include "tests/fuzz/structured_inputs/path_matcher_filter.pb.validate.h"
 
 #include "gmock/gmock.h"
@@ -60,6 +61,12 @@ DEFINE_PROTO_FUZZER(
 
     // Run data against the filter.
     ASSERT_NO_THROW(doTest(filter, input));
+
+    // Ensure the query param filter state is valid.
+    absl::string_view query_params = utils::getStringFilterState(
+        *mock_decoder_callbacks.stream_info_.filter_state_,
+        utils::kQueryParams);
+    ASSERT_TRUE(Envoy::Http::validHeaderString(query_params));
 
   } catch (const Envoy::EnvoyException& e) {
     ENVOY_LOG_MISC(debug, "Controlled envoy exception: {}", e.what());


### PR DESCRIPTION
They are extracted from the path header, so they should be valid. But just add a check to confirm.

Signed-off-by: Teju Nareddy <nareddyt@google.com>