### PR TITLE
[Refactor] Enforce test failures on teardown

### DIFF
--- a/tests/env/env.go
+++ b/tests/env/env.go
@@ -244,6 +244,7 @@ func (e *TestEnv) EnableEchoServerRootPathHandler() {
 // Limit usage of this, as it causes flakes in CI.
 // Only intended to be used to test if Envoy starts up correctly.
 // Ideally, the test using this should have it's own retry loop.
+// Can also call after setup but before teardown to skip teardown checks.
 func (e *TestEnv) SkipHealthChecks() {
 	e.skipHealthChecks = true
 }

--- a/tests/env/env.go
+++ b/tests/env/env.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
@@ -492,16 +493,21 @@ func (e *TestEnv) StopBackendServer() error {
 }
 
 // TearDown shutdown the servers.
-func (e *TestEnv) TearDown() {
+func (e *TestEnv) TearDown(t *testing.T) {
 	glog.Infof("start tearing down...")
 
-	// Run all health checks. If they fail, our test causes a server to become unhealthy...
+	// Run all health checks. If they fail, our test causes a server to crash.
+	// Fail the test.
 	if !e.skipHealthChecks {
 		if err := e.healthRegistry.RunAllHealthChecks(); err != nil {
-			glog.Errorf("health check failure during teardown: %v", err)
+			t.Errorf("health check failure during teardown: %v", err)
 		}
 	}
 
+	// TODO(nareddyt): Verify stats invariants and fail test on error.
+	// https://github.com/GoogleCloudPlatform/esp-v2/pull/167
+
+	// No need to fail test if any of these have errors.
 	if e.FakeJwtService != nil {
 		e.FakeJwtService.TearDown()
 	}

--- a/tests/integration_test/access_log_test.go
+++ b/tests/integration_test/access_log_test.go
@@ -74,7 +74,7 @@ func TestAccessLog(t *testing.T) {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
 	makeOneRequest(t, s)
-	s.TearDown()
+	s.TearDown(t)
 	expectAccessLog := fmt.Sprintf("\"POST /echo?key=api-key HTTP/1.1\"200"+
 		" - 20 19\"-\" \"Go-http-client/1.1\"\"localhost:%v\" \"127.0.0.1:%v\"\n",
 		s.Ports().ListenerPort, s.Ports().BackendServerPort)

--- a/tests/integration_test/auth_pkey_cache_test.go
+++ b/tests/integration_test/auth_pkey_cache_test.go
@@ -76,7 +76,7 @@ func TestAuthJwksCache(t *testing.T) {
 				args = append(args, fmt.Sprintf("--jwks_cache_duration_in_s=%v", tc.jwksCacheDurationInS))
 			}
 
-			defer s.TearDown()
+			defer s.TearDown(t)
 			if err := s.Setup(args); err != nil {
 				t.Fatalf("fail to setup test env, %v", err)
 			}

--- a/tests/integration_test/backend_auth_disable_auth_test.go
+++ b/tests/integration_test/backend_auth_disable_auth_test.go
@@ -37,7 +37,7 @@ func TestBackendAuthDisableAuth(t *testing.T) {
 			util.IdentityTokenSuffix + "?format=standard&audience=https://localhost":                      "ya29.DefaultAuth",
 		}, 0)
 
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(utils.CommonArgs()); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/backend_auth_using_iam_test.go
+++ b/tests/integration_test/backend_auth_using_iam_test.go
@@ -42,7 +42,7 @@ func TestBackendAuthWithIamIdToken(t *testing.T) {
 			fmt.Sprintf("%s?audience=https://localhost/bearertoken/append", util.IamIdentityTokenSuffix(serviceAccount)):   `{"token":  "id-token-for-append"}`,
 		}, 0)
 
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(utils.CommonArgs()); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -119,7 +119,7 @@ func TestBackendAuthWithIamIdTokenRetries(t *testing.T) {
 					fmt.Sprintf("%s?audience=https://localhost/bearertoken/constant", util.IamIdentityTokenSuffix(serviceAccount)): `{"token":  "id-token-for-constant"}`,
 				}, tc.wantNumFails)
 
-			defer s.TearDown()
+			defer s.TearDown(t)
 			if err := s.Setup(utils.CommonArgs()); err != nil {
 				t.Fatalf("fail to setup test env, %v", err)
 			}
@@ -166,7 +166,7 @@ func TestBackendAuthUsingIamIdTokenWithDelegates(t *testing.T) {
 			fmt.Sprintf("/v1/projects/-/serviceAccounts/%s:generateIdToken?audience=https://localhost/bearertoken/constant", serviceAccount): `{"token":  "id-token-for-constant"}`,
 		}, 0)
 
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(utils.CommonArgs()); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/backend_auth_using_imds_test.go
+++ b/tests/integration_test/backend_auth_using_imds_test.go
@@ -39,7 +39,7 @@ func TestBackendAuthWithImdsIdToken(t *testing.T) {
 			util.IdentityTokenSuffix + "?format=standard&audience=https://localhost/bearertoken/append":   "ya29.append",
 		}, 0)
 
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(utils.CommonArgs()); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -121,7 +121,7 @@ func TestBackendAuthWithImdsIdTokenRetries(t *testing.T) {
 					util.IdentityTokenSuffix + "?format=standard&audience=https://localhost/bearertoken/constant": "ya29.constant",
 				}, tc.wantNumFails)
 
-			defer s.TearDown()
+			defer s.TearDown(t)
 			if err := s.Setup(utils.CommonArgs()); err != nil {
 				t.Fatalf("fail to setup test env, %v", err)
 			}
@@ -169,7 +169,7 @@ func TestBackendAuthWithImdsIdTokenWhileAllowCors(t *testing.T) {
 		}, 0)
 	s.SetAllowCors()
 
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(utils.CommonArgs()); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/backend_protocol_test.go
+++ b/tests/integration_test/backend_protocol_test.go
@@ -90,7 +90,7 @@ func TestBackendHttpProtocol(t *testing.T) {
 			}
 
 			// Setup test env.
-			defer s.TearDown()
+			defer s.TearDown(t)
 			if err := s.Setup(utils.CommonArgs()); err != nil {
 				t.Fatalf("fail to setup test env, %v", err)
 			}

--- a/tests/integration_test/cors_integration_test.go
+++ b/tests/integration_test/cors_integration_test.go
@@ -46,7 +46,7 @@ func TestSimpleCorsWithBasicPreset(t *testing.T) {
 		"--cors_expose_headers=" + corsExposeHeadersValue}
 
 	s := env.NewTestEnv(comp.TestSimpleCorsWithBasicPreset, platform.EchoSidecar)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -110,7 +110,7 @@ func TestDifferentOriginSimpleCors(t *testing.T) {
 		"--cors_expose_headers=" + corsExposeHeadersValue}
 
 	s := env.NewTestEnv(comp.TestDifferentOriginSimpleCors, platform.EchoSidecar)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -154,7 +154,7 @@ func TestSimpleCorsWithRegexPreset(t *testing.T) {
 	s := env.NewTestEnv(comp.TestSimpleCorsWithRegexPreset, platform.EchoSidecar)
 	// UseWrongBackendCertForDR shouldn't impact simple Cors.
 	s.UseWrongBackendCertForDR(true)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -203,7 +203,7 @@ func TestPreflightCorsWithBasicPreset(t *testing.T) {
 		"--cors_expose_headers=" + corsExposeHeadersValue, "--cors_allow_credentials"}
 
 	s := env.NewTestEnv(comp.TestPreflightCorsWithBasicPreset, platform.EchoSidecar)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -257,7 +257,7 @@ func TestDifferentOriginPreflightCors(t *testing.T) {
 		"--cors_expose_headers=" + corsExposeHeadersValue, "--cors_allow_credentials"}
 
 	s := env.NewTestEnv(comp.TestDifferentOriginPreflightCors, platform.EchoSidecar)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -304,7 +304,7 @@ func TestGrpcBackendSimpleCors(t *testing.T) {
 		"--cors_expose_headers=" + corsExposeHeadersValue}
 
 	s := env.NewTestEnv(comp.TestGrpcBackendSimpleCors, platform.GrpcBookstoreSidecar)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -352,7 +352,7 @@ func TestGrpcBackendPreflightCors(t *testing.T) {
 		"--cors_expose_headers=" + corsExposeHeadersValue, "--cors_allow_credentials"}
 
 	s := env.NewTestEnv(comp.TestGrpcBackendPreflightCors, platform.GrpcBookstoreSidecar)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -404,7 +404,7 @@ func TestPreflightRequestWithAllowCors(t *testing.T) {
 
 	s := env.NewTestEnv(comp.TestPreflightRequestWithAllowCors, platform.EchoSidecar)
 	s.SetAllowCors()
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -497,7 +497,7 @@ func TestServiceControlRequestWithAllowCors(t *testing.T) {
 			},
 		},
 	})
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -667,7 +667,7 @@ func TestServiceControlRequestWithoutAllowCors(t *testing.T) {
 			},
 		},
 	})
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/dns_resolver_test.go
+++ b/tests/integration_test/dns_resolver_test.go
@@ -104,7 +104,7 @@ func TestDnsResolver(t *testing.T) {
 				"--dns_resolver_addresses=" + dnsResolverAddress,
 			}
 
-			defer s.TearDown()
+			defer s.TearDown(t)
 			if err := s.Setup(args); err != nil {
 				t.Fatalf("fail to setup test env, %v", err)
 			}

--- a/tests/integration_test/dynamic_routing_integration_test.go
+++ b/tests/integration_test/dynamic_routing_integration_test.go
@@ -38,7 +38,7 @@ func NewDynamicRoutingTestEnv(port uint16) *env.TestEnv {
 func TestDynamicRouting(t *testing.T) {
 	t.Parallel()
 	s := NewDynamicRoutingTestEnv(comp.TestDynamicRouting)
-	defer s.TearDown()
+	defer s.TearDown(t)
 
 	if err := s.Setup(utils.CommonArgs()); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
@@ -230,7 +230,7 @@ func TestDynamicRoutingWithAllowCors(t *testing.T) {
 	s := NewDynamicRoutingTestEnv(comp.TestDynamicRoutingWithAllowCors)
 	s.SetAllowCors()
 
-	defer s.TearDown()
+	defer s.TearDown(t)
 
 	if err := s.Setup(utils.CommonArgs()); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
@@ -293,7 +293,7 @@ func TestDynamicRoutingCorsByEnvoy(t *testing.T) {
 		"--cors_allow_credentials"}...)
 
 	s := NewDynamicRoutingTestEnv(comp.TestDynamicRoutingCorsByEnvoy)
-	defer s.TearDown()
+	defer s.TearDown(t)
 
 	if err := s.Setup(dynamicRoutingArgs); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
@@ -334,7 +334,7 @@ func TestServiceControlRequestForDynamicRouting(t *testing.T) {
 	t.Parallel()
 
 	s := NewDynamicRoutingTestEnv(comp.TestServiceControlRequestForDynamicRouting)
-	defer s.TearDown()
+	defer s.TearDown(t)
 
 	if err := s.Setup(utils.CommonArgs()); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
@@ -569,7 +569,7 @@ func TestDynamicBackendRoutingTLS(t *testing.T) {
 		func() {
 			s := env.NewTestEnv(comp.TestDynamicBackendRoutingTLS, platform.EchoRemote)
 			s.UseWrongBackendCertForDR(tc.useWrongCert)
-			defer s.TearDown()
+			defer s.TearDown(t)
 
 			if err := s.Setup(utils.CommonArgs()); err != nil {
 				t.Fatalf("fail to setup test env, %v", err)
@@ -692,7 +692,7 @@ func TestDynamicBackendRoutingMutualTLS(t *testing.T) {
 		func() {
 			s := env.NewTestEnv(comp.TestDynamicBackendRoutingMutualTLS, platform.EchoRemote)
 			s.SetBackendMTLSCert(tc.mtlsCertFile)
-			defer s.TearDown()
+			defer s.TearDown(t)
 
 			if err := s.Setup(args); err != nil {
 				t.Fatalf("fail to setup test env, %v", err)
@@ -786,7 +786,7 @@ func TestDynamicGrpcBackendTLS(t *testing.T) {
 		args := utils.CommonArgs()
 		func() {
 			s := env.NewTestEnv(comp.TestDynamicGrpcBackendTLS, platform.GrpcBookstoreRemote)
-			defer s.TearDown()
+			defer s.TearDown(t)
 			s.UseWrongBackendCertForDR(tc.useWrongBackendCert)
 			if tc.mtlsCertFile != "" {
 				s.SetBackendMTLSCert(tc.mtlsCertFile)

--- a/tests/integration_test/grpc_deadline_test.go
+++ b/tests/integration_test/grpc_deadline_test.go
@@ -33,7 +33,7 @@ func TestDeadlinesForGrpcDynamicRouting(t *testing.T) {
 
 	s := env.NewTestEnv(comp.TestDeadlinesForGrpcDynamicRouting, platform.GrpcEchoRemote)
 
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(utils.CommonArgs()); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -127,7 +127,7 @@ func TestDeadlinesForGrpcCatchAllBackend(t *testing.T) {
 
 	s := env.NewTestEnv(comp.TestDeadlinesForGrpcCatchAllBackend, platform.GrpcEchoSidecar)
 
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(utils.CommonArgs()); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/grpc_errors_test.go
+++ b/tests/integration_test/grpc_errors_test.go
@@ -34,7 +34,7 @@ func TestGRPCErrors(t *testing.T) {
 		"--rollout_strategy=fixed"}
 
 	s := env.NewTestEnv(comp.TestGRPCErrors, platform.GrpcEchoSidecar)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/grpc_fallback_test.go
+++ b/tests/integration_test/grpc_fallback_test.go
@@ -66,7 +66,7 @@ func TestGRPCFallback(t *testing.T) {
 			AllowUnregisteredCalls: true,
 		},
 	})
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/grpc_integration_test.go
+++ b/tests/integration_test/grpc_integration_test.go
@@ -46,7 +46,7 @@ func TestGRPC(t *testing.T) {
 	args := []string{"--service_config_id=" + configID, "--rollout_strategy=fixed", "--healthz=healthz"}
 
 	s := env.NewTestEnv(comp.TestGRPC, platform.GrpcBookstoreSidecar)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -152,7 +152,7 @@ func TestGRPCWeb(t *testing.T) {
 		"--rollout_strategy=fixed"}
 
 	s := env.NewTestEnv(comp.TestGRPCWeb, platform.GrpcBookstoreSidecar)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -236,7 +236,7 @@ func TestGRPCJwt(t *testing.T) {
 		"--rollout_strategy=fixed"}
 
 	s := env.NewTestEnv(comp.TestGRPCJwt, platform.GrpcBookstoreSidecar)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -501,7 +501,7 @@ func TestGRPCMetadata(t *testing.T) {
 		"--rollout_strategy=fixed"}
 
 	s := env.NewTestEnv(comp.TestGRPCMetadata, platform.GrpcEchoSidecar)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/grpc_interop_test.go
+++ b/tests/integration_test/grpc_interop_test.go
@@ -58,7 +58,7 @@ func TestGRPCInterops(t *testing.T) {
 		t.Fatalf("TestGRPCInteropMiniStress: grpc-interop test binaris are not built. Please run make build-grpc-interop.")
 	}
 
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -103,7 +103,7 @@ func TestGRPCInteropMiniStress(t *testing.T) {
 		t.Fatalf("TestGRPCInteropMiniStress: grpc-interop test binaris are not built. Please run make build-grpc-interop.")
 	}
 
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/grpc_ministress_test.go
+++ b/tests/integration_test/grpc_ministress_test.go
@@ -33,7 +33,7 @@ func TestGRPCMinistress(t *testing.T) {
 		"--rollout_strategy=fixed"}
 
 	s := env.NewTestEnv(comp.TestGRPCMinistress, platform.GrpcEchoSidecar)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/grpc_streaming_test.go
+++ b/tests/integration_test/grpc_streaming_test.go
@@ -36,7 +36,7 @@ func TestGRPCStreaming(t *testing.T) {
 		"--rollout_strategy=fixed"}
 
 	s := env.NewTestEnv(comp.TestGRPCStreaming, platform.GrpcEchoSidecar)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -153,7 +153,7 @@ func TestGRPCLongStreaming(t *testing.T) {
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
-	defer s.TearDown()
+	defer s.TearDown(t)
 
 	testPlans := `
 plans {

--- a/tests/integration_test/http1_deadline_test.go
+++ b/tests/integration_test/http1_deadline_test.go
@@ -41,7 +41,7 @@ func TestDeadlinesForDynamicRouting(t *testing.T) {
 
 	s := env.NewTestEnv(comp.TestDeadlinesForDynamicRouting, platform.EchoRemote)
 
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(utils.CommonArgs()); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -121,7 +121,7 @@ func TestDeadlinesForCatchAllBackend(t *testing.T) {
 
 	s := env.NewTestEnv(comp.TestDeadlinesForCatchAllBackend, platform.EchoSidecar)
 
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(utils.CommonArgs()); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/http1_integration_test.go
+++ b/tests/integration_test/http1_integration_test.go
@@ -41,7 +41,7 @@ func TestHttp1Basic(t *testing.T) {
 		"--rollout_strategy=fixed", "--healthz=/healthz"}
 
 	s := env.NewTestEnv(comp.TestHttp1Basic, platform.EchoSidecar)
-	defer s.TearDown()
+	defer s.TearDown(t)
 
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
@@ -114,7 +114,7 @@ func TestHttp1JWT(t *testing.T) {
 		"--skip_service_control_filter=true", "--rollout_strategy=fixed"}
 
 	s := env.NewTestEnv(comp.TestHttp1JWT, platform.EchoSidecar)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -214,7 +214,7 @@ func TestHttpHeaders(t *testing.T) {
 	for _, tc := range testData {
 		func() {
 			s := env.NewTestEnv(comp.TestHttpHeaders, platform.GrpcBookstoreSidecar)
-			defer s.TearDown()
+			defer s.TearDown(t)
 			args := utils.CommonArgs()
 			if tc.underscoresInHeaders {
 				args = append(args, "--underscores_in_headers")

--- a/tests/integration_test/http_method_override_test.go
+++ b/tests/integration_test/http_method_override_test.go
@@ -48,7 +48,7 @@ func TestMethodOverrideBackendMethod(t *testing.T) {
 		},
 	})
 
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(utils.CommonArgs()); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -114,7 +114,7 @@ func TestMethodOverrideBackendBody(t *testing.T) {
 	t.Parallel()
 
 	s := env.NewTestEnv(comp.TestMethodOverrideBackendBody, platform.EchoSidecar)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(utils.CommonArgs()); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -184,7 +184,7 @@ func TestMethodOverrideScReport(t *testing.T) {
 	t.Parallel()
 
 	s := env.NewTestEnv(comp.TestMethodOverrideScReport, platform.EchoSidecar)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(utils.CommonArgs()); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/iam_imds_data_path_test.go
+++ b/tests/integration_test/iam_imds_data_path_test.go
@@ -91,7 +91,7 @@ func TestIamImdsDataPath(t *testing.T) {
 				time.Sleep(7 * time.Second)
 			}
 
-			defer s.TearDown()
+			defer s.TearDown(t)
 			if err := s.Setup(utils.CommonArgs()); err != nil {
 				t.Fatalf("fail to setup test env, %v", err)
 			}

--- a/tests/integration_test/jwt_auth_integration_test.go
+++ b/tests/integration_test/jwt_auth_integration_test.go
@@ -195,11 +195,6 @@ func TestInvalidOpenIDConnectDiscovery(t *testing.T) {
 	args := []string{"--service_config_id=" + configID,
 		"--rollout_strategy=fixed"}
 
-	s := env.NewTestEnv(comp.TestInvalidOpenIDConnectDiscovery, platform.GrpcBookstoreSidecar)
-	if err := s.FakeJwtService.SetupInvalidOpenId(); err != nil {
-		t.Fatalf("fail to setup open id servers: %v", err)
-	}
-
 	tests := []struct {
 		desc        string
 		providerId  string
@@ -218,30 +213,38 @@ func TestInvalidOpenIDConnectDiscovery(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		s.OverrideAuthentication(&confpb.Authentication{
-			Rules: []*confpb.AuthenticationRule{
-				{
-					Selector: "endpoints.examples.bookstore.Bookstore.ListShelves",
-					Requirements: []*confpb.AuthRequirement{
-						{
-							ProviderId: tc.providerId,
-							Audiences:  "ok_audience",
+		func() {
+			s := env.NewTestEnv(comp.TestInvalidOpenIDConnectDiscovery, platform.GrpcBookstoreSidecar)
+			if err := s.FakeJwtService.SetupInvalidOpenId(); err != nil {
+				t.Fatalf("fail to setup open id servers: %v", err)
+			}
+
+			s.OverrideAuthentication(&confpb.Authentication{
+				Rules: []*confpb.AuthenticationRule{
+					{
+						Selector: "endpoints.examples.bookstore.Bookstore.ListShelves",
+						Requirements: []*confpb.AuthRequirement{
+							{
+								ProviderId: tc.providerId,
+								Audiences:  "ok_audience",
+							},
 						},
 					},
 				},
-			},
-		})
+			})
 
-		err := s.Setup(args)
-		// No need to defer teardown, there should be a setup error.
-		s.SkipHealthChecks()
-		s.TearDown(t)
+			err := s.Setup(args)
 
-		if err == nil {
-			t.Errorf("Test (%s): failed, expected error, got no err", tc.desc)
-		} else if !strings.Contains(err.Error(), tc.expectedErr) {
-			t.Errorf("Test (%s): failed, expected err: %v, got err: %v", tc.desc, tc.expectedErr, err)
-		}
+			// LIFO ordering. Disable health checks before teardown, we expect a failure.
+			defer s.TearDown(t)
+			defer s.SkipHealthChecks()
+
+			if err == nil {
+				t.Errorf("Test (%s): failed, expected error, got no err", tc.desc)
+			} else if !strings.Contains(err.Error(), tc.expectedErr) {
+				t.Errorf("Test (%s): failed, expected err: %v, got err: %v", tc.desc, tc.expectedErr, err)
+			}
+		}()
 	}
 }
 

--- a/tests/integration_test/jwt_auth_integration_test.go
+++ b/tests/integration_test/jwt_auth_integration_test.go
@@ -76,7 +76,7 @@ func TestAsymmetricKeys(t *testing.T) {
 			},
 		},
 	})
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -233,7 +233,8 @@ func TestInvalidOpenIDConnectDiscovery(t *testing.T) {
 		})
 
 		err := s.Setup(args)
-		s.TearDown()
+		// No need to defer teardown, there should be a setup error.
+		s.TearDown(t)
 
 		if err == nil {
 			t.Errorf("Test (%s): failed, expected error, got no err", tc.desc)
@@ -274,7 +275,7 @@ func TestFrontendAndBackendAuthHeaders(t *testing.T) {
 			util.IdentityTokenSuffix + "?format=standard&audience=https://localhost/bearertoken/constant": "ya29.BackendAuthToken",
 		}, 0)
 
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(utils.CommonArgs()); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/jwt_auth_integration_test.go
+++ b/tests/integration_test/jwt_auth_integration_test.go
@@ -234,6 +234,7 @@ func TestInvalidOpenIDConnectDiscovery(t *testing.T) {
 
 		err := s.Setup(args)
 		// No need to defer teardown, there should be a setup error.
+		s.SkipHealthChecks()
 		s.TearDown(t)
 
 		if err == nil {

--- a/tests/integration_test/jwt_locations_test.go
+++ b/tests/integration_test/jwt_locations_test.go
@@ -57,7 +57,7 @@ func TestJwtLocations(t *testing.T) {
 			},
 		},
 	})
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/managed_service_config_test.go
+++ b/tests/integration_test/managed_service_config_test.go
@@ -49,7 +49,7 @@ func TestManagedServiceConfig(t *testing.T) {
 			},
 		},
 	})
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/multi_grpc_services_test.go
+++ b/tests/integration_test/multi_grpc_services_test.go
@@ -35,7 +35,7 @@ func TestMultiGrpcServices(t *testing.T) {
 	args := []string{"--service_config_id=" + configID, "--rollout_strategy=fixed"}
 
 	s := env.NewTestEnv(comp.TestMultiGrpcServices, platform.GrpcBookstoreSidecar)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/opencensus_tracing_test.go
+++ b/tests/integration_test/opencensus_tracing_test.go
@@ -87,7 +87,7 @@ func TestServiceControlCheckTracesWithRetry(t *testing.T) {
 		M: s.ServiceControlServer,
 	}
 	s.ServiceControlServer.OverrideCheckHandler(&handler)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -186,7 +186,7 @@ func TestServiceControlSkipUsageTraces(t *testing.T) {
 			},
 		},
 	)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -255,7 +255,7 @@ func TestFetchingJwksTraces(t *testing.T) {
 			},
 		},
 	})
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/report_gcp_attributes_test.go
+++ b/tests/integration_test/report_gcp_attributes_test.go
@@ -119,7 +119,7 @@ func TestReportGCPAttributes(t *testing.T) {
 			s := env.NewTestEnv(comp.TestReportGCPAttributes, platform.EchoSidecar)
 			s.OverrideMockMetadata(tc.mockMetadataOverride, 0)
 
-			defer s.TearDown()
+			defer s.TearDown(t)
 			if err := s.Setup(args); err != nil {
 				t.Fatalf("Test(%s): fail to setup test env, %v", tc.desc, err)
 			}

--- a/tests/integration_test/service_control_access_token_test.go
+++ b/tests/integration_test/service_control_access_token_test.go
@@ -43,7 +43,7 @@ func TestServiceControlAccessToken(t *testing.T) {
 			fmt.Sprintf("/v1/projects/-/serviceAccounts/%s:generateAccessToken", serviceAccount): `{"accessToken":  "access-token-from-iam", "expireTime": "2022-10-02T15:01:23.045123456Z"}`,
 		}, 0)
 
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/service_control_apikey_location_test.go
+++ b/tests/integration_test/service_control_apikey_location_test.go
@@ -36,7 +36,7 @@ func TestServiceControlAPIKeyDefaultLocation(t *testing.T) {
 		"--rollout_strategy=fixed", "--suppress_envoy_headers"}
 
 	s := env.NewTestEnv(comp.TestServiceControlAPIKeyDefaultLocation, platform.GrpcBookstoreSidecar)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -129,7 +129,7 @@ func TestServiceControlAPIKeyCustomLocation(t *testing.T) {
 			},
 		},
 	})
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/service_control_apikey_restriction_test.go
+++ b/tests/integration_test/service_control_apikey_restriction_test.go
@@ -48,7 +48,7 @@ func TestServiceControlAPIKeyRestriction(t *testing.T) {
 	}
 
 	s := env.NewTestEnv(comp.TestServiceControlAPIKeyRestriction, platform.EchoSidecar)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("failed to setup test env, %v", err)
 	}
@@ -144,7 +144,7 @@ func TestServiceControlAPIKeyIpRestriction(t *testing.T) {
 
 	s := env.NewTestEnv(comp.TestServiceControlAPIKeyIpRestriction, platform.EchoSidecar)
 
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("failed to setup test env, %v", err)
 	}

--- a/tests/integration_test/service_control_auth_fail_test.go
+++ b/tests/integration_test/service_control_auth_fail_test.go
@@ -53,7 +53,7 @@ func TestServiceControlJwtAuthFail(t *testing.T) {
 			},
 		},
 	})
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/service_control_basic_test.go
+++ b/tests/integration_test/service_control_basic_test.go
@@ -61,7 +61,7 @@ func TestServiceControlBasic(t *testing.T) {
 			},
 		})
 
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/service_control_cache_test.go
+++ b/tests/integration_test/service_control_cache_test.go
@@ -37,7 +37,7 @@ func TestServiceControlCache(t *testing.T) {
 		"--rollout_strategy=fixed", "--suppress_envoy_headers"}
 
 	s := env.NewTestEnv(comp.TestServiceControlCache, platform.EchoSidecar)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/service_control_check_fail_test.go
+++ b/tests/integration_test/service_control_check_fail_test.go
@@ -40,7 +40,7 @@ func TestServiceControlCheckError(t *testing.T) {
 		"--rollout_strategy=fixed", "--suppress_envoy_headers"}
 
 	s := env.NewTestEnv(comp.TestServiceControlCheckError, platform.EchoSidecar)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/service_control_check_network_fail_test.go
+++ b/tests/integration_test/service_control_check_network_fail_test.go
@@ -73,7 +73,7 @@ func TestServiceControlCheckNetworkFail(t *testing.T) {
 			s := env.NewTestEnv(tc.allocatedPort, platform.GrpcBookstoreSidecar)
 			s.ServiceControlServer.SetURL(tc.serviceControlURL)
 
-			defer s.TearDown()
+			defer s.TearDown(t)
 			if err := s.Setup(args); err != nil {
 				t.Fatalf("fail to setup test env, %v", err)
 			}
@@ -110,7 +110,7 @@ func TestServiceControlCheckTimeout(t *testing.T) {
 
 	s := env.NewTestEnv(comp.TestServiceControlCheckTimeout, platform.GrpcBookstoreSidecar)
 	s.ServiceControlServer.SetURL("http://wrong_service_control_server_name")
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -201,7 +201,7 @@ func TestServiceControlNetworkFailFlagForTimeout(t *testing.T) {
 				s.EnableScNetworkFailOpen()
 			}
 
-			defer s.TearDown()
+			defer s.TearDown(t)
 			if err := s.Setup(args); err != nil {
 				t.Fatalf("fail to setup test env, %v", err)
 			}
@@ -297,7 +297,7 @@ func TestServiceControlNetworkFailFlagForUnavailableCheckResponse(t *testing.T) 
 				s.EnableScNetworkFailOpen()
 			}
 
-			defer s.TearDown()
+			defer s.TearDown(t)
 			if err := s.Setup(args); err != nil {
 				t.Fatalf("fail to setup test env, %v", err)
 			}

--- a/tests/integration_test/service_control_check_server_fail_test.go
+++ b/tests/integration_test/service_control_check_server_fail_test.go
@@ -108,7 +108,7 @@ func TestServiceControlCheckServerFailFlag(t *testing.T) {
 				s.EnableScNetworkFailOpen()
 			}
 
-			defer s.TearDown()
+			defer s.TearDown(t)
 			if err := s.Setup(args); err != nil {
 				t.Fatalf("fail to setup test env, %v", err)
 			}

--- a/tests/integration_test/service_control_credential_id_test.go
+++ b/tests/integration_test/service_control_credential_id_test.go
@@ -60,7 +60,7 @@ func TestServiceControlCredentialId(t *testing.T) {
 		},
 	})
 
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/service_control_failed_request_report_test.go
+++ b/tests/integration_test/service_control_failed_request_report_test.go
@@ -36,7 +36,7 @@ func TestServiceControlFailedRequestReport(t *testing.T) {
 	args := []string{"--service_config_id=" + configId,
 		"--rollout_strategy=fixed", "--suppress_envoy_headers"}
 	s := env.NewTestEnv(comp.TestServiceControlFailedRequestReport, platform.GrpcBookstoreSidecar)
-	defer s.TearDown()
+	defer s.TearDown(t)
 
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)

--- a/tests/integration_test/service_control_http_method_test.go
+++ b/tests/integration_test/service_control_http_method_test.go
@@ -71,7 +71,7 @@ func TestServiceControlAllHTTPMethods(t *testing.T) {
 		},
 	})
 
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/service_control_http_path_test.go
+++ b/tests/integration_test/service_control_http_path_test.go
@@ -39,7 +39,7 @@ func TestServiceControlAllHTTPPath(t *testing.T) {
 	s := env.NewTestEnv(comp.TestServiceControlAllHTTPPath, platform.EchoSidecar)
 	s.EnableEchoServerRootPathHandler()
 
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/service_control_log_test.go
+++ b/tests/integration_test/service_control_log_test.go
@@ -51,7 +51,7 @@ func TestServiceControlLogHeaders(t *testing.T) {
 		},
 	})
 
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -171,7 +171,7 @@ func TestServiceControlLogJwtPayloads(t *testing.T) {
 		},
 	})
 
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/service_control_protocol_test.go
+++ b/tests/integration_test/service_control_protocol_test.go
@@ -45,7 +45,7 @@ func TestServiceControlProtocolWithGRPCBackend(t *testing.T) {
 
 	s := env.NewTestEnv(comp.TestServiceControlProtocolWithGRPCBackend, platform.GrpcBookstoreSidecar)
 
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -157,7 +157,7 @@ func TestServiceControlProtocolWithHTTPBackend(t *testing.T) {
 
 	s := env.NewTestEnv(comp.TestServiceControlProtocolWithHTTPBackend, platform.EchoSidecar)
 
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/service_control_quota_test.go
+++ b/tests/integration_test/service_control_quota_test.go
@@ -53,7 +53,7 @@ func TestServiceControlQuota(t *testing.T) {
 			},
 		},
 	})
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -178,7 +178,7 @@ func TestServiceControlQuotaUnavailable(t *testing.T) {
 		},
 	})
 	s.ServiceControlServer.OverrideQuotaHandler(&unavailableQuotaServiceHandler{m: s.ServiceControlServer})
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -246,7 +246,7 @@ func TestServiceControlQuotaExhausted(t *testing.T) {
 			},
 		},
 	})
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/service_control_report_network_fail_test.go
+++ b/tests/integration_test/service_control_report_network_fail_test.go
@@ -36,7 +36,7 @@ func TestServiceControlReportNetworkFail(t *testing.T) {
 		"--rollout_strategy=fixed", "--service_control_report_retries=0"}
 
 	s := env.NewTestEnv(comp.TestServiceControlReportNetworkFail, platform.GrpcBookstoreSidecar)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/service_control_response_code_test.go
+++ b/tests/integration_test/service_control_response_code_test.go
@@ -71,7 +71,7 @@ func TestServiceControlReportResponseCode(t *testing.T) {
 			},
 		})
 
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/service_control_retry_timeout_test.go
+++ b/tests/integration_test/service_control_retry_timeout_test.go
@@ -41,7 +41,7 @@ func TestServiceControlCheckRetry(t *testing.T) {
 		M: s.ServiceControlServer,
 	}
 	s.ServiceControlServer.OverrideCheckHandler(&handler)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -142,7 +142,7 @@ func TestServiceControlQuotaRetry(t *testing.T) {
 		M: s.ServiceControlServer,
 	}
 	s.ServiceControlServer.OverrideQuotaHandler(&handler)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -216,7 +216,7 @@ func TestServiceControlReportRetry(t *testing.T) {
 		M: s.ServiceControlServer,
 	}
 	s.ServiceControlServer.OverrideReportHandler(&handler)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/service_control_skip_test.go
+++ b/tests/integration_test/service_control_skip_test.go
@@ -44,7 +44,7 @@ func TestServiceControlSkipUsage(t *testing.T) {
 			},
 		},
 	)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/statistics_test.go
+++ b/tests/integration_test/statistics_test.go
@@ -38,7 +38,7 @@ func TestStatistics(t *testing.T) {
 
 	s := env.NewTestEnv(comp.TestStatistics, platform.EchoRemote)
 
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(utils.CommonArgs()); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -216,7 +216,7 @@ func TestStatisticsServiceControlCallStatus(t *testing.T) {
 					},
 				},
 			})
-			defer s.TearDown()
+			defer s.TearDown(t)
 			if err := s.Setup(args); err != nil {
 				t.Fatalf("fail to setup test env, %v", err)
 			}

--- a/tests/integration_test/transcoding_bindings_test.go
+++ b/tests/integration_test/transcoding_bindings_test.go
@@ -54,7 +54,7 @@ func TestTranscodingBindings(t *testing.T) {
 		Rules: []*confpb.AuthenticationRule{},
 	})
 
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -216,7 +216,7 @@ func TestTranscodingPrintOptions(t *testing.T) {
 				Rules: []*confpb.AuthenticationRule{},
 			})
 
-			defer s.TearDown()
+			defer s.TearDown(t)
 			if err := s.Setup(args); err != nil {
 				t.Fatalf("fail to setup test env, %v", err)
 			}
@@ -303,7 +303,7 @@ func TestTranscodingIgnoreParameters(t *testing.T) {
 				Rules: []*confpb.AuthenticationRule{},
 			})
 
-			defer s.TearDown()
+			defer s.TearDown(t)
 			if err := s.Setup(args); err != nil {
 				t.Fatalf("fail to setup test env, %v", err)
 			}

--- a/tests/integration_test/transcoding_errors_test.go
+++ b/tests/integration_test/transcoding_errors_test.go
@@ -50,7 +50,7 @@ func TestTranscodingServiceUnavailableError(t *testing.T) {
 
 	s := env.NewTestEnv(comp.TestTranscodingServiceUnavailableError, platform.GrpcBookstoreSidecar)
 
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}
@@ -87,7 +87,7 @@ func TestTranscodingErrors(t *testing.T) {
 		"--rollout_strategy=fixed"}
 
 	s := env.NewTestEnv(comp.TestTranscodingErrors, platform.GrpcBookstoreSidecar)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}

--- a/tests/integration_test/transport_security_test.go
+++ b/tests/integration_test/transport_security_test.go
@@ -60,7 +60,7 @@ func TestServiceManagementWithTLS(t *testing.T) {
 	for _, tc := range testData {
 		func() {
 			s := env.NewTestEnv(tc.port, platform.EchoSidecar)
-			defer s.TearDown()
+			defer s.TearDown(t)
 			serverCerts, err := comp.GenerateCert(tc.certPath, tc.keyPath)
 			if err != nil {
 				t.Fatalf("fial to generate cert: %v", err)
@@ -119,7 +119,7 @@ func TestServiceControlWithTLS(t *testing.T) {
 	for _, tc := range tests {
 		func() {
 			s := env.NewTestEnv(tc.port, platform.GrpcBookstoreSidecar)
-			defer s.TearDown()
+			defer s.TearDown(t)
 			serverCerts, err := comp.GenerateCert(tc.certPath, tc.keyPath)
 			if err != nil {
 				t.Fatalf("fail to create cert, %v", err)
@@ -148,7 +148,7 @@ func TestHttpsClients(t *testing.T) {
 	args = append(args, "--ssl_server_cert_path=../env/testdata/")
 
 	s := env.NewTestEnv(comp.TestHttpsClients, platform.EchoSidecar)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	s.AppendHttpRules([]*annotationspb.HttpRule{
 		{
 			Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Simpleget",
@@ -222,7 +222,7 @@ func TestHSTS(t *testing.T) {
 	args = append(args, "--enable_strict_transport_security")
 
 	s := env.NewTestEnv(comp.TestHttpsClients, platform.EchoSidecar)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	s.AppendHttpRules([]*annotationspb.HttpRule{
 		{
 			Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Simpleget",

--- a/tests/integration_test/transport_security_test.go
+++ b/tests/integration_test/transport_security_test.go
@@ -60,8 +60,11 @@ func TestServiceManagementWithTLS(t *testing.T) {
 	for _, tc := range testData {
 		func() {
 			s := env.NewTestEnv(tc.port, platform.EchoSidecar)
-			defer s.SkipHealthChecks()
+
+			// LIFO ordering. Disable health checks before teardown, we expect a failure.
 			defer s.TearDown(t)
+			defer s.SkipHealthChecks()
+
 			serverCerts, err := comp.GenerateCert(tc.certPath, tc.keyPath)
 			if err != nil {
 				t.Fatalf("fial to generate cert: %v", err)

--- a/tests/integration_test/transport_security_test.go
+++ b/tests/integration_test/transport_security_test.go
@@ -60,6 +60,7 @@ func TestServiceManagementWithTLS(t *testing.T) {
 	for _, tc := range testData {
 		func() {
 			s := env.NewTestEnv(tc.port, platform.EchoSidecar)
+			defer s.SkipHealthChecks()
 			defer s.TearDown(t)
 			serverCerts, err := comp.GenerateCert(tc.certPath, tc.keyPath)
 			if err != nil {

--- a/tests/integration_test/websocket_test.go
+++ b/tests/integration_test/websocket_test.go
@@ -32,7 +32,7 @@ import (
 func TestWebsocket(t *testing.T) {
 	t.Parallel()
 	s := env.NewTestEnv(comp.TestWebsocket, platform.EchoSidecar)
-	defer s.TearDown()
+	defer s.TearDown(t)
 	if err := s.Setup(utils.CommonArgs()); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}


### PR DESCRIPTION
- Pass down `testing.T` to `TearDown`, allowing us to `Errorf` if needed.
- Modify all calls to `TearDown` to pass `testing.T`.

This will unblock https://github.com/GoogleCloudPlatform/esp-v2/pull/167.

Signed-off-by: Teju Nareddy <nareddyt@google.com>