### PR TITLE
b/155209585 #5: Verify stat invariants for all integration tests

### DIFF
--- a/tests/env/components/health_check_helpers.go
+++ b/tests/env/components/health_check_helpers.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/golang/glog"
@@ -152,25 +151,16 @@ func GrpcHealthCheck(addr string, opts *HealthCheckOptions) error {
 
 // HttpHealthCheck checks the service running at the specified port and path for a 200 OK response.
 // Does not support authentication. Supports retries and timeouts.
-func HttpHealthCheck(addr string, endpoint string, opts *HealthCheckOptions) error {
+func HttpHealthCheck(uri string, opts *HealthCheckOptions) error {
 
-	// Server address
-	u, err := url.Parse(addr)
-	if err != nil {
-		return err
-	}
-
-	// Health check path
-	u.Path = endpoint
-
-	err = withRetry(opts.HealthCheckRetries, opts.HealthCheckRetryBackoff, func() error {
+	err := withRetry(opts.HealthCheckRetries, opts.HealthCheckRetryBackoff, func() error {
 		// Create a client with an explicit deadline
 		client := http.Client{
 			Timeout: opts.HealthCheckDeadline,
 		}
 
 		// Make the request
-		resp, err := client.Get(u.String())
+		resp, err := client.Get(uri)
 		if err != nil {
 			return err
 		}

--- a/tests/env/components/stats_verifier.go
+++ b/tests/env/components/stats_verifier.go
@@ -1,0 +1,135 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package components
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
+	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
+	"github.com/golang/glog"
+)
+
+const (
+	// Ensure the stats are available in admin.
+	fetchDelay = time.Second * 3
+
+	// Margin of error for latency equality.
+	latencyMargin = 0.8
+)
+
+type StatsVerifier struct {
+	adminPort uint16
+}
+
+func NewStatsVerifier(ports *Ports) *StatsVerifier {
+	return &StatsVerifier{
+		adminPort: ports.AdminPort,
+	}
+}
+
+func (sv StatsVerifier) CheckExpectedCounters(wantCounters utils.StatCounters) error {
+	glog.Infof("Checking envoy counters")
+	time.Sleep(fetchDelay)
+
+	counters, _, err := utils.FetchStats(sv.adminPort)
+	if err != nil {
+		return err
+	}
+
+	for wantCounter, wantCounterVal := range wantCounters {
+		if getCountVal, ok := counters[wantCounter]; !ok {
+			return fmt.Errorf("expected counter %v not in the got counters: %v", wantCounter, counters)
+		} else if getCountVal != wantCounterVal {
+			return fmt.Errorf("for counter %v, expected value %v:, got value: %v ", wantCounter, wantCounterVal, getCountVal)
+		}
+	}
+
+	return nil
+}
+
+func (sv StatsVerifier) CheckExpectedHistograms(wantHistograms utils.StatHistograms) error {
+	glog.Infof("Checking envoy histograms")
+	time.Sleep(fetchDelay)
+
+	_, histograms, err := utils.FetchStats(sv.adminPort)
+	if err != nil {
+		return err
+	}
+
+	for wantHistogramName, wantHistogramVals := range wantHistograms {
+		getHistogramVals, ok := histograms[wantHistogramName]
+		if !ok {
+			return fmt.Errorf("expected histogram %v not in the got histograms: %v", wantHistogramName, histograms)
+		}
+
+		if len(wantHistogramVals) != len(getHistogramVals) {
+			return fmt.Errorf("different value number for histogram %v, expected vals: %v , got vals: %v", wantHistogramName, wantHistogramVals, getHistogramVals)
+		}
+
+		for i, wantHistogramVal := range wantHistogramVals {
+			if wantHistogramVal == 0.0 {
+				continue
+			}
+
+			if !roughEqual(getHistogramVals[i], wantHistogramVal, latencyMargin) {
+				return fmt.Errorf("histogram %v not matched, expected vals: %v , got vals: %v", wantHistogramName, wantHistogramVals, getHistogramVals)
+			}
+		}
+	}
+	return nil
+}
+
+func (sv StatsVerifier) VerifyInvariants() error {
+	glog.Infof("Verifying envoy stats invariants")
+	time.Sleep(fetchDelay)
+
+	counters, _, err := utils.FetchStats(sv.adminPort)
+	if err != nil {
+		return err
+	}
+
+	if counters["http.ingress_http.service_control.allowed"] <
+		counters["http.ingress_http.service_control.allowed_control_plane_fault"] {
+		return fmt.Errorf("sc allowed invariant failed: %v", counters)
+	}
+
+	if counters["http.ingress_http.service_control.denied"] !=
+		counters["http.ingress_http.service_control.denied_control_plane_fault"]+
+			counters["http.ingress_http.service_control.denied_producer_error"]+
+			counters["http.ingress_http.service_control.denied_consumer_quota"]+
+			counters["http.ingress_http.service_control.denied_consumer_blocked"]+
+			counters["http.ingress_http.service_control.denied_consumer_error"] {
+		return fmt.Errorf("sc denied invariant failed: %v", counters)
+	}
+
+	glog.Infof("Verified stats invariants successfully")
+	return nil
+}
+
+func (sv StatsVerifier) String() string {
+	return "Envoy Admin Endpoint for Stats"
+}
+
+func (sv StatsVerifier) CheckHealth() error {
+	endpoint := fmt.Sprintf("http://%v:%v%v", platform.GetLoopbackAddress(), sv.adminPort, utils.ESpv2FiltersStatsPath)
+	opts := NewHealthCheckOptions()
+	return HttpHealthCheck(endpoint, opts)
+}
+
+func roughEqual(i, j, latencyMargin float64) bool {
+	return i > j*(1-latencyMargin) && i < j*(1+latencyMargin)
+}

--- a/tests/integration_test/statistics_test.go
+++ b/tests/integration_test/statistics_test.go
@@ -29,10 +29,6 @@ import (
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
 )
 
-func roughEqual(i, j, latencyMargin float64) bool {
-	return i > j*(1-latencyMargin) && i < j*(1+latencyMargin)
-}
-
 func TestStatistics(t *testing.T) {
 	t.Parallel()
 
@@ -42,7 +38,6 @@ func TestStatistics(t *testing.T) {
 	if err := s.Setup(utils.CommonArgs()); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
-	const latencyMargin = 0.8
 
 	//the latency is different each run. Here the backend server introduces a
 	// fixed big N second latency, so the overall latency should be around N
@@ -54,20 +49,20 @@ func TestStatistics(t *testing.T) {
 		desc           string
 		reqCnt         int
 		reqDuration    time.Duration
-		wantCounts     map[string]int
-		wantHistograms map[string][]float64
+		wantCounters   utils.StatCounters
+		wantHistograms utils.StatHistograms
 	}{
 		{
 			desc:        "backend respond in 1s",
 			reqCnt:      2,
 			reqDuration: time.Second * 1,
-			wantCounts: map[string]int{
+			wantCounters: utils.StatCounters{
 				"http.ingress_http.backend_auth.token_added":                       2,
 				"http.ingress_http.backend_routing.append_path_to_address_request": 2,
 				"http.ingress_http.path_matcher.allowed":                           2,
 				"http.ingress_http.service_control.allowed":                        2,
 			},
-			wantHistograms: map[string][]float64{
+			wantHistograms: utils.StatHistograms{
 				"http.ingress_http.service_control.overhead_time": {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
 				"http.ingress_http.service_control.backend_time":  {1000, 1025, 1050, 1075, 1090, 1095, 1099, 1099.5, 1099.9, 1100},
 				"http.ingress_http.service_control.request_time":  {1000, 1025, 1050, 1075, 1090, 1095, 1099, 1099.5, 1099.9, 1100},
@@ -85,53 +80,12 @@ func TestStatistics(t *testing.T) {
 			}
 		}
 
-		// Ensure the stats is available in admin.
-		time.Sleep(time.Millisecond * 5000)
-
-		statsUrl := fmt.Sprintf("http://localhost:%v%v", s.Ports().AdminPort, utils.ESpv2FiltersStatsPath)
-		resp, err := utils.DoWithHeaders(statsUrl, "GET", "", nil)
-		if err != nil {
-			t.Fatalf("GET %s faild: %v", url, err)
+		if err := s.StatsVerifier.CheckExpectedCounters(tc.wantCounters); err != nil {
+			t.Errorf("Test (%v) failed: %v", tc.desc, err)
 		}
 
-		counts, histograms, err := utils.ParseStats(resp)
-		if err != nil {
-			t.Fatalf("fail to parse stats: %v", err)
-		}
-
-		for wantCountName, wantCountVal := range tc.wantCounts {
-			if getCountVal, ok := counts[wantCountName]; !ok {
-				t.Errorf("Test (%s): failed, expected counter %v not in the got counters: %v", tc.desc, wantCountName, counts)
-				break
-			} else if wantCountVal != getCountVal {
-				t.Errorf("Test (%s): failed, for counter %s, expected value %v:, got value: %v ", tc.desc, wantCountName, wantCountVal, getCountVal)
-				break
-			}
-		}
-
-		for wantHistogramName, wantHistogramVals := range tc.wantHistograms {
-			getHistogramVals, ok := histograms[wantHistogramName]
-			if !ok {
-				t.Errorf("Test (%s): failed, expected histogram %v not in the got histograms: %v", tc.desc, wantHistogramName, histograms)
-				break
-			}
-
-			if len(wantHistogramVals) != len(getHistogramVals) {
-				t.Errorf("Test (%s): failed, different value number for histogram %v, expected vals: %v , got vals: %v", tc.desc, wantHistogramName, wantHistogramVals, getHistogramVals)
-				continue
-			}
-
-			for i, wantHistogramVal := range wantHistogramVals {
-				if wantHistogramVal == 0.0 {
-					continue
-				}
-
-				if !roughEqual(getHistogramVals[i], wantHistogramVal, latencyMargin) {
-					t.Errorf("Test (%s): failed, histogram %v not matched, expected vals: %v , got vals: %v", tc.desc, wantHistogramName, wantHistogramVals, getHistogramVals)
-					break
-				}
-			}
-
+		if err := s.StatsVerifier.CheckExpectedHistograms(tc.wantHistograms); err != nil {
+			t.Errorf("Test (%v) failed: %v", tc.desc, err)
 		}
 	}
 }
@@ -150,12 +104,12 @@ func TestStatisticsServiceControlCallStatus(t *testing.T) {
 		checkRespCode  int
 		quotaRespCode  int
 		reportRespCode int
-		wantCounters   map[string]int
+		wantCounters   utils.StatCounters
 	}{
 		{
 			desc:          "check call, quota call and report call are successful",
 			checkRespCode: 200,
-			wantCounters: map[string]int{
+			wantCounters: utils.StatCounters{
 				"http.ingress_http.service_control.check.OK":          1,
 				"http.ingress_http.service_control.allocate_quota.OK": 1,
 				"http.ingress_http.service_control.report.OK":         1,
@@ -165,7 +119,7 @@ func TestStatisticsServiceControlCallStatus(t *testing.T) {
 			desc:          "check call, quota call and report call are cached",
 			checkRespCode: 200,
 			reqCnt:        5,
-			wantCounters: map[string]int{
+			wantCounters: utils.StatCounters{
 				"http.ingress_http.service_control.check.OK": 1,
 				// The quota call for the first incoming request and the quota call by cache flush after 1s.
 				"http.ingress_http.service_control.allocate_quota.OK": 2,
@@ -176,7 +130,7 @@ func TestStatisticsServiceControlCallStatus(t *testing.T) {
 			desc:           "check call and report call are both 403",
 			checkRespCode:  403,
 			reportRespCode: 403,
-			wantCounters: map[string]int{
+			wantCounters: utils.StatCounters{
 				"http.ingress_http.service_control.check.PERMISSION_DENIED":  1,
 				"http.ingress_http.service_control.report.PERMISSION_DENIED": 1,
 			},
@@ -184,7 +138,7 @@ func TestStatisticsServiceControlCallStatus(t *testing.T) {
 		{
 			desc:          "quota call is 403",
 			quotaRespCode: 403,
-			wantCounters: map[string]int{
+			wantCounters: utils.StatCounters{
 				"http.ingress_http.service_control.check.OK":                         1,
 				"http.ingress_http.service_control.allocate_quota.PERMISSION_DENIED": 1,
 			},
@@ -230,28 +184,9 @@ func TestStatisticsServiceControlCallStatus(t *testing.T) {
 				_, _ = bsclient.MakeCall("http", addr, "GET", "/v1/shelves/100/books?key=api-key", "", nil)
 			}
 
-			// Ensure the stats is available in admin.
-			time.Sleep(time.Millisecond * 5000)
-
-			statsUrl := fmt.Sprintf("http://localhost:%v%v", s.Ports().AdminPort, utils.ESpv2FiltersStatsPath)
-			statsResp, err := utils.DoWithHeaders(statsUrl, "GET", "", nil)
-			if err != nil {
-				t.Fatalf("GET %s faild: %v", addr, err)
+			if err := s.StatsVerifier.CheckExpectedCounters(tc.wantCounters); err != nil {
+				t.Errorf("Test (%v) failed: %v", tc.desc, err)
 			}
-
-			counters, _, err := utils.ParseStats(statsResp)
-			if err != nil {
-				t.Fatalf("fail to parse stats: %v", err)
-			}
-
-			for wantCounter, wantCounterVal := range tc.wantCounters {
-				if getCountVal, ok := counters[wantCounter]; !ok {
-					t.Errorf("Test (%s): failed, expected counter %v not in the got counters: %v", tc.desc, wantCounter, counters)
-				} else if getCountVal != wantCounterVal {
-					t.Errorf("Test (%s): failed, for counter %v, expected value %v:, got value: %v ", tc.desc, wantCounter, wantCounterVal, getCountVal)
-				}
-			}
-
 		}()
 	}
 }


### PR DESCRIPTION
Stats recording in SC Filter is split across multiple files and can be confusing to reason about. To ensure that requests are not double-counted in SLO-related stats, add a `stats_verifier` component in our integration tests. This component will fetch envoy stats at the end of each test and verify no invariants are broken.

Example invariants:
> The values of the detailed `service_control.denied_*` counters must sum up to `service_control.denied`

We can add more invariants as needed in the future.

Signed-off-by: Teju Nareddy <nareddyt@google.com>