### PR TITLE
Fuzz access logger and fix fuzz failures

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -39,9 +39,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # 3) Check if envoy_build_config/extensions_build_config.bzl is up-to-date.
 # Try to match it with the one in source/extensions and comment out unneeded extensions.
 
-ENVOY_SHA1 = "c8f330c1f99ee5d89048d52ac98faab2539d5a52"  # 2020-05-26
+ENVOY_SHA1 = "97064d19ca23e81d89ebcc298318be420c4379db"  # 2020-06-01
 
-ENVOY_SHA256 = "65480d91dc8f432a3b4b42d63d542b09d9803d4c76ea0accfd08f3a5f8b313d7"
+ENVOY_SHA256 = "447b9f46f3d5bff7d363f703a3bc094356269dc3be927bb6b0d833ada55655de"
 
 http_archive(
     name = "envoy",

--- a/src/envoy/http/backend_routing/filter_fuzz_test.cc
+++ b/src/envoy/http/backend_routing/filter_fuzz_test.cc
@@ -68,6 +68,7 @@ DEFINE_PROTO_FUZZER(
   static Envoy::Extensions::HttpFilters::UberFilterFuzzer fuzzer;
   fuzzer.runData(static_cast<Envoy::Http::StreamDecoderFilter*>(&filter),
                  input.downstream_request());
+  fuzzer.reset();
 }
 
 }  // namespace fuzz

--- a/src/envoy/http/path_matcher/filter_fuzz_test.cc
+++ b/src/envoy/http/path_matcher/filter_fuzz_test.cc
@@ -58,6 +58,7 @@ DEFINE_PROTO_FUZZER(
   static Envoy::Extensions::HttpFilters::UberFilterFuzzer fuzzer;
   fuzzer.runData(static_cast<Envoy::Http::StreamDecoderFilter*>(&filter),
                  input.downstream_request());
+  fuzzer.reset();
 
   // Ensure the query param filter state is valid.
   absl::string_view query_params = utils::getStringFilterState(

--- a/src/envoy/http/service_control/filter_fuzz_test.cc
+++ b/src/envoy/http/service_control/filter_fuzz_test.cc
@@ -35,15 +35,15 @@ namespace fuzz {
 namespace Logger = Envoy::Logger;
 
 void doTest(
-    ServiceControlFilter& filter, Envoy::TestStreamInfo&,
+    ServiceControlFilter& filter, Envoy::TestStreamInfo& stream_info,
     const espv2::tests::fuzz::protos::ServiceControlFilterInput& input) {
   static Envoy::Extensions::HttpFilters::UberFilterFuzzer fuzzer;
   fuzzer.runData(static_cast<Envoy::Http::StreamDecoderFilter*>(&filter),
                  input.downstream_request());
   fuzzer.runData(static_cast<Envoy::Http::StreamEncoderFilter*>(&filter),
                  input.upstream_response());
-
-  // TODO(nareddyt): Fuzz access log once #11288 is in upstream envoy.
+  fuzzer.accessLog(static_cast<Envoy::AccessLog::Instance*>(&filter), stream_info);
+  fuzzer.reset();
 }
 
 DEFINE_PROTO_FUZZER(


### PR DESCRIPTION
Minor envoy update to pull in some fuzz test changes from upstream.
- Fuzz filter access logger (SC Report).
- Reset logged headers between each iteration of the fuzzer. `UberFilterFuzzer` is in static storage duration for performance (setting up expectations in constructor is expensive). Because the destructor is never called, call the `reset` method on each iteration.

Signed-off-by: Teju Nareddy <nareddyt@google.com>