### PR TITLE
[Refactor] Remove cyclic dependency in integration tests

### DIFF
--- a/tests/env/components/mock_service_control_test.go
+++ b/tests/env/components/mock_service_control_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
 	"github.com/golang/protobuf/proto"
 
 	scpb "google.golang.org/genproto/googleapis/api/servicecontrol/v1"
@@ -54,7 +55,7 @@ func TestMockServiceControl(t *testing.T) {
 	if len(rr) != 1 {
 		t.Errorf("Wrong number: %d", len(rr))
 	}
-	if rr[0].ReqType != CHECK_REQUEST {
+	if rr[0].ReqType != utils.CheckRequest {
 		t.Errorf("Wrong type: %v", rr[0].ReqType)
 	}
 	req1 := &scpb.CheckRequest{}

--- a/tests/integration_test/cors_integration_test.go
+++ b/tests/integration_test/cors_integration_test.go
@@ -604,14 +604,14 @@ func TestServiceControlRequestWithAllowCors(t *testing.T) {
 				reqBody := scRequests[i].ReqBody
 				switch wantScRequest.(type) {
 				case *utils.ExpectedCheck:
-					if scRequests[i].ReqType != comp.CHECK_REQUEST {
+					if scRequests[i].ReqType != utils.CheckRequest {
 						t.Errorf("Test Desc(%s): service control request %v: should be Check", tc.desc, i)
 					}
 					if err := utils.VerifyCheck(reqBody, wantScRequest.(*utils.ExpectedCheck)); err != nil {
 						t.Error(err)
 					}
 				case *utils.ExpectedReport:
-					if scRequests[i].ReqType != comp.REPORT_REQUEST {
+					if scRequests[i].ReqType != utils.ReportRequest {
 						t.Errorf("Test Desc(%s): service control request %v: should be Report", tc.desc, i)
 					}
 					if err := utils.VerifyReport(reqBody, wantScRequest.(*utils.ExpectedReport)); err != nil {
@@ -751,14 +751,14 @@ func TestServiceControlRequestWithoutAllowCors(t *testing.T) {
 				reqBody := scRequests[i].ReqBody
 				switch wantScRequest.(type) {
 				case *utils.ExpectedCheck:
-					if scRequests[i].ReqType != comp.CHECK_REQUEST {
+					if scRequests[i].ReqType != utils.CheckRequest {
 						t.Errorf("Test Desc(%s): service control request %v: should be Check", tc.desc, i)
 					}
 					if err := utils.VerifyCheck(reqBody, wantScRequest.(*utils.ExpectedCheck)); err != nil {
 						t.Error(err)
 					}
 				case *utils.ExpectedReport:
-					if scRequests[i].ReqType != comp.REPORT_REQUEST {
+					if scRequests[i].ReqType != utils.ReportRequest {
 						t.Errorf("Test Desc(%s): service control request %v: should be Report", tc.desc, i)
 					}
 					if err := utils.VerifyReport(reqBody, wantScRequest.(*utils.ExpectedReport)); err != nil {

--- a/tests/integration_test/grpc_streaming_test.go
+++ b/tests/integration_test/grpc_streaming_test.go
@@ -181,13 +181,13 @@ plans {
 	}
 
 	//The first service control call should be check.
-	if len(scRequests) == 0 || scRequests[0].ReqType != comp.CHECK_REQUEST {
+	if len(scRequests) == 0 || scRequests[0].ReqType != utils.CheckRequest {
 		t.Errorf("First ScRequest should be check")
 	}
 
 	// All the rest service control call should be report.
 	for i := 1; i < len(scRequests); i++ {
-		if scRequests[i].ReqType != comp.REPORT_REQUEST {
+		if scRequests[i].ReqType != utils.ReportRequest {
 			t.Errorf("Except the first ScRequest, all the rest should be report")
 		}
 	}

--- a/tests/integration_test/opencensus_tracing_test.go
+++ b/tests/integration_test/opencensus_tracing_test.go
@@ -83,9 +83,7 @@ func TestServiceControlCheckTracesWithRetry(t *testing.T) {
 	}
 	s := env.NewTestEnv(comp.TestServiceControlCheckTracesWithRetry, platform.GrpcBookstoreSidecar)
 	s.SetupFakeTraceServer()
-	handler := utils.RetryServiceHandler{
-		M: s.ServiceControlServer,
-	}
+	handler := utils.RetryServiceHandler{}
 	s.ServiceControlServer.OverrideCheckHandler(&handler)
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {

--- a/tests/integration_test/report_gcp_attributes_test.go
+++ b/tests/integration_test/report_gcp_attributes_test.go
@@ -135,7 +135,7 @@ func TestReportGCPAttributes(t *testing.T) {
 				t.Fatalf("Test(%s): GetRequests returns error: %v", tc.desc, err)
 			}
 
-			if scRequests[0].ReqType != comp.REPORT_REQUEST {
+			if scRequests[0].ReqType != utils.ReportRequest {
 				t.Fatalf("Test(%s): service control request: should be Report", tc.desc)
 			}
 

--- a/tests/integration_test/service_control_protocol_test.go
+++ b/tests/integration_test/service_control_protocol_test.go
@@ -118,7 +118,7 @@ func TestServiceControlProtocolWithGRPCBackend(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if scRequests[tc.numRequestsToSkip].ReqType != comp.REPORT_REQUEST {
+		if scRequests[tc.numRequestsToSkip].ReqType != utils.ReportRequest {
 			t.Fatalf("Test (%s): Expected but did not get a ReportRequest", tc.desc)
 		}
 
@@ -181,7 +181,7 @@ func TestServiceControlProtocolWithHTTPBackend(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if scRequests[0].ReqType != comp.REPORT_REQUEST {
+	if scRequests[0].ReqType != utils.ReportRequest {
 		t.Fatalf("Test (%s): Expected but did not get a ReportRequest", desc)
 	}
 

--- a/tests/integration_test/service_control_quota_test.go
+++ b/tests/integration_test/service_control_quota_test.go
@@ -146,8 +146,8 @@ type unavailableQuotaServiceHandler struct {
 }
 
 func (h *unavailableQuotaServiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	req := &comp.ServiceRequest{
-		ReqType: comp.QUOTA_REQUEST,
+	req := &utils.ServiceRequest{
+		ReqType: utils.QuotaRequest,
 	}
 	req.ReqBody, _ = ioutil.ReadAll(r.Body)
 	h.m.CacheRequest(req)

--- a/tests/integration_test/service_control_response_code_test.go
+++ b/tests/integration_test/service_control_response_code_test.go
@@ -193,14 +193,14 @@ func TestServiceControlReportResponseCode(t *testing.T) {
 			reqBody := scRequests[i].ReqBody
 			switch wantScRequest.(type) {
 			case *utils.ExpectedCheck:
-				if scRequests[i].ReqType != comp.CHECK_REQUEST {
+				if scRequests[i].ReqType != utils.CheckRequest {
 					t.Errorf("Test desc (%v) service control request %v: should be Check", tc.desc, i)
 				}
 				if err := utils.VerifyCheck(reqBody, wantScRequest.(*utils.ExpectedCheck)); err != nil {
 					t.Error(err)
 				}
 			case *utils.ExpectedReport:
-				if scRequests[i].ReqType != comp.REPORT_REQUEST {
+				if scRequests[i].ReqType != utils.ReportRequest {
 					t.Errorf("Test desc (%v) service control request %v: should be Report", tc.desc, i)
 				}
 				if err := utils.VerifyReport(reqBody, wantScRequest.(*utils.ExpectedReport)); err != nil {

--- a/tests/integration_test/service_control_retry_timeout_test.go
+++ b/tests/integration_test/service_control_retry_timeout_test.go
@@ -37,9 +37,7 @@ func TestServiceControlCheckRetry(t *testing.T) {
 	args := []string{"--service_config_id=" + configID,
 		"--rollout_strategy=fixed", "--service_control_check_retries=2", "--service_control_check_timeout_ms=100"}
 	s := env.NewTestEnv(comp.TestServiceControlCheckRetry, platform.GrpcBookstoreSidecar)
-	handler := utils.RetryServiceHandler{
-		M: s.ServiceControlServer,
-	}
+	handler := utils.RetryServiceHandler{}
 	s.ServiceControlServer.OverrideCheckHandler(&handler)
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
@@ -138,9 +136,7 @@ func TestServiceControlQuotaRetry(t *testing.T) {
 			},
 		},
 	})
-	handler := utils.RetryServiceHandler{
-		M: s.ServiceControlServer,
-	}
+	handler := utils.RetryServiceHandler{}
 	s.ServiceControlServer.OverrideQuotaHandler(&handler)
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
@@ -212,9 +208,7 @@ func TestServiceControlReportRetry(t *testing.T) {
 	}
 	s := env.NewTestEnv(comp.TestServiceControlReportRetry, platform.GrpcBookstoreSidecar)
 
-	handler := utils.RetryServiceHandler{
-		M: s.ServiceControlServer,
-	}
+	handler := utils.RetryServiceHandler{}
 	s.ServiceControlServer.OverrideReportHandler(&handler)
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {

--- a/tests/utils/retry.go
+++ b/tests/utils/retry.go
@@ -17,12 +17,9 @@ package utils
 import (
 	"net/http"
 	"time"
-
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 )
 
 type RetryServiceHandler struct {
-	M             *comp.MockServiceCtrl
 	RequestCount  int32
 	SleepTimes    int32
 	SleepLengthMs int32


### PR DESCRIPTION
`tests/utils` should not depend on `tests/env/components`.
- Move some type aliases and const from components to utils.
- Remove reference to `MockServiceCtrl` in a handler. It's not used.

This will unblock #167:
```
import cycle not allowed
package github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/echo
	imports github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/echo/client
	imports github.com/GoogleCloudPlatform/esp-v2/tests/utils
	imports github.com/GoogleCloudPlatform/esp-v2/tests/env/components
	imports github.com/GoogleCloudPlatform/esp-v2/tests/utils
```

Signed-off-by: Teju Nareddy <nareddyt@google.com>