### PR TITLE
b/157791398,b/157743299: migrate all listeners to api/v3

### DIFF
--- a/examples/auth/envoy_config.json
+++ b/examples/auth/envoy_config.json
@@ -177,7 +177,7 @@
                     {
                       "name": "envoy.filters.http.jwt_authn",
                       "typedConfig": {
-                        "@type": "type.googleapis.com/envoy.config.filter.http.jwt_authn.v2alpha.JwtAuthentication",
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication",
                         "filterStateRules": {
                           "name": "envoy.filters.http.path_matcher.operation",
                           "requires": {
@@ -302,7 +302,7 @@
                     {
                       "name": "envoy.filters.http.router",
                       "typedConfig": {
-                        "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router",
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
                         "suppressEnvoyHeaders": true
                       }
                     }

--- a/examples/dynamic_routing/envoy_config.json
+++ b/examples/dynamic_routing/envoy_config.json
@@ -279,7 +279,7 @@
                     {
                       "name": "envoy.filters.http.router",
                       "typedConfig": {
-                        "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router",
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
                         "suppressEnvoyHeaders": true
                       }
                     }

--- a/examples/grpc_dynamic_routing/envoy_config.json
+++ b/examples/grpc_dynamic_routing/envoy_config.json
@@ -1062,7 +1062,7 @@
                       "typedConfig": {
                         "@type": "type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
                         "emitFilterState": true,
-                        "statsForAllMethods": true
+                        "statsForAllMethods": false
                       }
                     },
                     {

--- a/examples/grpc_dynamic_routing/envoy_config.json
+++ b/examples/grpc_dynamic_routing/envoy_config.json
@@ -417,7 +417,7 @@
                     {
                       "name": "envoy.filters.http.jwt_authn",
                       "typedConfig": {
-                        "@type": "type.googleapis.com/envoy.config.filter.http.jwt_authn.v2alpha.JwtAuthentication",
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication",
                         "filterStateRules": {
                           "name": "envoy.filters.http.path_matcher.operation",
                           "requires": {
@@ -1039,7 +1039,7 @@
                     {
                       "name": "envoy.filters.http.grpc_json_transcoder",
                       "typedConfig": {
-                        "@type": "type.googleapis.com/envoy.config.filter.http.transcoder.v2.GrpcJsonTranscoder",
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder",
                         "autoMapping": true,
                         "convertGrpcStatus": true,
                         "ignoredQueryParameters": [
@@ -1060,8 +1060,9 @@
                     {
                       "name": "envoy.filters.http.grpc_stats",
                       "typedConfig": {
-                        "@type": "type.googleapis.com/envoy.config.filter.http.grpc_stats.v2alpha.FilterConfig",
-                        "emitFilterState": true
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
+                        "emitFilterState": true,
+                        "statsForAllMethods": true
                       }
                     },
                     {
@@ -1096,7 +1097,7 @@
                     {
                       "name": "envoy.filters.http.router",
                       "typedConfig": {
-                        "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router",
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
                         "suppressEnvoyHeaders": true
                       }
                     }

--- a/examples/service_control/envoy_config.json
+++ b/examples/service_control/envoy_config.json
@@ -742,7 +742,7 @@
                     {
                       "name": "envoy.filters.http.router",
                       "typedConfig": {
-                        "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router",
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
                         "suppressEnvoyHeaders": true
                       }
                     }

--- a/examples/testdata/path_matcher/envoy_config.json
+++ b/examples/testdata/path_matcher/envoy_config.json
@@ -131,7 +131,7 @@
                     {
                       "name": "envoy.filters.http.router",
                       "typedConfig": {
-                        "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router",
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
                         "suppressEnvoyHeaders": true
                       }
                     }

--- a/src/go/configgenerator/listener_generator.go
+++ b/src/go/configgenerator/listener_generator.go
@@ -319,10 +319,6 @@ func makeGrpcStatsFilter() *hcmpb.HttpFilter {
 		EmitFilterState: true,
 		PerMethodStatSpecifier: &gspb.FilterConfig_StatsForAllMethods{
 			StatsForAllMethods: &wrappers.BoolValue{
-				// Right now, StatsForAllMethods is set to true by default for backward
-				// compatibility and will be flipped to false latter. In terms of
-				// security, set to false here specifically. Details are in
-				// https://github.com/envoyproxy/envoy/blob/3b52fc36373272902d9817f0db97dd2fccc40784/api/envoy/extensions/filters/http/grpc_stats/v3/config.proto#L55
 				Value: false,
 			},
 		},

--- a/src/go/configgenerator/listener_generator.go
+++ b/src/go/configgenerator/listener_generator.go
@@ -23,6 +23,7 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/wrappers"
 
 	sc "github.com/GoogleCloudPlatform/esp-v2/src/go/configinfo"
 	bapb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/http/backend_auth"

--- a/src/go/configgenerator/listener_generator.go
+++ b/src/go/configgenerator/listener_generator.go
@@ -319,15 +319,21 @@ func makeGrpcStatsFilter() *hcmpb.HttpFilter {
 		EmitFilterState: true,
 		PerMethodStatSpecifier: &gspb.FilterConfig_StatsForAllMethods{
 			StatsForAllMethods: &wrappers.BoolValue{
-				Value: true,
+				// Right now, StatsForAllMethods is set to true by default for backward
+				// compatibility and will be flipped to false latter. In terms of
+				// security, set to false here specifically. Details are in
+				// https://github.com/envoyproxy/envoy/blob/3b52fc36373272902d9817f0db97dd2fccc40784/api/envoy/extensions/filters/http/grpc_stats/v3/config.proto#L55
+				Value: false,
 			},
 		},
 	}
-	cfg_any, _ := ptypes.MarshalAny(cfg)
+	cfgAny, _ := ptypes.MarshalAny(cfg)
 
 	return &hcmpb.HttpFilter{
-		Name:       util.GrpcStatsFilterName,
-		ConfigType: &hcmpb.HttpFilter_TypedConfig{cfg_any},
+		Name: util.GrpcStatsFilterName,
+		ConfigType: &hcmpb.HttpFilter_TypedConfig{
+			TypedConfig: cfgAny,
+		},
 	}
 }
 

--- a/src/go/configgenerator/listener_generator.go
+++ b/src/go/configgenerator/listener_generator.go
@@ -30,18 +30,19 @@ import (
 	commonpb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/http/common"
 	pmpb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/http/path_matcher"
 	scpb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/http/service_control"
-	corepbv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+
 	acpb "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
 	corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	gspb "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/grpc_stats/v2alpha"
-	jwtpb "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/jwt_authn/v2alpha"
-	routerpb "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/router/v2"
-	transcoderpb "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/transcoder/v2"
 	listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	facpb "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/file/v3"
+	transcoderpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/grpc_json_transcoder/v3"
+	gspb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/grpc_stats/v3"
 	hcpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/health_check/v3"
+	jwtpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/jwt_authn/v3"
+	routerpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
 	hcmpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+
 	anypb "github.com/golang/protobuf/ptypes/any"
 	durationpb "github.com/golang/protobuf/ptypes/duration"
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
@@ -315,6 +316,11 @@ func makePathMatcherFilter(serviceInfo *sc.ServiceInfo) *hcmpb.HttpFilter {
 func makeGrpcStatsFilter() *hcmpb.HttpFilter {
 	cfg := &gspb.FilterConfig{
 		EmitFilterState: true,
+		PerMethodStatSpecifier: &gspb.FilterConfig_StatsForAllMethods{
+			StatsForAllMethods: &wrappers.BoolValue{
+				Value: true,
+			},
+		},
 	}
 	cfg_any, _ := ptypes.MarshalAny(cfg)
 
@@ -384,9 +390,9 @@ func makeJwtAuthnFilter(serviceInfo *sc.ServiceInfo) *hcmpb.HttpFilter {
 			Issuer: provider.GetIssuer(),
 			JwksSourceSpecifier: &jwtpb.JwtProvider_RemoteJwks{
 				RemoteJwks: &jwtpb.RemoteJwks{
-					HttpUri: &corepbv2.HttpUri{
+					HttpUri: &corepb.HttpUri{
 						Uri: provider.GetJwksUri(),
-						HttpUpstreamType: &corepbv2.HttpUri_Cluster{
+						HttpUpstreamType: &corepb.HttpUri_Cluster{
 							Cluster: clusterName,
 						},
 						Timeout: ptypes.DurationProto(serviceInfo.Options.HttpRequestTimeout),

--- a/src/go/configgenerator/listener_generator_test.go
+++ b/src/go/configgenerator/listener_generator_test.go
@@ -87,7 +87,7 @@ func TestTranscoderFilter(t *testing.T) {
 {
    "name":"envoy.filters.http.grpc_json_transcoder",
    "typedConfig":{
-      "@type":"type.googleapis.com/envoy.config.filter.http.transcoder.v2.GrpcJsonTranscoder",
+      "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder",
       "autoMapping":true,
       "convertGrpcStatus":true,
       "ignoredQueryParameters":[
@@ -162,7 +162,7 @@ func TestTranscoderFilter(t *testing.T) {
 {
    "name":"envoy.filters.http.grpc_json_transcoder",
    "typedConfig":{
-      "@type":"type.googleapis.com/envoy.config.filter.http.transcoder.v2.GrpcJsonTranscoder",
+      "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder",
       "autoMapping":true,
       "convertGrpcStatus":true,
       "ignoredQueryParameters":[
@@ -206,7 +206,7 @@ func TestTranscoderFilter(t *testing.T) {
 {
    "name":"envoy.filters.http.grpc_json_transcoder",
    "typedConfig":{
-      "@type":"type.googleapis.com/envoy.config.filter.http.transcoder.v2.GrpcJsonTranscoder",
+      "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder",
       "autoMapping":true,
       "convertGrpcStatus":true,
       "ignoreUnknownQueryParameters":true,
@@ -287,7 +287,7 @@ func TestJwtAuthnFilter(t *testing.T) {
 			wantJwtAuthnFilter: `{
     "name": "envoy.filters.http.jwt_authn",
     "typedConfig": {
-        "@type": "type.googleapis.com/envoy.config.filter.http.jwt_authn.v2alpha.JwtAuthentication",
+        "@type": "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication",
         "filterStateRules": {
             "name": "envoy.filters.http.path_matcher.operation"
         },
@@ -364,7 +364,7 @@ func TestJwtAuthnFilter(t *testing.T) {
 			wantJwtAuthnFilter: `{
     "name": "envoy.filters.http.jwt_authn",
     "typedConfig": {
-        "@type": "type.googleapis.com/envoy.config.filter.http.jwt_authn.v2alpha.JwtAuthentication",
+        "@type": "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication",
         "filterStateRules": {
             "name": "envoy.filters.http.path_matcher.operation"
         },
@@ -1456,7 +1456,7 @@ func TestMakeListeners(t *testing.T) {
               {
                 "name": "envoy.filters.http.router",
                 "typedConfig": {
-                  "@type": "type.googleapis.com/envoy.config.filter.http.router.v2.Router",
+                  "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
                   "startChildSpan": true,
                   "suppressEnvoyHeaders": true
                 }

--- a/src/go/configmanager/config_manager_test.go
+++ b/src/go/configmanager/config_manager_test.go
@@ -155,7 +155,7 @@ func TestFetchListeners(t *testing.T) {
                         "typedConfig":{
                            "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
                            "emitFilterState":true,
-                           "statsForAllMethods":true
+                           "statsForAllMethods":false
                         }
                      },
                      {
@@ -336,7 +336,7 @@ func TestFetchListeners(t *testing.T) {
                         "typedConfig":{
                            "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
                            "emitFilterState":true,
-                           "statsForAllMethods":true
+                           "statsForAllMethods":false
                         }
                      },
                      {
@@ -550,7 +550,7 @@ func TestFetchListeners(t *testing.T) {
                         "typedConfig":{
                            "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
                            "emitFilterState":true,
-                           "statsForAllMethods":true
+                           "statsForAllMethods":false
                         }
                      },
                      {
@@ -801,7 +801,7 @@ func TestFetchListeners(t *testing.T) {
                         "typedConfig":{
                            "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
                            "emitFilterState":true,
-                           "statsForAllMethods":true
+                           "statsForAllMethods":false
                         }
                      },
                      {
@@ -1026,7 +1026,7 @@ func TestFetchListeners(t *testing.T) {
                         "typedConfig":{
                            "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
                            "emitFilterState":true,
-                           "statsForAllMethods":true
+                           "statsForAllMethods":false
                         }
                      },
                      {

--- a/src/go/configmanager/config_manager_test.go
+++ b/src/go/configmanager/config_manager_test.go
@@ -133,7 +133,7 @@ func TestFetchListeners(t *testing.T) {
                      {
                         "name":"envoy.filters.http.grpc_json_transcoder",
                         "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.config.filter.http.transcoder.v2.GrpcJsonTranscoder",
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder",
                            "autoMapping":true,
                            "convertGrpcStatus":true,
                            "ignoredQueryParameters":[
@@ -153,14 +153,15 @@ func TestFetchListeners(t *testing.T) {
                      {
                         "name":"envoy.filters.http.grpc_stats",
                         "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.config.filter.http.grpc_stats.v2alpha.FilterConfig",
-                           "emitFilterState":true
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
+                           "emitFilterState":true,
+                           "statsForAllMethods":true
                         }
                      },
                      {
                         "name":"envoy.filters.http.router",
                         "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.config.filter.http.router.v2.Router",
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
                        		 "suppressEnvoyHeaders": true
                         }
                      }
@@ -279,7 +280,7 @@ func TestFetchListeners(t *testing.T) {
                      {
                         "name":"envoy.filters.http.jwt_authn",
                         "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.config.filter.http.jwt_authn.v2alpha.JwtAuthentication",
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication",
                            "filterStateRules":{
                               "name":"envoy.filters.http.path_matcher.operation",
                               "requires":{
@@ -333,14 +334,15 @@ func TestFetchListeners(t *testing.T) {
                      {
                         "name":"envoy.filters.http.grpc_stats",
                         "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.config.filter.http.grpc_stats.v2alpha.FilterConfig",
-                           "emitFilterState":true
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
+                           "emitFilterState":true,
+                           "statsForAllMethods":true
                         }
                      },
                      {
                         "name":"envoy.filters.http.router",
                         "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.config.filter.http.router.v2.Router",
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
                        		 "suppressEnvoyHeaders": true
                         }
                      }
@@ -495,7 +497,7 @@ func TestFetchListeners(t *testing.T) {
                      {
                         "name":"envoy.filters.http.jwt_authn",
                         "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.config.filter.http.jwt_authn.v2alpha.JwtAuthentication",
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication",
                            "filterStateRules":{
                               "name":"envoy.filters.http.path_matcher.operation",
                               "requires":{
@@ -546,14 +548,15 @@ func TestFetchListeners(t *testing.T) {
                      {
                         "name":"envoy.filters.http.grpc_stats",
                         "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.config.filter.http.grpc_stats.v2alpha.FilterConfig",
-                           "emitFilterState":true
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
+                           "emitFilterState":true,
+                           "statsForAllMethods":true
                         }
                      },
                      {
                         "name":"envoy.filters.http.router",
                         "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.config.filter.http.router.v2.Router",
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
                        		 "suppressEnvoyHeaders": true
                         }
                      }
@@ -710,7 +713,7 @@ func TestFetchListeners(t *testing.T) {
                      {
                         "name":"envoy.filters.http.jwt_authn",
                         "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.config.filter.http.jwt_authn.v2alpha.JwtAuthentication",
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication",
                            "filterStateRules":{
                               "name":"envoy.filters.http.path_matcher.operation",
                               "requires":{
@@ -796,14 +799,15 @@ func TestFetchListeners(t *testing.T) {
                      {
                         "name":"envoy.filters.http.grpc_stats",
                         "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.config.filter.http.grpc_stats.v2alpha.FilterConfig",
-                           "emitFilterState":true
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
+                           "emitFilterState":true,
+                           "statsForAllMethods":true
                         }
                      },
                      {
                         "name":"envoy.filters.http.router",
                         "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.config.filter.http.router.v2.Router",
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
                        		 "suppressEnvoyHeaders": true
                         }
                      }
@@ -1020,14 +1024,15 @@ func TestFetchListeners(t *testing.T) {
                      {
                         "name":"envoy.filters.http.grpc_stats",
                         "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.config.filter.http.grpc_stats.v2alpha.FilterConfig",
-                           "emitFilterState":true
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
+                           "emitFilterState":true,
+                           "statsForAllMethods":true
                         }
                      },
                      {
                         "name":"envoy.filters.http.router",
                         "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.config.filter.http.router.v2.Router",
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
                        		 "suppressEnvoyHeaders": true
                         }
                      }
@@ -1165,7 +1170,7 @@ func TestFetchListeners(t *testing.T) {
                      {
                         "name":"envoy.filters.http.jwt_authn",
                         "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.config.filter.http.jwt_authn.v2alpha.JwtAuthentication",
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication",
                            "filterStateRules":{
                               "name":"envoy.filters.http.path_matcher.operation",
                               "requires":{
@@ -1216,7 +1221,7 @@ func TestFetchListeners(t *testing.T) {
                      {
                         "name":"envoy.filters.http.router",
                         "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.config.filter.http.router.v2.Router",
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
                        		 "suppressEnvoyHeaders": true
                         }
                      }
@@ -1382,7 +1387,7 @@ func TestFetchListeners(t *testing.T) {
                      {
                         "name":"envoy.filters.http.router",
                         "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.config.filter.http.router.v2.Router",
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
                            "startChildSpan":true
                         }
                      }

--- a/src/go/configmanager/testdata/fake_data_for_dynamic_routing.go
+++ b/src/go/configmanager/testdata/fake_data_for_dynamic_routing.go
@@ -362,7 +362,7 @@ var (
                      {
                         "name":"envoy.filters.http.router",
                         "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.config.filter.http.router.v2.Router",
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
                            "suppressEnvoyHeaders":true
                         }
                      }

--- a/src/go/util/marshal.go
+++ b/src/go/util/marshal.go
@@ -25,13 +25,11 @@ import (
 	drpb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/http/backend_routing"
 	pmpb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/http/path_matcher"
 	scpb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/http/service_control"
-	authpb "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
-	filepb "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v2"
-	gspb "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/grpc_stats/v2alpha"
-	jwtpb "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/jwt_authn/v2alpha"
-	routerpb "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/router/v2"
-	transcoderpb "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/transcoder/v2"
-	hcmpbv2 "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+
+	transcoderpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/grpc_json_transcoder/v3"
+	gspb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/grpc_stats/v3"
+	jwtpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/jwt_authn/v3"
+	routerpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
 	hcmpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	tlspb "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 
@@ -75,14 +73,12 @@ var Resolver = FuncResolver(func(url string) (proto.Message, error) {
 		return new(wrapperspb.UInt32Value), nil
 	case "type.googleapis.com/google.api.Service":
 		return new(confpb.Service), nil
-	case "type.googleapis.com/envoy.config.filter.http.grpc_stats.v2alpha.FilterConfig":
+	case "type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig":
 		return new(gspb.FilterConfig), nil
-	case "type.googleapis.com/envoy.config.filter.http.transcoder.v2.GrpcJsonTranscoder":
+	case "type.googleapis.com/envoy.extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder":
 		return new(transcoderpb.GrpcJsonTranscoder), nil
-	case "type.googleapis.com/envoy.config.filter.http.jwt_authn.v2alpha.JwtAuthentication":
+	case "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication":
 		return new(jwtpb.JwtAuthentication), nil
-	case "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager":
-		return new(hcmpbv2.HttpConnectionManager), nil
 	case "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager":
 		return new(hcmpb.HttpConnectionManager), nil
 	case "type.googleapis.com/google.api.envoy.http.path_matcher.FilterConfig":
@@ -93,16 +89,10 @@ var Resolver = FuncResolver(func(url string) (proto.Message, error) {
 		return new(bapb.FilterConfig), nil
 	case "type.googleapis.com/google.api.envoy.http.backend_routing.FilterConfig":
 		return new(drpb.FilterConfig), nil
-	case "type.googleapis.com/envoy.config.filter.http.router.v2.Router":
+	case "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router":
 		return new(routerpb.Router), nil
 	case "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext":
 		return new(tlspb.UpstreamTlsContext), nil
-	case "type.googleapis.com/envoy.api.v2.auth.UpstreamTlsContext":
-		return new(authpb.UpstreamTlsContext), nil
-	case "type.googleapis.com/envoy.api.v2.auth.DownstreamTlsContext":
-		return new(authpb.DownstreamTlsContext), nil
-	case "type.googleapis.com/envoy.config.accesslog.v2.FileAccessLog":
-		return new(filepb.FileAccessLog), nil
 	default:
 		return nil, fmt.Errorf("unexpected protobuf.Any with url: %s", url)
 	}


### PR DESCRIPTION
- migrate all listeners config to api/v3 and after that all api/v2 are replaced
- make `grpc_stats` stats for all methods, for which grpc stats has been tested locally