### PR TITLE
Improve readability/validation of backend routing config and filter

### DIFF
--- a/api/envoy/http/backend_routing/config.proto
+++ b/api/envoy/http/backend_routing/config.proto
@@ -22,15 +22,17 @@ message BackendRoutingRule {
   // Operation name, also known as selector.
   string operation = 1 [(validate.rules).string.min_bytes = 1];
 
-  // True if CONSTANT_ADDRESS, otherwise is APPEND_PATH_TO_ADDRESS.
+  // Corresponds to the path translation options in Google Cloud Endpoints.
   // https://cloud.google.com/endpoints/docs/openapi/openapi-extensions#understanding_path_translation
-  bool is_const_address = 2;
+  enum PathTranslation {
+    PATH_TRANSLATION_UNSPECIFIED = 0;
+    CONSTANT_ADDRESS = 1;
+    APPEND_PATH_TO_ADDRESS = 2;
+  }
+
+  PathTranslation path_translation = 2;
 
   // Prefix used when re-writing the path for the backend.
-  // Example for CONSTANT_ADDRESS:
-  //     https://us-central1-my-project-id.cloudfunctions.net/helloGET
-  // Example for APPEND_PATH_TO_ADDRESS:
-  //     https://my-project-id.appspot.com
   string path_prefix = 3 [(validate.rules).string = {
     well_known_regex: HTTP_HEADER_VALUE,
     strict: false
@@ -38,7 +40,7 @@ message BackendRoutingRule {
 }
 
 message FilterConfig {
-  // A list of backend routing rules for those selectors which needs path
+  // A list of backend routing rules for those selectors that needs path
   // translation.
   repeated BackendRoutingRule rules = 1;
 }

--- a/api/envoy/http/backend_routing/config.proto
+++ b/api/envoy/http/backend_routing/config.proto
@@ -19,6 +19,8 @@ package google.api.envoy.http.backend_routing;
 import "validate/validate.proto";
 
 message BackendRoutingRule {
+  reserved 2;
+
   // Operation name, also known as selector.
   string operation = 1 [(validate.rules).string.min_bytes = 1];
 
@@ -30,7 +32,7 @@ message BackendRoutingRule {
     APPEND_PATH_TO_ADDRESS = 2;
   }
 
-  PathTranslation path_translation = 2;
+  PathTranslation path_translation = 4;
 
   // Prefix used when re-writing the path for the backend.
   string path_prefix = 3 [(validate.rules).string = {

--- a/examples/dynamic_routing/envoy_config.json
+++ b/examples/dynamic_routing/envoy_config.json
@@ -260,13 +260,14 @@
                                                 "@type": "type.googleapis.com/google.api.envoy.http.backend_routing.FilterConfig",
                                                 "rules": [
                                                     {
-                                                        "isConstAddress": true,
                                                         "operation": "1.esp_bookstore_f6x3rlu5aa_uc_a_run_app.CreateShelf",
-                                                        "pathPrefix": "/shelves"
+                                                        "pathPrefix": "/shelves",
+                                                        "pathTranslation":"CONSTANT_ADDRESS"
                                                     },
                                                     {
                                                         "operation": "1.esp_bookstore_f6x3rlu5aa_uc_a_run_app.ListShelves",
-                                                        "pathPrefix": "/shelves"
+                                                        "pathPrefix": "/shelves",
+                                                        "pathTranslation":"APPEND_PATH_TO_ADDRESS"
                                                     }
                                                 ]
                                             }

--- a/src/envoy/http/backend_routing/BUILD
+++ b/src/envoy/http/backend_routing/BUILD
@@ -34,6 +34,7 @@ envoy_cc_library(
     deps = [
         "//api/envoy/http/backend_routing:config_proto_cc_proto",
         "//src/envoy/utils:filter_state_utils_lib",
+        "@envoy//source/common/common:assert_lib",
         "@envoy//source/common/http:headers_lib",
         "@envoy//source/common/protobuf:utility_lib",
         "@envoy//source/exe:envoy_common_lib",

--- a/src/envoy/http/backend_routing/filter.h
+++ b/src/envoy/http/backend_routing/filter.h
@@ -37,6 +37,16 @@ class Filter : public Envoy::Http::PassThroughDecoderFilter,
                                                  bool) override;
 
  private:
+  std::string translateConstPath(
+      const ::google::api::envoy::http::backend_routing::BackendRoutingRule*
+          rule,
+      absl::string_view original_path);
+
+  std::string translateAppendPath(
+      const ::google::api::envoy::http::backend_routing::BackendRoutingRule*
+          rule,
+      absl::string_view original_path);
+
   const FilterConfigSharedPtr config_;
 };
 

--- a/src/envoy/http/backend_routing/filter.h
+++ b/src/envoy/http/backend_routing/filter.h
@@ -37,15 +37,11 @@ class Filter : public Envoy::Http::PassThroughDecoderFilter,
                                                  bool) override;
 
  private:
-  std::string translateConstPath(
-      const ::google::api::envoy::http::backend_routing::BackendRoutingRule*
-          rule,
-      absl::string_view original_path);
+  std::string translateConstPath(absl::string_view prefix,
+                                 absl::string_view original_path);
 
-  std::string translateAppendPath(
-      const ::google::api::envoy::http::backend_routing::BackendRoutingRule*
-          rule,
-      absl::string_view original_path);
+  std::string translateAppendPath(absl::string_view prefix,
+                                  absl::string_view original_path);
 
   const FilterConfigSharedPtr config_;
 };

--- a/src/envoy/http/backend_routing/filter_config.h
+++ b/src/envoy/http/backend_routing/filter_config.h
@@ -50,6 +50,9 @@ class FilterConfig : public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
       : proto_config_(proto_config),
         stats_(generateStats(stats_prefix, context.scope())) {
     for (const auto& rule : proto_config_.rules()) {
+      if (rule.path_translation() == ::google::api::envoy::http::backend_routing::BackendRoutingRule::PATH_TRANSLATION_UNSPECIFIED) {
+        throw Envoy::ProtoValidationException("Path translation for BackendRouting rule must be specified", rule);
+      }
       backend_routing_map_[rule.operation()] = &rule;
     }
   }

--- a/src/envoy/http/backend_routing/filter_test.cc
+++ b/src/envoy/http/backend_routing/filter_test.cc
@@ -37,27 +37,27 @@ namespace {
 const char kFilterConfig[] = R"(
 rules {
   operation: "append-operation"
-  is_const_address: false
+  path_translation: APPEND_PATH_TO_ADDRESS
   path_prefix: ""
 }
 rules {
   operation: "append-with-prefix-operation"
-  is_const_address: false
+  path_translation: APPEND_PATH_TO_ADDRESS
   path_prefix: "/test-prefix"
 }
 rules {
   operation: "const-operation"
-  is_const_address: true
+  path_translation: CONSTANT_ADDRESS
   path_prefix: "/"
 }
 rules {
   operation: "const-with-prefix-operation"
-  is_const_address: true
+  path_translation: CONSTANT_ADDRESS
   path_prefix: "/test-prefix"
 }
 rules {
   operation: "const-with-bad-prefix-operation"
-  is_const_address: true
+  path_translation: CONSTANT_ADDRESS
   path_prefix: ""
 }
 )";

--- a/src/envoy/http/service_control/BUILD
+++ b/src/envoy/http/service_control/BUILD
@@ -101,8 +101,8 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         ":client_cache_lib",
-        ":service_control_callback_func_lib",
         ":mocks_lib",
+        ":service_control_callback_func_lib",
         "@envoy//source/common/common:empty_string",
         "@envoy//test/mocks/event:event_mocks",
         "@envoy//test/mocks/server:server_mocks",

--- a/src/go/configgenerator/listener_generator_test.go
+++ b/src/go/configgenerator/listener_generator_test.go
@@ -487,13 +487,14 @@ func TestBackendRoutingFilter(t *testing.T) {
           "@type":"type.googleapis.com/google.api.envoy.http.backend_routing.FilterConfig",
           "rules": [
             {
-              "isConstAddress": true,
               "operation": "endpoints.examples.bookstore.Bookstore.CreateShelf",
-              "pathPrefix": "/foo"
+              "pathPrefix": "/foo",
+              "pathTranslation":"CONSTANT_ADDRESS"
             },
             {
               "operation":  "endpoints.examples.bookstore.Bookstore.ListShelves",
-              "pathPrefix": "/foo"
+              "pathPrefix": "/foo",
+              "pathTranslation":"APPEND_PATH_TO_ADDRESS"
             }
           ]
         }
@@ -564,12 +565,13 @@ func TestBackendRoutingFilter(t *testing.T) {
           "rules": [
             {
               "operation": "testapi.bar",
-              "pathPrefix": "/foo"
+              "pathPrefix": "/foo",
+              "pathTranslation":"APPEND_PATH_TO_ADDRESS"
             },
             {
-              "isConstAddress": true,
               "operation":"testapi.foo",
-              "pathPrefix": "/foo"
+              "pathPrefix": "/foo",
+              "pathTranslation":"CONSTANT_ADDRESS"
             }
           ]
         }
@@ -646,21 +648,23 @@ func TestBackendRoutingFilter(t *testing.T) {
           "rules": [
             {
               "operation":"testapi.CORS_bar",
-              "pathPrefix": "/bar"
+              "pathPrefix": "/bar",
+              "pathTranslation":"APPEND_PATH_TO_ADDRESS"
             },
             {
-              "isConstAddress": true,
               "operation":"testapi.CORS_foo",
-              "pathPrefix": "/foo"
+              "pathPrefix": "/foo",
+              "pathTranslation":"CONSTANT_ADDRESS"
             },
             {
               "operation": "testapi.bar",
-              "pathPrefix": "/bar"
+              "pathPrefix": "/bar",
+              "pathTranslation":"APPEND_PATH_TO_ADDRESS"
             },
             {
-              "isConstAddress": true,
               "operation":"testapi.foo",
-              "pathPrefix": "/foo"
+              "pathPrefix": "/foo",
+              "pathTranslation":"CONSTANT_ADDRESS"
             }
           ]
         }

--- a/src/go/configmanager/testdata/fake_data_for_dynamic_routing.go
+++ b/src/go/configmanager/testdata/fake_data_for_dynamic_routing.go
@@ -331,24 +331,28 @@ var (
                            "rules":[
                               {
                                  "operation":"1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_AddPet",
-                                 "pathPrefix":"/api"
+                                 "pathPrefix":"/api",
+                                 "pathTranslation":"APPEND_PATH_TO_ADDRESS"
                               },
                               {
                                  "operation":"1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_GetPetById",
-                                 "pathPrefix":"/api"
+                                 "pathPrefix":"/api",
+                                 "pathTranslation":"APPEND_PATH_TO_ADDRESS"
                               },
                               {
                                  "operation":"1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_Hello",
-                                 "pathPrefix":"/hello"
+                                 "pathPrefix":"/hello",
+                                 "pathTranslation":"APPEND_PATH_TO_ADDRESS"
                               },
                               {
                                  "operation":"1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_ListPets",
-                                 "pathPrefix":"/api"
+                                 "pathPrefix":"/api",
+                                 "pathTranslation":"APPEND_PATH_TO_ADDRESS"
                               },
                               {
-                                 "isConstAddress":true,
                                  "operation":"1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_Search",
-                                 "pathPrefix":"/search"
+                                 "pathPrefix":"/search",
+                                 "pathTranslation":"CONSTANT_ADDRESS"
                               }
                            ]
                         }


### PR DESCRIPTION
During security review, there were some concerns about when backend rules are created and what the default path translation behavior is.

To address these:
- Change path translation into an enum, similar to service config BackendRule.
- Better validation/clarification of the enum in Config Manager and backend routing filter config.
- Split `decodeHeaders` into functions based on the path translation. This is easier to read and clarifies the cases where query params are needed.

Breaking change in filter config, but API Config Versioning should handle this. 

Signed-off-by: Teju Nareddy <nareddyt@google.com>