### PR TITLE
b/155209585 #2: Implement `denied_consumer_blocked` and `denied_consumer_error` stats

### DIFF
--- a/src/api_proxy/service_control/check_response_test.cc
+++ b/src/api_proxy/service_control/check_response_test.cc
@@ -29,174 +29,236 @@ namespace {
 
 Status ConvertCheckErrorToStatus(gasv1::CheckError::Code code,
                                  const char* error_detail,
-                                 const char* service_name) {
+                                 const char* service_name,
+                                 CheckResponseInfo* info) {
   gasv1::CheckResponse response;
   gasv1::CheckError* check_error = response.add_check_errors();
-  CheckRequestInfo info;
   check_error->set_code(code);
   check_error->set_detail(error_detail);
-  return RequestBuilder::ConvertCheckResponse(response, service_name, nullptr);
+  return RequestBuilder::ConvertCheckResponse(response, service_name, info);
 }
 
-Status ConvertCheckErrorToStatus(gasv1::CheckError::Code code) {
+Status ConvertCheckErrorToStatus(gasv1::CheckError::Code code,
+                                 CheckResponseInfo* info) {
   gasv1::CheckResponse response;
   std::string service_name;
   response.add_check_errors()->set_code(code);
-  return RequestBuilder::ConvertCheckResponse(response, service_name, nullptr);
+  return RequestBuilder::ConvertCheckResponse(response, service_name, info);
 }
 
 }  // namespace
 
 TEST(CheckResponseTest, AbortedWithInvalidArgumentWhenRespIsKeyInvalid) {
-  Status result = ConvertCheckErrorToStatus(CheckError::API_KEY_INVALID);
+  CheckResponseInfo info;
+  Status result = ConvertCheckErrorToStatus(CheckError::API_KEY_INVALID, &info);
   EXPECT_EQ(Code::INVALID_ARGUMENT, result.code());
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::API_KEY_INVALID);
 }
 
 TEST(CheckResponseTest, AbortedWithInvalidArgumentWhenRespIsKeyExpired) {
-  Status result = ConvertCheckErrorToStatus(CheckError::API_KEY_EXPIRED);
+  CheckResponseInfo info;
+  Status result = ConvertCheckErrorToStatus(CheckError::API_KEY_EXPIRED, &info);
   EXPECT_EQ(Code::INVALID_ARGUMENT, result.code());
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::API_KEY_INVALID);
 }
 
 TEST(CheckResponseTest,
      AbortedWithInvalidArgumentWhenRespIsBlockedWithNotFound) {
-  Status result = ConvertCheckErrorToStatus(CheckError::NOT_FOUND);
+  CheckResponseInfo info;
+  Status result = ConvertCheckErrorToStatus(CheckError::NOT_FOUND, &info);
   EXPECT_EQ(Code::INVALID_ARGUMENT, result.code());
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::CONSUMER_ERROR);
 }
 
 TEST(CheckResponseTest,
      AbortedWithInvalidArgumentWhenRespIsBlockedWithKeyNotFound) {
-  Status result = ConvertCheckErrorToStatus(CheckError::API_KEY_NOT_FOUND);
+  CheckResponseInfo info;
+  Status result =
+      ConvertCheckErrorToStatus(CheckError::API_KEY_NOT_FOUND, &info);
   EXPECT_EQ(Code::INVALID_ARGUMENT, result.code());
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::API_KEY_INVALID);
 }
 
 TEST(CheckResponseTest,
      AbortedWithPermissionDeniedWhenRespIsBlockedWithServiceNotActivated) {
-  Status result = ConvertCheckErrorToStatus(
-      CheckError::SERVICE_NOT_ACTIVATED, "Service not activated.", "api_xxxx");
+  CheckResponseInfo info;
+  Status result =
+      ConvertCheckErrorToStatus(CheckError::SERVICE_NOT_ACTIVATED,
+                                "Service not activated.", "api_xxxx", &info);
   EXPECT_EQ(Code::PERMISSION_DENIED, result.code());
   EXPECT_EQ(result.message(), "API api_xxxx is not enabled for the project.");
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::SERVICE_NOT_ACTIVATED);
 }
 
 TEST(CheckResponseTest,
      AbortedWithPermissionDeniedWhenRespIsBlockedWithPermissionDenied) {
-  Status result = ConvertCheckErrorToStatus(CheckError::PERMISSION_DENIED);
+  CheckResponseInfo info;
+  Status result =
+      ConvertCheckErrorToStatus(CheckError::PERMISSION_DENIED, &info);
   EXPECT_EQ(Code::PERMISSION_DENIED, result.code());
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::CONSUMER_ERROR);
 }
 
 TEST(CheckResponseTest,
      AbortedWithPermissionDeniedWhenRespIsBlockedWithIpAddressBlocked) {
-  Status result = ConvertCheckErrorToStatus(CheckError::IP_ADDRESS_BLOCKED);
+  CheckResponseInfo info;
+  Status result =
+      ConvertCheckErrorToStatus(CheckError::IP_ADDRESS_BLOCKED, &info);
   EXPECT_EQ(Code::PERMISSION_DENIED, result.code());
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::CONSUMER_BLOCKED);
 }
 
 TEST(CheckResponseTest,
      AbortedWithPermissionDeniedWhenRespIsBlockedWithRefererBlocked) {
-  Status result = ConvertCheckErrorToStatus(CheckError::REFERER_BLOCKED);
+  CheckResponseInfo info;
+  Status result = ConvertCheckErrorToStatus(CheckError::REFERER_BLOCKED, &info);
   EXPECT_EQ(Code::PERMISSION_DENIED, result.code());
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::CONSUMER_BLOCKED);
 }
 
 TEST(CheckResponseTest,
      AbortedWithPermissionDeniedWhenRespIsBlockedWithClientAppBlocked) {
-  Status result = ConvertCheckErrorToStatus(CheckError::CLIENT_APP_BLOCKED);
+  CheckResponseInfo info;
+  Status result =
+      ConvertCheckErrorToStatus(CheckError::CLIENT_APP_BLOCKED, &info);
   EXPECT_EQ(Code::PERMISSION_DENIED, result.code());
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::CONSUMER_BLOCKED);
 }
 
 TEST(CheckResponseTest,
      AbortedWithPermissionDeniedWhenResponseIsBlockedWithProjectDeleted) {
-  Status result = ConvertCheckErrorToStatus(CheckError::PROJECT_DELETED);
+  CheckResponseInfo info;
+  Status result = ConvertCheckErrorToStatus(CheckError::PROJECT_DELETED, &info);
   EXPECT_EQ(Code::PERMISSION_DENIED, result.code());
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::CONSUMER_ERROR);
 }
 
 TEST(CheckResponseTest,
      AbortedWithPermissionDeniedWhenResponseIsBlockedWithProjectInvalid) {
-  Status result = ConvertCheckErrorToStatus(CheckError::PROJECT_INVALID);
+  CheckResponseInfo info;
+  Status result = ConvertCheckErrorToStatus(CheckError::PROJECT_INVALID, &info);
   EXPECT_EQ(Code::INVALID_ARGUMENT, result.code());
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::CONSUMER_ERROR);
 }
 
 TEST(CheckResponseTest,
      AbortedWithPermissionDeniedWhenResponseIsBlockedWithBillingDisabled) {
-  Status result = ConvertCheckErrorToStatus(CheckError::BILLING_DISABLED);
+  CheckResponseInfo info;
+  Status result =
+      ConvertCheckErrorToStatus(CheckError::BILLING_DISABLED, &info);
   EXPECT_EQ(Code::PERMISSION_DENIED, result.code());
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::CONSUMER_ERROR);
 }
 
 TEST(CheckResponseTest, WhenResponseIsBlockedWithSecurityPolicyViolated) {
+  CheckResponseInfo info;
   Status result =
-      ConvertCheckErrorToStatus(CheckError::SECURITY_POLICY_VIOLATED);
+      ConvertCheckErrorToStatus(CheckError::SECURITY_POLICY_VIOLATED, &info);
   EXPECT_EQ(Code::PERMISSION_DENIED, result.code());
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::CONSUMER_BLOCKED);
 }
 
 TEST(CheckResponseTest, WhenResponseIsBlockedWithInvalidCredentail) {
-  Status result = ConvertCheckErrorToStatus(CheckError::INVALID_CREDENTIAL);
+  CheckResponseInfo info;
+  Status result =
+      ConvertCheckErrorToStatus(CheckError::INVALID_CREDENTIAL, &info);
   EXPECT_EQ(Code::PERMISSION_DENIED, result.code());
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::CONSUMER_ERROR);
 }
 
 TEST(CheckResponseTest, WhenResponseIsBlockedWithLocationPolicyViolated) {
+  CheckResponseInfo info;
   Status result =
-      ConvertCheckErrorToStatus(CheckError::LOCATION_POLICY_VIOLATED);
+      ConvertCheckErrorToStatus(CheckError::LOCATION_POLICY_VIOLATED, &info);
   EXPECT_EQ(Code::PERMISSION_DENIED, result.code());
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::CONSUMER_BLOCKED);
 }
 
 TEST(CheckResponseTest, WhenResponseIsBlockedWithConsumerInvalid) {
-  Status result = ConvertCheckErrorToStatus(CheckError::CONSUMER_INVALID);
+  CheckResponseInfo info;
+  Status result =
+      ConvertCheckErrorToStatus(CheckError::CONSUMER_INVALID, &info);
   EXPECT_EQ(Code::PERMISSION_DENIED, result.code());
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::CONSUMER_ERROR);
 }
 
 TEST(CheckResponseTest, WhenResponseIsBlockedWithResourceExhuasted) {
-  Status result = ConvertCheckErrorToStatus(CheckError::RESOURCE_EXHAUSTED);
+  CheckResponseInfo info;
+  Status result =
+      ConvertCheckErrorToStatus(CheckError::RESOURCE_EXHAUSTED, &info);
   EXPECT_EQ(Code::RESOURCE_EXHAUSTED, result.code());
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::UNKNOWN);
 }
 
 TEST(CheckResponseTest, WhenResponseIsBlockedWithAbuserDetected) {
-  Status result = ConvertCheckErrorToStatus(CheckError::ABUSER_DETECTED);
+  CheckResponseInfo info;
+  Status result = ConvertCheckErrorToStatus(CheckError::ABUSER_DETECTED, &info);
   EXPECT_EQ(Code::PERMISSION_DENIED, result.code());
-  EXPECT_EQ("", result.error_message());
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::CONSUMER_ERROR);
 }
 
 TEST(CheckResponseTest, WhenResponseIsBlockedWithApiTargetBlocked) {
-  Status result = ConvertCheckErrorToStatus(CheckError::API_TARGET_BLOCKED);
+  CheckResponseInfo info;
+  Status result =
+      ConvertCheckErrorToStatus(CheckError::API_TARGET_BLOCKED, &info);
   EXPECT_EQ(Code::PERMISSION_DENIED, result.code());
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::CONSUMER_BLOCKED);
 }
 
 TEST(CheckResponseTest, WhenResponseIsBlockedWithNamespaceLookup) {
-  const Status result =
-      ConvertCheckErrorToStatus(CheckError::NAMESPACE_LOOKUP_UNAVAILABLE);
+  CheckResponseInfo info;
+  const Status result = ConvertCheckErrorToStatus(
+      CheckError::NAMESPACE_LOOKUP_UNAVAILABLE, &info);
   EXPECT_EQ(Code::UNAVAILABLE, result.code());
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::UNKNOWN);
 }
 
 TEST(CheckResponseTest, WhenResponseIsBlockedWithBillingStatus) {
+  CheckResponseInfo info;
   const Status result =
-      ConvertCheckErrorToStatus(CheckError::BILLING_STATUS_UNAVAILABLE);
+      ConvertCheckErrorToStatus(CheckError::BILLING_STATUS_UNAVAILABLE, &info);
   EXPECT_EQ(Code::UNAVAILABLE, result.code());
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::UNKNOWN);
 }
 
 TEST(CheckResponseTest, WhenResponseIsBlockedWithServiceStatus) {
+  CheckResponseInfo info;
   const Status result =
-      ConvertCheckErrorToStatus(CheckError::SERVICE_STATUS_UNAVAILABLE);
+      ConvertCheckErrorToStatus(CheckError::SERVICE_STATUS_UNAVAILABLE, &info);
   EXPECT_EQ(Code::UNAVAILABLE, result.code());
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::UNKNOWN);
 }
 
 TEST(CheckResponseTest, WhenResponseIsBlockedWithQuotaCheck) {
+  CheckResponseInfo info;
   const Status result =
-      ConvertCheckErrorToStatus(CheckError::QUOTA_CHECK_UNAVAILABLE);
+      ConvertCheckErrorToStatus(CheckError::QUOTA_CHECK_UNAVAILABLE, &info);
   EXPECT_EQ(Code::UNAVAILABLE, result.code());
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::UNKNOWN);
 }
 
 TEST(CheckResponseTest, WhenResponseIsBlockedWithCloudResourceManager) {
+  CheckResponseInfo info;
   const Status result = ConvertCheckErrorToStatus(
-      CheckError::CLOUD_RESOURCE_MANAGER_BACKEND_UNAVAILABLE);
+      CheckError::CLOUD_RESOURCE_MANAGER_BACKEND_UNAVAILABLE, &info);
   EXPECT_EQ(Code::UNAVAILABLE, result.code());
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::UNKNOWN);
 }
 
 TEST(CheckResponseTest, WhenResponseIsBlockedWithSecurityPolicy) {
+  CheckResponseInfo info;
   const Status result = ConvertCheckErrorToStatus(
-      CheckError::SECURITY_POLICY_BACKEND_UNAVAILABLE);
+      CheckError::SECURITY_POLICY_BACKEND_UNAVAILABLE, &info);
   EXPECT_EQ(Code::UNAVAILABLE, result.code());
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::UNKNOWN);
 }
 
 TEST(CheckResponseTest, WhenResponseIsBlockedWithLocationPolicy) {
+  CheckResponseInfo info;
   const Status result = ConvertCheckErrorToStatus(
-      CheckError::LOCATION_POLICY_BACKEND_UNAVAILABLE);
+      CheckError::LOCATION_POLICY_BACKEND_UNAVAILABLE, &info);
   EXPECT_EQ(Code::UNAVAILABLE, result.code());
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::UNKNOWN);
 }
 
 }  // namespace service_control

--- a/src/api_proxy/service_control/check_response_test.cc
+++ b/src/api_proxy/service_control/check_response_test.cc
@@ -187,7 +187,7 @@ TEST(CheckResponseTest, WhenResponseIsBlockedWithResourceExhuasted) {
   Status result =
       ConvertCheckErrorToStatus(CheckError::RESOURCE_EXHAUSTED, &info);
   EXPECT_EQ(Code::RESOURCE_EXHAUSTED, result.code());
-  EXPECT_EQ(info.error_type, CheckResponseErrorType::UNKNOWN);
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::ERROR_TYPE_UNSPECIFIED);
 }
 
 TEST(CheckResponseTest, WhenResponseIsBlockedWithAbuserDetected) {
@@ -210,7 +210,7 @@ TEST(CheckResponseTest, WhenResponseIsBlockedWithNamespaceLookup) {
   const Status result = ConvertCheckErrorToStatus(
       CheckError::NAMESPACE_LOOKUP_UNAVAILABLE, &info);
   EXPECT_EQ(Code::UNAVAILABLE, result.code());
-  EXPECT_EQ(info.error_type, CheckResponseErrorType::UNKNOWN);
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::ERROR_TYPE_UNSPECIFIED);
 }
 
 TEST(CheckResponseTest, WhenResponseIsBlockedWithBillingStatus) {
@@ -218,7 +218,7 @@ TEST(CheckResponseTest, WhenResponseIsBlockedWithBillingStatus) {
   const Status result =
       ConvertCheckErrorToStatus(CheckError::BILLING_STATUS_UNAVAILABLE, &info);
   EXPECT_EQ(Code::UNAVAILABLE, result.code());
-  EXPECT_EQ(info.error_type, CheckResponseErrorType::UNKNOWN);
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::ERROR_TYPE_UNSPECIFIED);
 }
 
 TEST(CheckResponseTest, WhenResponseIsBlockedWithServiceStatus) {
@@ -226,7 +226,7 @@ TEST(CheckResponseTest, WhenResponseIsBlockedWithServiceStatus) {
   const Status result =
       ConvertCheckErrorToStatus(CheckError::SERVICE_STATUS_UNAVAILABLE, &info);
   EXPECT_EQ(Code::UNAVAILABLE, result.code());
-  EXPECT_EQ(info.error_type, CheckResponseErrorType::UNKNOWN);
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::ERROR_TYPE_UNSPECIFIED);
 }
 
 TEST(CheckResponseTest, WhenResponseIsBlockedWithQuotaCheck) {
@@ -234,7 +234,7 @@ TEST(CheckResponseTest, WhenResponseIsBlockedWithQuotaCheck) {
   const Status result =
       ConvertCheckErrorToStatus(CheckError::QUOTA_CHECK_UNAVAILABLE, &info);
   EXPECT_EQ(Code::UNAVAILABLE, result.code());
-  EXPECT_EQ(info.error_type, CheckResponseErrorType::UNKNOWN);
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::ERROR_TYPE_UNSPECIFIED);
 }
 
 TEST(CheckResponseTest, WhenResponseIsBlockedWithCloudResourceManager) {
@@ -242,7 +242,7 @@ TEST(CheckResponseTest, WhenResponseIsBlockedWithCloudResourceManager) {
   const Status result = ConvertCheckErrorToStatus(
       CheckError::CLOUD_RESOURCE_MANAGER_BACKEND_UNAVAILABLE, &info);
   EXPECT_EQ(Code::UNAVAILABLE, result.code());
-  EXPECT_EQ(info.error_type, CheckResponseErrorType::UNKNOWN);
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::ERROR_TYPE_UNSPECIFIED);
 }
 
 TEST(CheckResponseTest, WhenResponseIsBlockedWithSecurityPolicy) {
@@ -250,7 +250,7 @@ TEST(CheckResponseTest, WhenResponseIsBlockedWithSecurityPolicy) {
   const Status result = ConvertCheckErrorToStatus(
       CheckError::SECURITY_POLICY_BACKEND_UNAVAILABLE, &info);
   EXPECT_EQ(Code::UNAVAILABLE, result.code());
-  EXPECT_EQ(info.error_type, CheckResponseErrorType::UNKNOWN);
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::ERROR_TYPE_UNSPECIFIED);
 }
 
 TEST(CheckResponseTest, WhenResponseIsBlockedWithLocationPolicy) {
@@ -258,7 +258,7 @@ TEST(CheckResponseTest, WhenResponseIsBlockedWithLocationPolicy) {
   const Status result = ConvertCheckErrorToStatus(
       CheckError::LOCATION_POLICY_BACKEND_UNAVAILABLE, &info);
   EXPECT_EQ(Code::UNAVAILABLE, result.code());
-  EXPECT_EQ(info.error_type, CheckResponseErrorType::UNKNOWN);
+  EXPECT_EQ(info.error_type, CheckResponseErrorType::ERROR_TYPE_UNSPECIFIED);
 }
 
 }  // namespace service_control

--- a/src/api_proxy/service_control/request_builder.cc
+++ b/src/api_proxy/service_control/request_builder.cc
@@ -1429,8 +1429,8 @@ Status RequestBuilder::ConvertCheckResponse(
     case CheckError::BILLING_DISABLED:
       check_response_info->error_type = CheckResponseErrorType::CONSUMER_ERROR;
       return Status(Code::PERMISSION_DENIED,
-                    std::string("API ") + service_name +
-                        " has billing disabled. Please enable it.");
+                    absl::StrCat("API ", service_name,
+                                 " has billing disabled. Please enable it."));
     case CheckError::SECURITY_POLICY_VIOLATED:
       check_response_info->error_type =
           CheckResponseErrorType::CONSUMER_BLOCKED;

--- a/src/api_proxy/service_control/request_builder.cc
+++ b/src/api_proxy/service_control/request_builder.cc
@@ -1371,62 +1371,82 @@ Status RequestBuilder::ConvertCheckResponse(
   const CheckError& error = check_response.check_errors(0);
   switch (error.code()) {
     case CheckError::NOT_FOUND:
+      check_response_info->error_type = CheckResponseErrorType::CONSUMER_ERROR;
       return Status(Code::INVALID_ARGUMENT,
                     "Client project not found. Please pass a valid project.");
     case CheckError::RESOURCE_EXHAUSTED:
       return Status(Code::RESOURCE_EXHAUSTED, "Quota check failed.");
     case CheckError::ABUSER_DETECTED:
+      check_response_info->error_type = CheckResponseErrorType::CONSUMER_ERROR;
       // Should not expose this to the client.
-      return Status(Code::PERMISSION_DENIED, "");
+      return Status(Code::PERMISSION_DENIED, "Permission denied.");
     case CheckError::API_TARGET_BLOCKED:
+      check_response_info->error_type =
+          CheckResponseErrorType::CONSUMER_BLOCKED;
       return Status(Code::PERMISSION_DENIED,
                     " The API targeted by this request is invalid for the "
                     "given API key.");
     case CheckError::API_KEY_NOT_FOUND:
-      if (check_response_info) check_response_info->is_api_key_valid = false;
+      check_response_info->error_type = CheckResponseErrorType::API_KEY_INVALID;
       return Status(Code::INVALID_ARGUMENT,
                     "API key not found. Please pass a valid API key.");
     case CheckError::API_KEY_EXPIRED:
-      if (check_response_info) check_response_info->is_api_key_valid = false;
+      check_response_info->error_type = CheckResponseErrorType::API_KEY_INVALID;
       return Status(Code::INVALID_ARGUMENT,
                     "API key expired. Please renew the API key.");
     case CheckError::API_KEY_INVALID:
-      if (check_response_info) check_response_info->is_api_key_valid = false;
+      check_response_info->error_type = CheckResponseErrorType::API_KEY_INVALID;
       return Status(Code::INVALID_ARGUMENT,
                     "API key not valid. Please pass a valid API key.");
     case CheckError::SERVICE_NOT_ACTIVATED:
-      if (check_response_info)
-        check_response_info->service_is_activated = false;
+      check_response_info->error_type =
+          CheckResponseErrorType::SERVICE_NOT_ACTIVATED;
       return Status(Code::PERMISSION_DENIED,
-                    std::string("API ") + service_name +
-                        " is not enabled for the project.");
+                    absl::StrCat("API ", service_name,
+                                 " is not enabled for the project."));
     case CheckError::PERMISSION_DENIED:
+      check_response_info->error_type = CheckResponseErrorType::CONSUMER_ERROR;
       return Status(Code::PERMISSION_DENIED, "Permission denied.");
     case CheckError::IP_ADDRESS_BLOCKED:
+      check_response_info->error_type =
+          CheckResponseErrorType::CONSUMER_BLOCKED;
       return Status(Code::PERMISSION_DENIED, "IP address blocked.");
     case CheckError::REFERER_BLOCKED:
+      check_response_info->error_type =
+          CheckResponseErrorType::CONSUMER_BLOCKED;
       return Status(Code::PERMISSION_DENIED, "Referer blocked.");
     case CheckError::CLIENT_APP_BLOCKED:
+      check_response_info->error_type =
+          CheckResponseErrorType::CONSUMER_BLOCKED;
       return Status(Code::PERMISSION_DENIED, "Client application blocked.");
     case CheckError::PROJECT_DELETED:
+      check_response_info->error_type = CheckResponseErrorType::CONSUMER_ERROR;
       return Status(Code::PERMISSION_DENIED, "Project has been deleted.");
     case CheckError::PROJECT_INVALID:
+      check_response_info->error_type = CheckResponseErrorType::CONSUMER_ERROR;
       return Status(Code::INVALID_ARGUMENT,
                     "Client project not valid. Please pass a valid project.");
     case CheckError::BILLING_DISABLED:
+      check_response_info->error_type = CheckResponseErrorType::CONSUMER_ERROR;
       return Status(Code::PERMISSION_DENIED,
                     std::string("API ") + service_name +
                         " has billing disabled. Please enable it.");
     case CheckError::SECURITY_POLICY_VIOLATED:
+      check_response_info->error_type =
+          CheckResponseErrorType::CONSUMER_BLOCKED;
       return Status(Code::PERMISSION_DENIED,
                     "Request is not allowed as per security policies.");
     case CheckError::INVALID_CREDENTIAL:
+      check_response_info->error_type = CheckResponseErrorType::CONSUMER_ERROR;
       return Status(Code::PERMISSION_DENIED,
                     "The credential in the request can not be verified.");
     case CheckError::LOCATION_POLICY_VIOLATED:
+      check_response_info->error_type =
+          CheckResponseErrorType::CONSUMER_BLOCKED;
       return Status(Code::PERMISSION_DENIED,
                     "Request is not allowed as per location policies.");
     case CheckError::CONSUMER_INVALID:
+      check_response_info->error_type = CheckResponseErrorType::CONSUMER_ERROR;
       return Status(Code::PERMISSION_DENIED,
                     "The consumer from the API key does not represent"
                     " a valid consumer folder or organization.");

--- a/src/api_proxy/service_control/request_info.h
+++ b/src/api_proxy/service_control/request_info.h
@@ -104,16 +104,17 @@ struct CheckRequestInfo : public OperationInfo {
 };
 
 enum CheckResponseErrorType {
-  UNKNOWN = 0,
+  ERROR_TYPE_UNSPECIFIED = 0,
   API_KEY_INVALID = 1,
   SERVICE_NOT_ACTIVATED = 2,
   CONSUMER_BLOCKED = 3,
   CONSUMER_ERROR = 4,
 };
 
-// Stores the information subtracted from the check response.
+// Stores the information extracted from the check response.
 struct CheckResponseInfo {
-  CheckResponseErrorType error_type = CheckResponseErrorType::UNKNOWN;
+  CheckResponseErrorType error_type =
+      CheckResponseErrorType::ERROR_TYPE_UNSPECIFIED;
 
   std::string consumer_project_id;
 };

--- a/src/api_proxy/service_control/request_info.h
+++ b/src/api_proxy/service_control/request_info.h
@@ -103,18 +103,19 @@ struct CheckRequestInfo : public OperationInfo {
   std::string ios_bundle_id;
 };
 
+enum CheckResponseErrorType {
+  UNKNOWN = 0,
+  API_KEY_INVALID = 1,
+  SERVICE_NOT_ACTIVATED = 2,
+  CONSUMER_BLOCKED = 3,
+  CONSUMER_ERROR = 4,
+};
+
 // Stores the information subtracted from the check response.
 struct CheckResponseInfo {
-  // If the request have a valid api key.
-  bool is_api_key_valid;
-  // If service is activated.
-  bool service_is_activated;
-  // Consumer project id
-  std::string consumer_project_id;
+  CheckResponseErrorType error_type = CheckResponseErrorType::UNKNOWN;
 
-  // By default api_key is valid and service is activated.
-  // They only set to false by the check response from server.
-  CheckResponseInfo() : is_api_key_valid(true), service_is_activated(true) {}
+  std::string consumer_project_id;
 };
 
 struct QuotaRequestInfo : public OperationInfo {

--- a/src/envoy/http/service_control/BUILD
+++ b/src/envoy/http/service_control/BUILD
@@ -101,6 +101,7 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         ":client_cache_lib",
+        ":service_control_callback_func_lib",
         ":mocks_lib",
         "@envoy//source/common/common:empty_string",
         "@envoy//test/mocks/event:event_mocks",

--- a/src/envoy/http/service_control/client_cache.h
+++ b/src/envoy/http/service_control/client_cache.h
@@ -33,7 +33,8 @@ namespace service_control {
 // Forward declare friend class to test private functions.
 namespace test {
 class ClientCacheCheckResponseTest;
-}
+class ClientCacheCheckResponseErrorTypeTest;
+}  // namespace test
 
 // The class to cache check and batch report.
 class ClientCache : public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
@@ -63,6 +64,7 @@ class ClientCache : public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
 
  private:
   friend class test::ClientCacheCheckResponseTest;
+  friend class test::ClientCacheCheckResponseErrorTypeTest;
 
   // Ownership of CheckResponse is passed to this function.
   // The function will always call CheckDoneFunc.

--- a/src/envoy/http/service_control/client_cache_test.cc
+++ b/src/envoy/http/service_control/client_cache_test.cc
@@ -72,6 +72,8 @@ class ClientCacheCheckResponseTest : public ::testing::Test {
   void TearDown() override {
     checkAndReset(stats_base_.stats().filter_.allowed_control_plane_fault_, 0);
     checkAndReset(stats_base_.stats().filter_.denied_control_plane_fault_, 0);
+    checkAndReset(stats_base_.stats().filter_.denied_consumer_blocked_, 0);
+    checkAndReset(stats_base_.stats().filter_.denied_consumer_error_, 0);
   }
 
   // Helpers for SetUp.
@@ -116,6 +118,7 @@ TEST_F(ClientCacheCheckResponseTest, Sc4xxBlocked) {
   check_error->set_code(CheckError::CLIENT_APP_BLOCKED);
 
   runTest(Code::OK, response, Code::PERMISSION_DENIED);
+  checkAndReset(stats_base_.stats().filter_.denied_consumer_blocked_, 1);
 }
 
 TEST_F(ClientCacheCheckResponseTest, ScOkAllowed) {

--- a/src/envoy/http/service_control/filter_stats.h
+++ b/src/envoy/http/service_control/filter_stats.h
@@ -31,6 +31,8 @@ namespace service_control {
   COUNTER(allowed_control_plane_fault)   \
   COUNTER(denied)                        \
   COUNTER(denied_control_plane_fault)    \
+  COUNTER(denied_consumer_blocked)       \
+  COUNTER(denied_consumer_error)         \
   HISTOGRAM(request_time, Milliseconds)  \
   HISTOGRAM(backend_time, Milliseconds)  \
   HISTOGRAM(overhead_time, Milliseconds)

--- a/src/envoy/http/service_control/handler_impl.cc
+++ b/src/envoy/http/service_control/handler_impl.cc
@@ -22,15 +22,16 @@
 #include "src/envoy/utils/filter_state_utils.h"
 #include "src/envoy/utils/http_header_utils.h"
 
-using ::espv2::api_proxy::service_control::CheckResponseInfo;
-using ::espv2::api_proxy::service_control::OperationInfo;
-using ::google::protobuf::util::Status;
-using ::google::protobuf::util::error::Code;
-
 namespace espv2 {
 namespace envoy {
 namespace http_filters {
 namespace service_control {
+
+using ::espv2::api_proxy::service_control::CheckResponseErrorType;
+using ::espv2::api_proxy::service_control::CheckResponseInfo;
+using ::espv2::api_proxy::service_control::OperationInfo;
+using ::google::protobuf::util::Status;
+using ::google::protobuf::util::error::Code;
 
 // The HTTP header to send consumer project to backend.
 const Envoy::Http::LowerCaseString kConsumerProjectId(
@@ -130,8 +131,10 @@ void ServiceControlHandlerImpl::prepareReportRequest(
   fillOperationInfo(info);
 
   // Report: not to send api-key if invalid or service is not enabled.
-  if (!check_response_info_.is_api_key_valid ||
-      !check_response_info_.service_is_activated) {
+  if (check_response_info_.error_type ==
+          CheckResponseErrorType::API_KEY_INVALID ||
+      check_response_info_.error_type ==
+          CheckResponseErrorType::SERVICE_NOT_ACTIVATED) {
     info.api_key.clear();
   }
 


### PR DESCRIPTION
Implementation details:
- Modify `CheckResponseInfo` to have a summarized `ErrorType` instead of booleans.
- Increment the correct stat based on the `ErrorType`.

Testing:
- Unit tests to ensure `ErrorType` is set correctly.
- Unit tests to ensure correct stat is incremented for each `ErrorType`.

Signed-off-by: Teju Nareddy <nareddyt@google.com>