### PR TITLE
b/155209585 #1: Refactor callback for testability and implement `denied_control_plane_fault`

### DIFF
--- a/src/api_proxy/service_control/check_response_test.cc
+++ b/src/api_proxy/service_control/check_response_test.cc
@@ -140,7 +140,7 @@ TEST(CheckResponseTest, WhenResponseIsBlockedWithConsumerInvalid) {
   Status result = ConvertCheckErrorToStatus(CheckError::CONSUMER_INVALID);
   EXPECT_EQ(Code::PERMISSION_DENIED, result.code());
 }
-  
+
 TEST(CheckResponseTest, WhenResponseIsBlockedWithResourceExhuasted) {
   Status result = ConvertCheckErrorToStatus(CheckError::RESOURCE_EXHAUSTED);
   EXPECT_EQ(Code::RESOURCE_EXHAUSTED, result.code());

--- a/src/envoy/http/service_control/BUILD
+++ b/src/envoy/http/service_control/BUILD
@@ -92,6 +92,24 @@ envoy_cc_library(
     ],
 )
 
+envoy_cc_test(
+    name = "client_cache_test",
+    size = "small",
+    srcs = [
+        "client_cache_test.cc",
+    ],
+    repository = "@envoy",
+    deps = [
+        ":client_cache_lib",
+        ":mocks_lib",
+        "@envoy//source/common/common:empty_string",
+        "@envoy//test/mocks/event:event_mocks",
+        "@envoy//test/mocks/server:server_mocks",
+        "@envoy//test/mocks/stats:stats_mocks",
+        "@envoy//test/test_common:utility_lib",
+    ],
+)
+
 envoy_cc_library(
     name = "service_control_call_impl_lib",
     srcs = ["service_control_call_impl.cc"],

--- a/src/envoy/http/service_control/client_cache.h
+++ b/src/envoy/http/service_control/client_cache.h
@@ -62,6 +62,8 @@ class ClientCache : public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
       const ::google::api::servicecontrol::v1::ReportRequest& request);
 
  private:
+  friend class test::ClientCacheCheckResponseTest;
+
   // Ownership of CheckResponse is passed to this function.
   // The function will always call CheckDoneFunc.
   void handleCheckResponse(
@@ -117,8 +119,6 @@ class ClientCache : public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
 
   // Used to retrieve the current time for tracing.
   Envoy::TimeSource& time_source_;
-
-  friend class test::ClientCacheCheckResponseTest;
 };
 
 }  // namespace service_control

--- a/src/envoy/http/service_control/client_cache.h
+++ b/src/envoy/http/service_control/client_cache.h
@@ -30,8 +30,10 @@ namespace envoy {
 namespace http_filters {
 namespace service_control {
 
-using ::google::api::servicecontrol::v1::CheckResponse;
-using ::google::protobuf::util::Status;
+// Forward declare friend class to test private functions.
+namespace test {
+class ClientCacheCheckResponseTest;
+}
 
 // The class to cache check and batch report.
 class ClientCache : public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
@@ -52,11 +54,6 @@ class ClientCache : public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
       const ::google::api::servicecontrol::v1::CheckRequest& request,
       Envoy::Tracing::Span& parent_span, CheckDoneFunc on_done);
 
-  // Ownership of CheckResponse is passed to this function.
-  // The function will always call CheckDoneFunc.
-  void handleCheckResponse(const Status& http_status, CheckResponse* response,
-                           CheckDoneFunc on_done);
-
   void callQuota(
       const ::google::api::servicecontrol::v1::AllocateQuotaRequest& request,
       QuotaDoneFunc on_done);
@@ -65,6 +62,13 @@ class ClientCache : public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
       const ::google::api::servicecontrol::v1::ReportRequest& request);
 
  private:
+  // Ownership of CheckResponse is passed to this function.
+  // The function will always call CheckDoneFunc.
+  void handleCheckResponse(
+      const ::google::protobuf::util::Status& http_status,
+      ::google::api::servicecontrol::v1::CheckResponse* response,
+      CheckDoneFunc on_done);
+
   void initHttpRequestSetting(
       const ::google::api::envoy::http::service_control::FilterConfig&
           filter_config);
@@ -113,6 +117,8 @@ class ClientCache : public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
 
   // Used to retrieve the current time for tracing.
   Envoy::TimeSource& time_source_;
+
+  friend class test::ClientCacheCheckResponseTest;
 };
 
 }  // namespace service_control

--- a/src/envoy/http/service_control/client_cache.h
+++ b/src/envoy/http/service_control/client_cache.h
@@ -30,6 +30,9 @@ namespace envoy {
 namespace http_filters {
 namespace service_control {
 
+using ::google::api::servicecontrol::v1::CheckResponse;
+using ::google::protobuf::util::Status;
+
 // The class to cache check and batch report.
 class ClientCache : public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
  public:
@@ -48,6 +51,11 @@ class ClientCache : public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
   CancelFunc callCheck(
       const ::google::api::servicecontrol::v1::CheckRequest& request,
       Envoy::Tracing::Span& parent_span, CheckDoneFunc on_done);
+
+  // Ownership of CheckResponse is passed to this function.
+  // The function will always call CheckDoneFunc.
+  void handleCheckResponse(const Status& http_status, CheckResponse* response,
+                           CheckDoneFunc on_done);
 
   void callQuota(
       const ::google::api::servicecontrol::v1::AllocateQuotaRequest& request,

--- a/src/envoy/http/service_control/client_cache_test.cc
+++ b/src/envoy/http/service_control/client_cache_test.cc
@@ -1,0 +1,179 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/envoy/http/service_control/client_cache.h"
+#include "common/common/empty_string.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "test/mocks/common.h"
+#include "test/mocks/event/mocks.h"
+#include "test/mocks/server/mocks.h"
+#include "test/mocks/stats/mocks.h"
+#include "test/test_common/utility.h"
+
+namespace espv2 {
+namespace envoy {
+namespace http_filters {
+namespace service_control {
+namespace {
+
+using ::espv2::api_proxy::service_control::CheckResponseInfo;
+using ::google::api::envoy::http::service_control::FilterConfig;
+using ::google::api::envoy::http::service_control::Service;
+using ::google::api::servicecontrol::v1::CheckError;
+using ::google::protobuf::util::Status;
+using ::google::protobuf::util::error::Code;
+using ::testing::NiceMock;
+
+class ClientCacheCheckResponseTest : public ::testing::Test {
+ protected:
+  ClientCacheCheckResponseTest() : stats_base_("test", context_.scope_) {
+    token_fn_ = []() { return Envoy::EMPTY_STRING; };
+  }
+
+  void SetUp() override {
+    cache_ = std::make_unique<ClientCache>(
+        service_config_, filter_config_, stats_base_.stats(), cm_, time_source_,
+        dispatcher_, token_fn_, token_fn_);
+  }
+
+  void CheckAndReset(Envoy::Stats::Counter& counter, const int expected_value) {
+    EXPECT_EQ(counter.value(), expected_value);
+    counter.reset();
+  }
+
+  void TearDown() override {
+    CheckAndReset(stats_base_.stats().filter_.allowed_control_plane_fault_, 0);
+    CheckAndReset(stats_base_.stats().filter_.denied_control_plane_fault_, 0);
+  }
+
+  // Helpers for SetUp.
+  Service service_config_;
+  FilterConfig filter_config_;
+  NiceMock<Envoy::Upstream::MockClusterManager> cm_;
+  NiceMock<Envoy::Event::MockDispatcher> dispatcher_;
+  NiceMock<Envoy::MockTimeSystem> time_source_;
+  NiceMock<Envoy::Server::Configuration::MockFactoryContext> context_;
+  ServiceControlFilterStatBase stats_base_;
+  std::function<const std::string&()> token_fn_;
+
+  // Class under test.
+  std::unique_ptr<ClientCache> cache_;
+};
+
+TEST_F(ClientCacheCheckResponseTest, Http5xxAllowed) {
+  CheckDoneFunc on_done = [](const Status& status, const CheckResponseInfo&) {
+    EXPECT_EQ(status.code(), Code::OK);
+  };
+
+  CheckResponse* resp = new CheckResponse();
+  const Status http_status(Code::UNAVAILABLE, "");
+  cache_->handleCheckResponse(http_status, resp, on_done);
+
+  CheckAndReset(stats_base_.stats().filter_.allowed_control_plane_fault_, 1);
+}
+
+TEST_F(ClientCacheCheckResponseTest, Http4xxTranslatedAndBlocked) {
+  CheckDoneFunc on_done = [](const Status& status, const CheckResponseInfo&) {
+    EXPECT_EQ(status.code(), Code::INTERNAL);
+  };
+
+  CheckResponse* resp = new CheckResponse();
+  const Status http_status(Code::PERMISSION_DENIED, "");
+  cache_->handleCheckResponse(http_status, resp, on_done);
+}
+
+TEST_F(ClientCacheCheckResponseTest, Sc5xxAllowed) {
+  CheckDoneFunc on_done = [](const Status& status, const CheckResponseInfo&) {
+    EXPECT_EQ(status.code(), Code::OK);
+  };
+
+  CheckResponse* resp = new CheckResponse();
+  CheckError* check_error = resp->mutable_check_errors()->Add();
+  check_error->set_code(CheckError::NAMESPACE_LOOKUP_UNAVAILABLE);
+
+  const Status http_status(Code::OK, "");
+  cache_->handleCheckResponse(http_status, resp, on_done);
+
+  CheckAndReset(stats_base_.stats().filter_.allowed_control_plane_fault_, 1);
+}
+
+TEST_F(ClientCacheCheckResponseTest, Sc4xxBlocked) {
+  CheckDoneFunc on_done = [](const Status& status, const CheckResponseInfo&) {
+    EXPECT_EQ(status.code(), Code::PERMISSION_DENIED);
+  };
+
+  CheckResponse* resp = new CheckResponse();
+  CheckError* check_error = resp->mutable_check_errors()->Add();
+  check_error->set_code(CheckError::CLIENT_APP_BLOCKED);
+
+  const Status http_status(Code::OK, "");
+  cache_->handleCheckResponse(http_status, resp, on_done);
+}
+
+TEST_F(ClientCacheCheckResponseTest, ScOkAllowed) {
+  CheckDoneFunc on_done = [](const Status& status, const CheckResponseInfo&) {
+    EXPECT_EQ(status.code(), Code::OK);
+  };
+
+  CheckResponse* resp = new CheckResponse();
+
+  const Status http_status(Code::OK, "");
+  cache_->handleCheckResponse(http_status, resp, on_done);
+}
+
+class ClientCacheCheckResponseNetworkFailClosedTest
+    : public ClientCacheCheckResponseTest {
+  void SetUp() override {
+    filter_config_.mutable_sc_calling_config()
+        ->mutable_network_fail_open()
+        ->set_value(false);
+    cache_ = std::make_unique<ClientCache>(
+        service_config_, filter_config_, stats_base_.stats(), cm_, time_source_,
+        dispatcher_, token_fn_, token_fn_);
+  }
+};
+
+TEST_F(ClientCacheCheckResponseNetworkFailClosedTest, Http5xxBlocked) {
+  CheckDoneFunc on_done = [](const Status& status, const CheckResponseInfo&) {
+    EXPECT_EQ(status.code(), Code::UNAVAILABLE);
+  };
+
+  CheckResponse* resp = new CheckResponse();
+  const Status http_status(Code::UNAVAILABLE, "");
+  cache_->handleCheckResponse(http_status, resp, on_done);
+
+  CheckAndReset(stats_base_.stats().filter_.denied_control_plane_fault_, 1);
+}
+
+TEST_F(ClientCacheCheckResponseNetworkFailClosedTest, Sc5xxBlocked) {
+  CheckDoneFunc on_done = [](const Status& status, const CheckResponseInfo&) {
+    EXPECT_EQ(status.code(), Code::UNAVAILABLE);
+  };
+
+  CheckResponse* resp = new CheckResponse();
+  CheckError* check_error = resp->mutable_check_errors()->Add();
+  check_error->set_code(CheckError::NAMESPACE_LOOKUP_UNAVAILABLE);
+
+  const Status http_status(Code::OK, "");
+  cache_->handleCheckResponse(http_status, resp, on_done);
+
+  CheckAndReset(stats_base_.stats().filter_.denied_control_plane_fault_, 1);
+}
+
+}  // namespace
+}  // namespace service_control
+}  // namespace http_filters
+}  // namespace envoy
+}  // namespace espv2

--- a/src/envoy/http/service_control/filter_stats.h
+++ b/src/envoy/http/service_control/filter_stats.h
@@ -26,10 +26,11 @@ namespace service_control {
 /**
  * General service control filter stats. @see stats_macros.h
  */
-// clang-format off
 #define FILTER_STATS(COUNTER, HISTOGRAM) \
   COUNTER(allowed)                       \
+  COUNTER(allowed_control_plane_fault)   \
   COUNTER(denied)                        \
+  COUNTER(denied_control_plane_fault)    \
   HISTOGRAM(request_time, Milliseconds)  \
   HISTOGRAM(backend_time, Milliseconds)  \
   HISTOGRAM(overhead_time, Milliseconds)
@@ -55,8 +56,6 @@ namespace service_control {
   COUNTER(UNAVAILABLE)             \
   COUNTER(DATA_LOSS)               \
   COUNTER(UNAUTHENTICATED)
-
-// clang-format on
 
 /**
  * Wrapper struct for general service control filter stats. @see stats_macros.h


### PR DESCRIPTION
When HTTP call is unsuccessful, SC Check returns HTTP 500, or SC Check returns a check response with a 5xx-like status:
- For network fail open: Increment `allowed_control_plane_fault`
- For network fail closed: Increment `refactor_control_plane_fault`

The code changes for above are very simple (2 lines to increment a counter). Most of this diff is from splitting the callback into another function that we can unit test. Added unit tests for blocked/allowed requests and the stats.

Signed-off-by: Teju Nareddy <nareddyt@google.com>