### PR TITLE
b/155209585 #3: Implement `denied_consumer_quota` and `denied_producer_error`

### DIFF
--- a/src/api_proxy/service_control/check_response_test.cc
+++ b/src/api_proxy/service_control/check_response_test.cc
@@ -30,7 +30,7 @@ using ::google::protobuf::util::error::Code;
 class ConvertCheckResponseTest : public ::testing::Test {
  protected:
   void runTest(CheckError_Code got_check_error_code, Code want_code,
-               CheckResponseErrorType want_error_type) {
+               ScResponseErrorType want_error_type) {
     CheckResponseInfo info;
     CheckResponse response;
     response.add_check_errors()->set_code(got_check_error_code);
@@ -45,140 +45,140 @@ class ConvertCheckResponseTest : public ::testing::Test {
 TEST_F(ConvertCheckResponseTest,
        AbortedWithInvalidArgumentWhenRespIsKeyInvalid) {
   runTest(CheckError::API_KEY_INVALID, Code::INVALID_ARGUMENT,
-          CheckResponseErrorType::API_KEY_INVALID);
+          ScResponseErrorType::API_KEY_INVALID);
 }
 
 TEST_F(ConvertCheckResponseTest,
        AbortedWithInvalidArgumentWhenRespIsKeyExpired) {
   runTest(CheckError::API_KEY_EXPIRED, Code::INVALID_ARGUMENT,
-          CheckResponseErrorType::API_KEY_INVALID);
+          ScResponseErrorType::API_KEY_INVALID);
 }
 
 TEST_F(ConvertCheckResponseTest,
        AbortedWithInvalidArgumentWhenRespIsBlockedWithKeyNotFound) {
   runTest(CheckError::API_KEY_NOT_FOUND, Code::INVALID_ARGUMENT,
-          CheckResponseErrorType::API_KEY_INVALID);
+          ScResponseErrorType::API_KEY_INVALID);
 }
 
 TEST_F(ConvertCheckResponseTest,
        AbortedWithInvalidArgumentWhenRespIsBlockedWithNotFound) {
   runTest(CheckError::NOT_FOUND, Code::INVALID_ARGUMENT,
-          CheckResponseErrorType::CONSUMER_ERROR);
+          ScResponseErrorType::CONSUMER_ERROR);
 }
 
 TEST_F(ConvertCheckResponseTest,
        AbortedWithPermissionDeniedWhenRespIsBlockedWithPermissionDenied) {
   runTest(CheckError::PERMISSION_DENIED, Code::PERMISSION_DENIED,
-          CheckResponseErrorType::CONSUMER_ERROR);
+          ScResponseErrorType::CONSUMER_ERROR);
 }
 
 TEST_F(ConvertCheckResponseTest,
        AbortedWithPermissionDeniedWhenRespIsBlockedWithIpAddressBlocked) {
   runTest(CheckError::IP_ADDRESS_BLOCKED, Code::PERMISSION_DENIED,
-          CheckResponseErrorType::CONSUMER_BLOCKED);
+          ScResponseErrorType::CONSUMER_BLOCKED);
 }
 
 TEST_F(ConvertCheckResponseTest,
        AbortedWithPermissionDeniedWhenRespIsBlockedWithRefererBlocked) {
   runTest(CheckError::REFERER_BLOCKED, Code::PERMISSION_DENIED,
-          CheckResponseErrorType::CONSUMER_BLOCKED);
+          ScResponseErrorType::CONSUMER_BLOCKED);
 }
 
 TEST_F(ConvertCheckResponseTest,
        AbortedWithPermissionDeniedWhenRespIsBlockedWithClientAppBlocked) {
   runTest(CheckError::CLIENT_APP_BLOCKED, Code::PERMISSION_DENIED,
-          CheckResponseErrorType::CONSUMER_BLOCKED);
+          ScResponseErrorType::CONSUMER_BLOCKED);
 }
 
 TEST_F(ConvertCheckResponseTest,
        AbortedWithPermissionDeniedWhenResponseIsBlockedWithProjectDeleted) {
   runTest(CheckError::PROJECT_DELETED, Code::PERMISSION_DENIED,
-          CheckResponseErrorType::CONSUMER_ERROR);
+          ScResponseErrorType::CONSUMER_ERROR);
 }
 
 TEST_F(ConvertCheckResponseTest,
        AbortedWithPermissionDeniedWhenResponseIsBlockedWithProjectInvalid) {
   runTest(CheckError::PROJECT_INVALID, Code::INVALID_ARGUMENT,
-          CheckResponseErrorType::CONSUMER_ERROR);
+          ScResponseErrorType::CONSUMER_ERROR);
 }
 
 TEST_F(ConvertCheckResponseTest,
        AbortedWithPermissionDeniedWhenResponseIsBlockedWithBillingDisabled) {
   runTest(CheckError::BILLING_DISABLED, Code::PERMISSION_DENIED,
-          CheckResponseErrorType::CONSUMER_ERROR);
+          ScResponseErrorType::CONSUMER_ERROR);
 }
 
 TEST_F(ConvertCheckResponseTest,
        WhenResponseIsBlockedWithSecurityPolicyViolated) {
   runTest(CheckError::SECURITY_POLICY_VIOLATED, Code::PERMISSION_DENIED,
-          CheckResponseErrorType::CONSUMER_BLOCKED);
+          ScResponseErrorType::CONSUMER_BLOCKED);
 }
 
 TEST_F(ConvertCheckResponseTest, WhenResponseIsBlockedWithInvalidCredentail) {
   runTest(CheckError::INVALID_CREDENTIAL, Code::PERMISSION_DENIED,
-          CheckResponseErrorType::CONSUMER_ERROR);
+          ScResponseErrorType::CONSUMER_ERROR);
 }
 
 TEST_F(ConvertCheckResponseTest,
        WhenResponseIsBlockedWithLocationPolicyViolated) {
   runTest(CheckError::LOCATION_POLICY_VIOLATED, Code::PERMISSION_DENIED,
-          CheckResponseErrorType::CONSUMER_BLOCKED);
+          ScResponseErrorType::CONSUMER_BLOCKED);
 }
 
 TEST_F(ConvertCheckResponseTest, WhenResponseIsBlockedWithConsumerInvalid) {
   runTest(CheckError::CONSUMER_INVALID, Code::PERMISSION_DENIED,
-          CheckResponseErrorType::CONSUMER_ERROR);
+          ScResponseErrorType::CONSUMER_ERROR);
 }
 
 TEST_F(ConvertCheckResponseTest, WhenResponseIsBlockedWithResourceExhuasted) {
   runTest(CheckError::RESOURCE_EXHAUSTED, Code::RESOURCE_EXHAUSTED,
-          CheckResponseErrorType::ERROR_TYPE_UNSPECIFIED);
+          ScResponseErrorType::CONSUMER_QUOTA);
 }
 
 TEST_F(ConvertCheckResponseTest, WhenResponseIsBlockedWithAbuserDetected) {
   runTest(CheckError::ABUSER_DETECTED, Code::PERMISSION_DENIED,
-          CheckResponseErrorType::CONSUMER_ERROR);
+          ScResponseErrorType::CONSUMER_ERROR);
 }
 
 TEST_F(ConvertCheckResponseTest, WhenResponseIsBlockedWithApiTargetBlocked) {
   runTest(CheckError::API_TARGET_BLOCKED, Code::PERMISSION_DENIED,
-          CheckResponseErrorType::CONSUMER_BLOCKED);
+          ScResponseErrorType::CONSUMER_BLOCKED);
 }
 
 TEST_F(ConvertCheckResponseTest, WhenResponseIsBlockedWithNamespaceLookup) {
   runTest(CheckError::NAMESPACE_LOOKUP_UNAVAILABLE, Code::UNAVAILABLE,
-          CheckResponseErrorType::ERROR_TYPE_UNSPECIFIED);
+          ScResponseErrorType::ERROR_TYPE_UNSPECIFIED);
 }
 
 TEST_F(ConvertCheckResponseTest, WhenResponseIsBlockedWithBillingStatus) {
   runTest(CheckError::BILLING_STATUS_UNAVAILABLE, Code::UNAVAILABLE,
-          CheckResponseErrorType::ERROR_TYPE_UNSPECIFIED);
+          ScResponseErrorType::ERROR_TYPE_UNSPECIFIED);
 }
 
 TEST_F(ConvertCheckResponseTest, WhenResponseIsBlockedWithServiceStatus) {
   runTest(CheckError::SERVICE_STATUS_UNAVAILABLE, Code::UNAVAILABLE,
-          CheckResponseErrorType::ERROR_TYPE_UNSPECIFIED);
+          ScResponseErrorType::ERROR_TYPE_UNSPECIFIED);
 }
 
 TEST_F(ConvertCheckResponseTest, WhenResponseIsBlockedWithQuotaCheck) {
   runTest(CheckError::QUOTA_CHECK_UNAVAILABLE, Code::UNAVAILABLE,
-          CheckResponseErrorType::ERROR_TYPE_UNSPECIFIED);
+          ScResponseErrorType::ERROR_TYPE_UNSPECIFIED);
 }
 
 TEST_F(ConvertCheckResponseTest,
        WhenResponseIsBlockedWithCloudResourceManager) {
   runTest(CheckError::CLOUD_RESOURCE_MANAGER_BACKEND_UNAVAILABLE,
-          Code::UNAVAILABLE, CheckResponseErrorType::ERROR_TYPE_UNSPECIFIED);
+          Code::UNAVAILABLE, ScResponseErrorType::ERROR_TYPE_UNSPECIFIED);
 }
 
 TEST_F(ConvertCheckResponseTest, WhenResponseIsBlockedWithSecurityPolicy) {
   runTest(CheckError::SECURITY_POLICY_BACKEND_UNAVAILABLE, Code::UNAVAILABLE,
-          CheckResponseErrorType::ERROR_TYPE_UNSPECIFIED);
+          ScResponseErrorType::ERROR_TYPE_UNSPECIFIED);
 }
 
 TEST_F(ConvertCheckResponseTest, WhenResponseIsBlockedWithLocationPolicy) {
   runTest(CheckError::LOCATION_POLICY_BACKEND_UNAVAILABLE, Code::UNAVAILABLE,
-          CheckResponseErrorType::ERROR_TYPE_UNSPECIFIED);
+          ScResponseErrorType::ERROR_TYPE_UNSPECIFIED);
 }
 
 TEST_F(ConvertCheckResponseTest,
@@ -194,7 +194,7 @@ TEST_F(ConvertCheckResponseTest,
 
   EXPECT_EQ(Code::PERMISSION_DENIED, result.code());
   EXPECT_EQ(result.message(), "API api_xxxx is not enabled for the project.");
-  EXPECT_EQ(info.error_type, CheckResponseErrorType::SERVICE_NOT_ACTIVATED);
+  EXPECT_EQ(info.error_type, ScResponseErrorType::SERVICE_NOT_ACTIVATED);
 }
 
 }  // namespace

--- a/src/api_proxy/service_control/request_builder.h
+++ b/src/api_proxy/service_control/request_builder.h
@@ -84,7 +84,7 @@ class RequestBuilder final {
 
   static ::google::protobuf::util::Status ConvertAllocateQuotaResponse(
       const ::google::api::servicecontrol::v1::AllocateQuotaResponse& response,
-      const std::string& service_name);
+      const std::string& service_name, QuotaResponseInfo* quota_response_info);
 
   static bool IsMetricSupported(const ::google::api::MetricDescriptor& metric);
   static bool IsLabelSupported(const ::google::api::LabelDescriptor& label);

--- a/src/api_proxy/service_control/request_info.h
+++ b/src/api_proxy/service_control/request_info.h
@@ -103,18 +103,18 @@ struct CheckRequestInfo : public OperationInfo {
   std::string ios_bundle_id;
 };
 
-enum CheckResponseErrorType {
+enum ScResponseErrorType {
   ERROR_TYPE_UNSPECIFIED = 0,
   API_KEY_INVALID = 1,
   SERVICE_NOT_ACTIVATED = 2,
   CONSUMER_BLOCKED = 3,
   CONSUMER_ERROR = 4,
+  CONSUMER_QUOTA = 5,
 };
 
 // Stores the information extracted from the check response.
 struct CheckResponseInfo {
-  CheckResponseErrorType error_type =
-      CheckResponseErrorType::ERROR_TYPE_UNSPECIFIED;
+  ScResponseErrorType error_type = ScResponseErrorType::ERROR_TYPE_UNSPECIFIED;
 
   std::string consumer_project_id;
 };
@@ -123,6 +123,11 @@ struct QuotaRequestInfo : public OperationInfo {
   std::string method_name;
 
   const std::vector<std::pair<std::string, int>>* metric_cost_vector;
+};
+
+// Stores the information extracted from the quota response.
+struct QuotaResponseInfo {
+  ScResponseErrorType error_type = ScResponseErrorType::ERROR_TYPE_UNSPECIFIED;
 };
 
 // Information to fill Report request protobuf.

--- a/src/envoy/http/service_control/README.md
+++ b/src/envoy/http/service_control/README.md
@@ -11,3 +11,31 @@ to check authentication, rate-limit calls, report metrics, and create logs for A
 This filter will not function unless the following filters appear earlier in the filter chain:
 
 - [Path Matcher](../path_matcher/README.md)
+
+## Statistics
+
+This filter records statistics.
+
+### Counters
+
+- `allowed`: Total number of API consumer requests allowed.
+- `allowed_control_plane_fault`: Number of API consumer requests allowed
+ due to network fail open policy when Service Control Check was unavailable.
+- `denied`: Total number of API consumer requests denied.
+- `denied_control_plane_fault`: Number of API consumer requests denied
+ due to network fail closed policy when Service Control Check was unavailable.
+- `denied_consumer_blocked`: Number of API consumer requests denied due
+ to API Key restrictions.
+- `denied_consumer_error`: Number of API consumer requests denied due
+ to problems with the consumer request.
+- `denied_consumer_quota`: Number of API consumer requests denied due
+ to exceeding the quota configured by the API Producer.
+- `denied_producer_error`: Number of API consumer requests denied due
+ to errors in the producer ESPv2 deployment (authentication, roles, etc).
+
+### Histograms
+
+- `request_time` (ms): This is recorded for calls to service control.
+ Each operation (Check, AllocateQuota, Report) has its own histogram.
+- `backend_time` (ms): Time for the backend to respond.
+- `overhead_time` (ms): Overhead introduced by ESPv2.

--- a/src/envoy/http/service_control/client_cache.h
+++ b/src/envoy/http/service_control/client_cache.h
@@ -71,7 +71,7 @@ class ClientCache : public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
   friend class test::ClientCacheQuotaResponseErrorTypeTest;
 
   // Increments the corresponding stat for the given error type.
-  void handleScResponseErrorStats(
+  void collectScResponseErrorStats(
       ::espv2::api_proxy::service_control::ScResponseErrorType error_type);
 
   // Ownership of CheckResponse is passed to this function.
@@ -83,7 +83,7 @@ class ClientCache : public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
 
   // Ownership of AllocateQuotaResponse is passed to this function.
   // The function will always call QuotaDoneFunction.
-  void handleQuotaResponse(
+  void handleQuotaOnDone(
       const ::google::protobuf::util::Status& http_status,
       ::google::api::servicecontrol::v1::AllocateQuotaResponse* response,
       QuotaDoneFunc on_done);

--- a/src/envoy/http/service_control/client_cache.h
+++ b/src/envoy/http/service_control/client_cache.h
@@ -34,6 +34,8 @@ namespace service_control {
 namespace test {
 class ClientCacheCheckResponseTest;
 class ClientCacheCheckResponseErrorTypeTest;
+class ClientCacheQuotaResponseTest;
+class ClientCacheQuotaResponseErrorTypeTest;
 }  // namespace test
 
 // The class to cache check and batch report.
@@ -65,6 +67,12 @@ class ClientCache : public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
  private:
   friend class test::ClientCacheCheckResponseTest;
   friend class test::ClientCacheCheckResponseErrorTypeTest;
+  friend class test::ClientCacheQuotaResponseTest;
+  friend class test::ClientCacheQuotaResponseErrorTypeTest;
+
+  // Increments the corresponding stat for the given error type.
+  void handleScResponseErrorStats(
+      ::espv2::api_proxy::service_control::ScResponseErrorType error_type);
 
   // Ownership of CheckResponse is passed to this function.
   // The function will always call CheckDoneFunc.
@@ -72,6 +80,13 @@ class ClientCache : public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
       const ::google::protobuf::util::Status& http_status,
       ::google::api::servicecontrol::v1::CheckResponse* response,
       CheckDoneFunc on_done);
+
+  // Ownership of AllocateQuotaResponse is passed to this function.
+  // The function will always call QuotaDoneFunction.
+  void handleQuotaResponse(
+      const ::google::protobuf::util::Status& http_status,
+      ::google::api::servicecontrol::v1::AllocateQuotaResponse* response,
+      QuotaDoneFunc on_done);
 
   void initHttpRequestSetting(
       const ::google::api::envoy::http::service_control::FilterConfig&

--- a/src/envoy/http/service_control/client_cache_test.cc
+++ b/src/envoy/http/service_control/client_cache_test.cc
@@ -214,7 +214,7 @@ class ClientCacheQuotaResponseTest : public ClientCacheTestBase {
     };
 
     const Status http_status(got_http_code, Envoy::EMPTY_STRING);
-    cache_->handleQuotaResponse(http_status, got_response, on_done);
+    cache_->handleQuotaOnDone(http_status, got_response, on_done);
   }
 };
 
@@ -249,7 +249,7 @@ class ClientCacheQuotaResponseErrorTypeTest : public ClientCacheTestBase {
 
     QuotaDoneFunc on_done = [&](const Status&) {};
     const Status http_status(Code::OK, Envoy::EMPTY_STRING);
-    cache_->handleQuotaResponse(http_status, response, on_done);
+    cache_->handleQuotaOnDone(http_status, response, on_done);
   }
 };
 

--- a/src/envoy/http/service_control/filter_stats.h
+++ b/src/envoy/http/service_control/filter_stats.h
@@ -33,6 +33,8 @@ namespace service_control {
   COUNTER(denied_control_plane_fault)    \
   COUNTER(denied_consumer_blocked)       \
   COUNTER(denied_consumer_error)         \
+  COUNTER(denied_consumer_quota)         \
+  COUNTER(denied_producer_error)         \
   HISTOGRAM(request_time, Milliseconds)  \
   HISTOGRAM(backend_time, Milliseconds)  \
   HISTOGRAM(overhead_time, Milliseconds)

--- a/src/envoy/http/service_control/handler_impl.cc
+++ b/src/envoy/http/service_control/handler_impl.cc
@@ -27,9 +27,9 @@ namespace envoy {
 namespace http_filters {
 namespace service_control {
 
-using ::espv2::api_proxy::service_control::CheckResponseErrorType;
 using ::espv2::api_proxy::service_control::CheckResponseInfo;
 using ::espv2::api_proxy::service_control::OperationInfo;
+using ::espv2::api_proxy::service_control::ScResponseErrorType;
 using ::google::protobuf::util::Status;
 using ::google::protobuf::util::error::Code;
 
@@ -131,10 +131,9 @@ void ServiceControlHandlerImpl::prepareReportRequest(
   fillOperationInfo(info);
 
   // Report: not to send api-key if invalid or service is not enabled.
-  if (check_response_info_.error_type ==
-          CheckResponseErrorType::API_KEY_INVALID ||
+  if (check_response_info_.error_type == ScResponseErrorType::API_KEY_INVALID ||
       check_response_info_.error_type ==
-          CheckResponseErrorType::SERVICE_NOT_ACTIVATED) {
+          ScResponseErrorType::SERVICE_NOT_ACTIVATED) {
     info.api_key.clear();
   }
 

--- a/src/envoy/http/service_control/handler_impl_test.cc
+++ b/src/envoy/http/service_control/handler_impl_test.cc
@@ -39,10 +39,10 @@ using Envoy::Http::TestResponseHeaderMapImpl;
 using Envoy::Http::TestResponseTrailerMapImpl;
 using Envoy::StreamInfo::MockStreamInfo;
 using ::espv2::api_proxy::service_control::CheckRequestInfo;
-using ::espv2::api_proxy::service_control::CheckResponseErrorType;
 using ::espv2::api_proxy::service_control::CheckResponseInfo;
 using ::espv2::api_proxy::service_control::QuotaRequestInfo;
 using ::espv2::api_proxy::service_control::ReportRequestInfo;
+using ::espv2::api_proxy::service_control::ScResponseErrorType;
 using ::espv2::api_proxy::service_control::protocol::Protocol;
 using ::google::api::envoy::http::service_control::FilterConfig;
 using ::google::protobuf::TextFormat;
@@ -620,7 +620,7 @@ TEST_F(HandlerTest, HandlerFailCheckSync) {
                              "test bad status returned from service control");
 
   CheckResponseInfo response_info;
-  response_info.error_type = CheckResponseErrorType::API_KEY_INVALID;
+  response_info.error_type = ScResponseErrorType::API_KEY_INVALID;
 
   CheckRequestInfo expected_check_info;
   expected_check_info.api_key = "foobar";
@@ -795,7 +795,7 @@ TEST_F(HandlerTest, HandlerFailCheckAsync) {
                                     stats_base_.stats());
 
   CheckResponseInfo response_info;
-  response_info.error_type = CheckResponseErrorType::API_KEY_INVALID;
+  response_info.error_type = ScResponseErrorType::API_KEY_INVALID;
 
   CheckRequestInfo expected_check_info;
   expected_check_info.api_key = "foobar";


### PR DESCRIPTION
Implementation notes:
- Rename enum and re-use for check and quota responses.
- Add in a `QuotaResponseInfo` to serve as an intermediate translation of the codes.
- Move logic to increment stats into its own function to share between check and quota.
- Move logic to handle Quota responses into it's own function for testability.

Testing done:
- Similar to #156, add tests for the quota response.

Signed-off-by: Teju Nareddy <nareddyt@google.com>