### PR TITLE
b/155209585 #4: Ensure all consumer/producer errors are logged in stats

### DIFF
--- a/src/envoy/http/backend_auth/filter_test.cc
+++ b/src/envoy/http/backend_auth/filter_test.cc
@@ -120,7 +120,7 @@ TEST_F(BackendAuthFilterTest, SucceedAppendToken) {
   utils::setStringFilterState(
       *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kOperation,
       "operation-with-audience");
-  testing::NiceMock<Envoy::Stats::MockStore> scope;
+  testing::NiceMock<Envoy::Stats::MockIsolatedStatsStore> scope;
   const std::string prefix = Envoy::EMPTY_STRING;
   FilterStats filter_stats{
       ALL_BACKEND_AUTH_FILTER_STATS(POOL_COUNTER_PREFIX(scope, prefix))};
@@ -155,7 +155,7 @@ TEST_F(BackendAuthFilterTest, SucceedTokenCopied) {
   utils::setStringFilterState(
       *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kOperation,
       "operation-with-audience");
-  testing::NiceMock<Envoy::Stats::MockStore> scope;
+  testing::NiceMock<Envoy::Stats::MockIsolatedStatsStore> scope;
   const std::string prefix = Envoy::EMPTY_STRING;
   FilterStats filter_stats{
       ALL_BACKEND_AUTH_FILTER_STATS(POOL_COUNTER_PREFIX(scope, prefix))};

--- a/src/envoy/http/service_control/filter_test.cc
+++ b/src/envoy/http/service_control/filter_test.cc
@@ -68,7 +68,7 @@ class ServiceControlFilterTest : public ::testing::Test {
   testing::NiceMock<MockServiceControlHandler>* mock_handler_;
   ServiceControlHandlerPtr mock_handler_ptr_;
   testing::NiceMock<Envoy::MockBuffer> mock_buffer_;
-  testing::NiceMock<Envoy::Stats::MockStore> mock_stats_scope_;
+  testing::NiceMock<Envoy::Stats::MockIsolatedStatsStore> mock_stats_scope_;
   ServiceControlFilterStatBase stats_base_;
   Envoy::Http::TestRequestHeaderMapImpl req_headers_;
   Envoy::Http::TestRequestTrailerMapImpl req_trailer_;

--- a/src/envoy/http/service_control/handler_utils_test.cc
+++ b/src/envoy/http/service_control/handler_utils_test.cc
@@ -293,7 +293,7 @@ TEST(ServiceControlUtils, FillLatency) {
   };
 
   const std::chrono::nanoseconds zero = std::chrono::nanoseconds(0);
-  testing::NiceMock<Envoy::Stats::MockStore> mock_stats_scope;
+  testing::NiceMock<Envoy::Stats::MockIsolatedStatsStore> mock_stats_scope;
   ServiceControlFilterStatBase stats_base(Envoy::EMPTY_STRING,
                                           mock_stats_scope);
 


### PR DESCRIPTION
- When API key is not included in request that requires CHECK, increment stat.
- When filter is not configured, increment stat.

Other minor changes:
- Prefer `MockIsolatedStatsStore` for testing
- Fix small typo

Signed-off-by: Teju Nareddy <nareddyt@google.com>