### PR TITLE
Handle errors and test stats in Backend Routing

### DIFF
--- a/src/envoy/http/backend_routing/BUILD
+++ b/src/envoy/http/backend_routing/BUILD
@@ -35,6 +35,7 @@ envoy_cc_library(
         "//api/envoy/http/backend_routing:config_proto_cc_proto",
         "//src/envoy/utils:filter_state_utils_lib",
         "@envoy//source/common/common:assert_lib",
+        "@envoy//source/common/http:codes_lib",
         "@envoy//source/common/http:headers_lib",
         "@envoy//source/common/protobuf:utility_lib",
         "@envoy//source/exe:envoy_common_lib",

--- a/src/envoy/http/backend_routing/README.md
+++ b/src/envoy/http/backend_routing/README.md
@@ -29,6 +29,8 @@ This filter records statistics.
 ### Counters
 
 - `denied`: Number of API Consumer requests that are denied due to invalid headers, etc.
+- `pass_through`: Number of API Consumer requests that are allowed through
+ without modification. Occurs when the request is not for dynamic routing.
 - `append_path_to_address_request`: Number of API Consumer requests that are
  accepted and translated as APPEND_PATH_TO_ADDRESS.
 - `constant_address_request`: Number of API Consumer requests that are

--- a/src/envoy/http/backend_routing/README.md
+++ b/src/envoy/http/backend_routing/README.md
@@ -28,9 +28,10 @@ This filter records statistics.
 
 ### Counters
 
-- `denied`: Number of API Consumer requests that are denied due to invalid headers, etc.
-- `pass_through`: Number of API Consumer requests that are allowed through
- without modification. Occurs when the request is not for dynamic routing.
+- `denied_by_no_path`: Number of API Consumer requests that are denied due to invalid path header.
+- `denied_by_no_operation`: Number of API Consumer requests that are denied due to missing filter state.
+- `allowed_by_no_configured_rules`: Number of API Consumer requests that are allowed through
+ without modification. Occurs when the operation is not configured for dynamic routing.
 - `append_path_to_address_request`: Number of API Consumer requests that are
  accepted and translated as APPEND_PATH_TO_ADDRESS.
 - `constant_address_request`: Number of API Consumer requests that are

--- a/src/envoy/http/backend_routing/README.md
+++ b/src/envoy/http/backend_routing/README.md
@@ -21,3 +21,15 @@ This filter is designed to strongly integrate with the following filters:
 
 View the [backend routing configuration proto](../../../../api/envoy/http/backend_routing/config.proto)
 for inline documentation.
+
+## Statistics
+
+This filter records statistics.
+
+### Counters
+
+- `denied`: Number of API Consumer requests that are denied due to invalid headers, etc.
+- `append_path_to_address_request`: Number of API Consumer requests that are
+ accepted and translated as APPEND_PATH_TO_ADDRESS.
+- `constant_address_request`: Number of API Consumer requests that are
+ accepted and translated as CONSTANT_ADDRESS.

--- a/src/envoy/http/backend_routing/filter.h
+++ b/src/envoy/http/backend_routing/filter.h
@@ -16,7 +16,9 @@
 
 #include <string>
 
+#include "absl/strings/string_view.h"
 #include "common/common/logger.h"
+#include "envoy/http/codes.h"
 #include "envoy/http/filter.h"
 #include "envoy/http/header_map.h"
 #include "extensions/filters/http/common/pass_through_filter.h"
@@ -37,6 +39,9 @@ class Filter : public Envoy::Http::PassThroughDecoderFilter,
                                                  bool) override;
 
  private:
+  void rejectRequest(Envoy::Http::Code code, absl::string_view error_msg,
+                     absl::string_view details);
+
   std::string translateConstPath(absl::string_view prefix,
                                  absl::string_view original_path);
 

--- a/src/envoy/http/backend_routing/filter_config.h
+++ b/src/envoy/http/backend_routing/filter_config.h
@@ -30,7 +30,8 @@ namespace backend_routing {
 #define ALL_BACKEND_ROUTING_FILTER_STATS(COUNTER) \
   COUNTER(append_path_to_address_request)         \
   COUNTER(constant_address_request)               \
-  COUNTER(denied)
+  COUNTER(denied)                                 \
+  COUNTER(pass_through)
 
 /**
  * Wrapper struct for backend routing filter stats. @see stats_macros.h

--- a/src/envoy/http/backend_routing/filter_config.h
+++ b/src/envoy/http/backend_routing/filter_config.h
@@ -27,11 +27,10 @@ namespace backend_routing {
  * All stats for the backend routing filter. @see stats_macros.h
  */
 
-// clang-format off
-#define ALL_BACKEND_ROUTING_FILTER_STATS(COUNTER)     \
-  COUNTER(append_path_to_address_request)             \
-  COUNTER(constant_address_request)                   \
-// clang-format on
+#define ALL_BACKEND_ROUTING_FILTER_STATS(COUNTER) \
+  COUNTER(append_path_to_address_request)         \
+  COUNTER(constant_address_request)               \
+  COUNTER(denied)
 
 /**
  * Wrapper struct for backend routing filter stats. @see stats_macros.h
@@ -50,15 +49,18 @@ class FilterConfig : public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
       : proto_config_(proto_config),
         stats_(generateStats(stats_prefix, context.scope())) {
     for (const auto& rule : proto_config_.rules()) {
-      if (rule.path_translation() == ::google::api::envoy::http::backend_routing::BackendRoutingRule::PATH_TRANSLATION_UNSPECIFIED) {
-        throw Envoy::ProtoValidationException("Path translation for BackendRouting rule must be specified", rule);
+      if (rule.path_translation() ==
+          ::google::api::envoy::http::backend_routing::BackendRoutingRule::
+              PATH_TRANSLATION_UNSPECIFIED) {
+        throw Envoy::ProtoValidationException(
+            "Path translation for BackendRouting rule must be specified", rule);
       }
       backend_routing_map_[rule.operation()] = &rule;
     }
   }
 
-  const ::google::api::envoy::http::backend_routing::BackendRoutingRule* findRule(
-	  absl::string_view operation) const {
+  const ::google::api::envoy::http::backend_routing::BackendRoutingRule*
+  findRule(absl::string_view operation) const {
     const auto it = backend_routing_map_.find(operation);
     if (it == backend_routing_map_.end()) {
       return nullptr;
@@ -69,7 +71,8 @@ class FilterConfig : public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
   FilterStats& stats() { return stats_; }
 
  private:
-  FilterStats generateStats(const std::string& prefix, Envoy::Stats::Scope& scope) {
+  FilterStats generateStats(const std::string& prefix,
+                            Envoy::Stats::Scope& scope) {
     const std::string final_prefix = prefix + "backend_routing.";
     return {ALL_BACKEND_ROUTING_FILTER_STATS(
         POOL_COUNTER_PREFIX(scope, final_prefix))};
@@ -88,8 +91,7 @@ class FilterConfig : public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
 
 using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;
 
-}  // namespace BackendRouting
-}  // namespace HttpFilters
-}  // namespace Extensions
-}  // namespace Envoy
-
+}  // namespace backend_routing
+}  // namespace http_filters
+}  // namespace envoy
+}  // namespace espv2

--- a/src/envoy/http/backend_routing/filter_config.h
+++ b/src/envoy/http/backend_routing/filter_config.h
@@ -30,8 +30,9 @@ namespace backend_routing {
 #define ALL_BACKEND_ROUTING_FILTER_STATS(COUNTER) \
   COUNTER(append_path_to_address_request)         \
   COUNTER(constant_address_request)               \
-  COUNTER(denied)                                 \
-  COUNTER(pass_through)
+  COUNTER(denied_by_no_path)                      \
+  COUNTER(denied_by_no_operation)                 \
+  COUNTER(allowed_by_no_configured_rules)
 
 /**
  * Wrapper struct for backend routing filter stats. @see stats_macros.h

--- a/src/envoy/http/backend_routing/filter_test.cc
+++ b/src/envoy/http/backend_routing/filter_test.cc
@@ -122,14 +122,14 @@ TEST_F(BackendRoutingFilterTest, UnknownOperationName) {
   Envoy::Http::FilterHeadersStatus status =
       filter_->decodeHeaders(headers, false);
 
-  // Expect the filter to be a NOOP and reject the request.
+  // Expect the filter to be a NOOP and pass the request through.
   EXPECT_EQ(headers.Path()->value().getStringView(), "/books/1");
-  EXPECT_EQ(status, Envoy::Http::FilterHeadersStatus::StopIteration);
+  EXPECT_EQ(status, Envoy::Http::FilterHeadersStatus::Continue);
 
   // Stats.
   const Envoy::Stats::CounterSharedPtr counter =
       Envoy::TestUtility::findCounter(mock_factory_context_.scope_,
-                                      "backend_routing.denied");
+                                      "backend_routing.pass_through");
   ASSERT_NE(counter, nullptr);
   EXPECT_EQ(counter->value(), 1);
 }

--- a/src/envoy/http/backend_routing/filter_test.cc
+++ b/src/envoy/http/backend_routing/filter_test.cc
@@ -91,7 +91,7 @@ class BackendRoutingFilterTest : public ::testing::Test {
       mock_factory_context_;
 };
 
-TEST_F(BackendRoutingFilterTest, NoOperationName) {
+TEST_F(BackendRoutingFilterTest, NoOperationNameBlocked) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
                                                 {":path", "/books/1"}};
 
@@ -111,7 +111,7 @@ TEST_F(BackendRoutingFilterTest, NoOperationName) {
   EXPECT_EQ(counter->value(), 1);
 }
 
-TEST_F(BackendRoutingFilterTest, UnknownOperationName) {
+TEST_F(BackendRoutingFilterTest, OperationNotConfiguredAllowed) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
                                                 {":path", "/books/1"}};
   utils::setStringFilterState(
@@ -135,7 +135,7 @@ TEST_F(BackendRoutingFilterTest, UnknownOperationName) {
   EXPECT_EQ(counter->value(), 1);
 }
 
-TEST_F(BackendRoutingFilterTest, NoPathHeader) {
+TEST_F(BackendRoutingFilterTest, NoPathHeaderBlocked) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "GET"}};
   utils::setStringFilterState(
       *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kOperation,

--- a/src/envoy/http/backend_routing/filter_test.cc
+++ b/src/envoy/http/backend_routing/filter_test.cc
@@ -106,7 +106,7 @@ TEST_F(BackendRoutingFilterTest, NoOperationName) {
   // Stats.
   const Envoy::Stats::CounterSharedPtr counter =
       Envoy::TestUtility::findCounter(mock_factory_context_.scope_,
-                                      "backend_routing.denied");
+                                      "backend_routing.denied_by_no_operation");
   ASSERT_NE(counter, nullptr);
   EXPECT_EQ(counter->value(), 1);
 }
@@ -128,8 +128,9 @@ TEST_F(BackendRoutingFilterTest, UnknownOperationName) {
 
   // Stats.
   const Envoy::Stats::CounterSharedPtr counter =
-      Envoy::TestUtility::findCounter(mock_factory_context_.scope_,
-                                      "backend_routing.pass_through");
+      Envoy::TestUtility::findCounter(
+          mock_factory_context_.scope_,
+          "backend_routing.allowed_by_no_configured_rules");
   ASSERT_NE(counter, nullptr);
   EXPECT_EQ(counter->value(), 1);
 }
@@ -151,7 +152,7 @@ TEST_F(BackendRoutingFilterTest, NoPathHeader) {
   // Stats.
   const Envoy::Stats::CounterSharedPtr counter =
       Envoy::TestUtility::findCounter(mock_factory_context_.scope_,
-                                      "backend_routing.denied");
+                                      "backend_routing.denied_by_no_path");
   ASSERT_NE(counter, nullptr);
   EXPECT_EQ(counter->value(), 1);
 }


### PR DESCRIPTION
Error handling:
- Errors should occur very rarely in the Backend Routing filter, but we must handle those cases for security review.
- Reject the requests when error occurs. This will prevent forwarding requests to localhost. It will also present clearer error messages to users.
- If no operation is found, still allow pass through.

Stats:
- Add some more stats, documented in README.
- Add unit tests for pre-existing stats.

Also cleanup uses of `ASSERT_EQ` to `EXPECT_EQ`.

Signed-off-by: Teju Nareddy <nareddyt@google.com>