### PR TITLE
Cleanup / validation / tests for Backend Routing

### DIFF
--- a/api/envoy/http/backend_auth/config.proto
+++ b/api/envoy/http/backend_auth/config.proto
@@ -24,9 +24,13 @@ message BackendAuthRule {
   string operation = 1 [(validate.rules).string.min_bytes = 1];
 
   // Audience used to create the JWT token sent to the backend.
-  // If empty, then no JWT token will be created.
+  // Must have a value, otherwise JWT is not valid.
   // https://cloud.google.com/endpoints/docs/openapi/openapi-extensions#jwt_audience_disable_auth
-  string jwt_audience = 2 [(validate.rules).string.min_bytes = 1];
+  string jwt_audience = 2 [(validate.rules).string = {
+    min_bytes: 1,
+    well_known_regex: HTTP_HEADER_VALUE,
+    strict: false
+  }];
 }
 
 message FilterConfig {
@@ -34,6 +38,8 @@ message FilterConfig {
   repeated BackendAuthRule rules = 1;
 
   oneof id_token_info {
+    option (validate.required) = true;
+
     // The Instance Metadata Server uri used to fetch id token from Instance
     // Metadata Server.
     api.envoy.http.common.HttpUri imds_token = 2;

--- a/api/envoy/http/common/base.proto
+++ b/api/envoy/http/common/base.proto
@@ -65,7 +65,8 @@ message HttpUri {
       [(validate.rules).duration.required = true];
 }
 
-/* TODO(taoxuy): replace with envoy internal DataSource proto */
+// Duplicate DataSource from envoy for self containment.
+// https://aip.dev/213
 message DataSource {
   oneof specifier {
     option (validate.required) = true;
@@ -80,6 +81,8 @@ message DataSource {
 
 message AccessToken {
   oneof token_type {
+    option (validate.required) = true;
+
     // remote_token contains:
     // - Token server uri. The Default is
     //   http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity

--- a/api/envoy/http/service_control/config.proto
+++ b/api/envoy/http/service_control/config.proto
@@ -110,6 +110,8 @@ message FilterConfig {
   GcpAttributes gcp_attributes = 3;
 
   oneof access_token {
+    option (validate.required) = true;
+
     // The Instance Metadata Server uri used to fetch access token from Instance
     // Metadata Server.
     api.envoy.http.common.HttpUri imds_token = 4;

--- a/api/envoy/http/service_control/requirement.proto
+++ b/api/envoy/http/service_control/requirement.proto
@@ -24,6 +24,8 @@ import "validate/validate.proto";
 // for a general overview of API keys as defined by OpenAPI.
 message ApiKeyLocation {
   oneof key {
+    option (validate.required) = true;
+
     // API Key is sent as a query parameter. `query` represents the
     // query string parameter name.
     //

--- a/src/envoy/http/backend_auth/BUILD
+++ b/src/envoy/http/backend_auth/BUILD
@@ -50,6 +50,7 @@ envoy_cc_library(
     deps = [
         "//api/envoy/http/backend_auth:config_proto_cc_proto",
         "//src/envoy/token:token_subscriber_factory_lib",
+        "@envoy//source/common/common:assert_lib",
     ],
 )
 
@@ -65,6 +66,7 @@ envoy_cc_test(
         ":filter_lib",
         ":mocks_lib",
         "//src/envoy/token:mocks_lib",
+        "@envoy//source/common/common:empty_string",
         "@envoy//test/mocks/http:http_mocks",
         "@envoy//test/mocks/server:server_mocks",
         "@envoy//test/test_common:utility_lib",

--- a/src/envoy/http/backend_auth/config_parser_impl_test.cc
+++ b/src/envoy/http/backend_auth/config_parser_impl_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "src/envoy/http/backend_auth/config_parser_impl.h"
+#include "common/common/empty_string.h"
 #include "gmock/gmock.h"
 #include "google/protobuf/text_format.h"
 #include "gtest/gtest.h"
@@ -112,6 +113,10 @@ rules {
 
   EXPECT_EQ(*config_parser_->getJwtToken("audience-foo"), "token-foo");
   EXPECT_EQ(*config_parser_->getJwtToken("audience-bar"), "token-bar");
+
+  EXPECT_EQ(config_parser_->getJwtToken("audience-non-existent"), nullptr);
+  EXPECT_EQ(config_parser_->getAudience("operation-non-existent"),
+            Envoy::EMPTY_STRING);
 }
 
 TEST_F(ConfigParserImplTest, GetIdTokenByIam) {

--- a/src/envoy/http/service_control/BUILD
+++ b/src/envoy/http/service_control/BUILD
@@ -122,6 +122,7 @@ envoy_cc_library(
         "//src/api_proxy/service_control:logs_metrics_loader_lib",
         "//src/envoy/token:token_subscriber_factory_lib",
         "@envoy//include/envoy/server:filter_config_interface",
+        "@envoy//source/common/common:empty_string",
         "@envoy//source/common/protobuf:utility_lib",
     ],
 )

--- a/src/envoy/http/service_control/service_control_call_impl.h
+++ b/src/envoy/http/service_control/service_control_call_impl.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "api/envoy/http/service_control/config.pb.h"
+#include "common/common/empty_string.h"
 #include "common/common/logger.h"
 #include "envoy/server/filter_config.h"
 #include "envoy/thread_local/thread_local.h"
@@ -53,19 +54,14 @@ class ThreadLocalCache : public Envoy::ThreadLocal::ThreadLocalObject {
 
   void set_sc_token(TokenSharedPtr sc_token) { sc_token_ = sc_token; }
   const std::string& sc_token() const {
-    return (sc_token_) ? *sc_token_ : empty_token();
+    return (sc_token_) ? *sc_token_ : Envoy::EMPTY_STRING;
   }
 
   void set_quota_token(TokenSharedPtr quota_token) {
     quota_token_ = quota_token;
   }
   const std::string& quota_token() const {
-    return (quota_token_) ? *quota_token_ : empty_token();
-  }
-
-  const std::string& empty_token() const {
-    static const std::string* const kEmptyToken = new std::string;
-    return *kEmptyToken;
+    return (quota_token_) ? *quota_token_ : Envoy::EMPTY_STRING;
   }
 
   ClientCache& client_cache() { return client_cache_; }


### PR DESCRIPTION
- `oneofs` are required to be set.
- `jwt_audience` should be a valid header string, other envoy will crash.
- Test case for missing audience / operation.
- Cleanup empty string.

Signed-off-by: Teju Nareddy <nareddyt@google.com>