### PR TITLE
b/158192303: #1 fix data race in config_manager_test.go

### DIFF
--- a/src/go/configmanager/config_manager_test.go
+++ b/src/go/configmanager/config_manager_test.go
@@ -15,13 +15,13 @@ package configmanager
 
 import (
 	"context"
-	"encoding/base64"
 	"flag"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -43,23 +43,9 @@ import (
 	smpb "google.golang.org/genproto/googleapis/api/servicemanagement/v1"
 )
 
-const (
-	testProjectName  = "bookstore.endpoints.project123.cloud.goog"
-	testEndpointName = "endpoints.examples.bookstore.Bookstore"
-	testConfigID     = "2017-05-01r0"
-	testProjectID    = "project123"
-	fakeToken        = `{"access_token": "ya29.new", "expires_in":3599, "token_type":"Bearer"}`
-)
-
-var (
-	fakeConfig             []byte
-	fakeScReport           []byte
-	fakeRollouts           []byte
-	fakeProtoDescriptor    = base64.StdEncoding.EncodeToString([]byte("rawDescriptor"))
-	testBackendClusterName = fmt.Sprintf("%s_local", testProjectName)
-)
-
 func TestFetchListeners(t *testing.T) {
+	var fakeConfig, fakeScReport, fakeRollouts safeData
+
 	testData := []struct {
 		desc              string
 		enableTracing     bool
@@ -69,1372 +55,56 @@ func TestFetchListeners(t *testing.T) {
 		wantedListeners   string
 	}{
 		{
-			desc:           "Success for grpc backend with transcoding",
-			BackendAddress: "grpc://127.0.0.1:80",
-			fakeServiceConfig: fmt.Sprintf(`{
-                "name":"%s",
-                "id": "2017-05-01r0",
-                "apis":[
-                    {
-                        "name":"%s",
-                        "version":"v1",
-                        "syntax":"SYNTAX_PROTO3",
-                    "methods": [
-                          {
-                             "name": "CreateShelf"
-                          }
-                        ]
-                    }
-                ],
-                "endpoints": [{"name": "%s"}],
-                "sourceInfo":{
-                    "sourceFiles":[
-                        {
-                            "@type":"type.googleapis.com/google.api.servicemanagement.v1.ConfigFile",
-                            "filePath":"api_descriptor.pb",
-                            "fileContents":"%s",
-                            "fileType":"FILE_DESCRIPTOR_SET_PROTO"
-                        }
-                    ]
-                }
-            }`, testProjectName, testEndpointName, testEndpointName, fakeProtoDescriptor),
-			wantedListeners: fmt.Sprintf(`
-{
-   "address":{
-      "socketAddress":{
-         "address":"0.0.0.0",
-         "portValue":8080
-      }
-	 },
-	 "name": "ingress_listener",
-   "filterChains":[
-      {
-         "filters":[
-            {
-               "name":"envoy.filters.network.http_connection_manager",
-               "typedConfig":{
-                  "@type":"type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                  "httpFilters":[
-                     {
-                        "name":"com.google.espv2.filters.http.path_matcher",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/espv2.api.envoy.http.path_matcher.FilterConfig",
-                           "rules":[
-                              {
-                                 "operation":"endpoints.examples.bookstore.Bookstore.CreateShelf",
-                                 "pattern":{
-                                    "httpMethod":"POST",
-                                    "uriTemplate":"/endpoints.examples.bookstore.Bookstore/CreateShelf"
-                                 }
-                              }
-                           ]
-                        }
-                     },
-                     {
-                        "name":"envoy.filters.http.grpc_web"
-                     },
-                     {
-                        "name":"envoy.filters.http.grpc_json_transcoder",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder",
-                           "autoMapping":true,
-                           "convertGrpcStatus":true,
-                           "ignoredQueryParameters":[
-                              "api_key",
-                              "key"
-                           ],
-                           "printOptions":{},
-                           "protoDescriptorBin":"%s",
-                           "services":[
-                              "%s"
-                           ]
-                        }
-                     },
-                     {
-                        "name":"envoy.filters.http.grpc_stats",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
-                           "emitFilterState":true,
-                           "statsForAllMethods":false
-                        }
-                     },
-                     {
-                        "name":"envoy.filters.http.router",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
-                       		 "suppressEnvoyHeaders": true
-                        }
-                     }
-                  ],
-                  "routeConfig":{
-                     "name":"local_route",
-                     "virtualHosts":[
-                        {
-                           "domains":[
-                              "*"
-                           ],
-                           "name":"backend",
-                           "routes":[
-                              {
-                                 "match":{
-                                    "prefix":"/"
-                                 },
-                                 "route":{
-                                    "cluster":"%s",
-                                    "timeout":"15s"
-                                 }
-                              }
-                           ]
-                        }
-                     ]
-                  },
-                  "upgradeConfigs": [{"upgradeType": "websocket"}],
-                  "statPrefix":"ingress_http",
-                  "commonHttpProtocolOptions":{"headersWithUnderscoresAction":"REJECT_REQUEST"},
-                  "useRemoteAddress":false,
-                  "xffNumTrustedHops":2
-               }
-            }
-         ]
-      }
-   ]
-}
-`,
-				fakeProtoDescriptor, testEndpointName, testBackendClusterName),
+			desc:              "Success for grpc backend with transcoding",
+			BackendAddress:    "grpc://127.0.0.1:80",
+			fakeServiceConfig: testdata.FakeServiceConfigForGrpcWithTranscoding,
+			wantedListeners:   testdata.WantedListsenerForGrpcWithTranscoding,
 		},
 		{
-			desc:           "Success for grpc backend, with Jwt filter, with audiences, no Http Rules",
-			BackendAddress: "grpc://127.0.0.1:80",
-			fakeServiceConfig: fmt.Sprintf(`{
-                "name":"bookstore.endpoints.project123.cloud.goog",
-                "id": "2017-05-01r0",
-                "apis":[
-                    {
-                        "name":"%s",
-                        "methods": [
-                           {
-                                "name": "CreateShelf"
-                           }
-                        ]
-                    }
-                ],
-                "endpoints": [{"name": "%s"}],
-                "authentication": {
-                    "providers": [
-                        {
-                            "id": "firebase",
-                            "issuer": "https://test_issuer.google.com/",
-                            "jwks_uri": "$JWKSURI",
-                            "audiences": "test_audience1, test_audience2 "
-                        }
-                    ],
-                    "rules": [
-                        {
-                            "selector": "endpoints.examples.bookstore.Bookstore.CreateShelf",
-                            "requirements": [
-                                {
-                                    "provider_id": "firebase",
-                                    "audiences": "test_audience1"
-                                }
-                            ]
-                        },
-                        {
-                            "selector": "endpoints.examples.bookstore.Bookstore.ListShelves"
-                        }
-                    ]
-                }
-            }`, testEndpointName, testEndpointName),
-
-			wantedListeners: fmt.Sprintf(`
-{
-   "address":{
-      "socketAddress":{
-         "address":"0.0.0.0",
-         "portValue":8080
-      }
-   },
-	 "name": "ingress_listener",
-   "filterChains":[
-      {
-         "filters":[
-            {
-               "name":"envoy.filters.network.http_connection_manager",
-               "typedConfig":{
-                  "@type":"type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                  "httpFilters":[
-                     {
-                        "name":"com.google.espv2.filters.http.path_matcher",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/espv2.api.envoy.http.path_matcher.FilterConfig",
-                           "rules":[
-                              {
-                                 "operation":"endpoints.examples.bookstore.Bookstore.CreateShelf",
-                                 "pattern":{
-                                    "httpMethod":"POST",
-                                    "uriTemplate":"/endpoints.examples.bookstore.Bookstore/CreateShelf"
-                                 }
-                              }
-                           ]
-                        }
-                     },
-                     {
-                        "name":"envoy.filters.http.jwt_authn",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication",
-                           "filterStateRules":{
-                              "name":"com.google.espv2.filters.http.path_matcher.operation",
-                              "requires":{
-                                 "endpoints.examples.bookstore.Bookstore.CreateShelf":{
-                                    "providerAndAudiences":{
-                                       "audiences":[
-                                          "test_audience1"
-                                       ],
-                                       "providerName":"firebase"
-                                    }
-                                 }
-                              }
-                           },
-                           "providers":{
-                              "firebase":{
-                                 "audiences":[
-                                    "test_audience1",
-                                    "test_audience2"
-                                 ],
-                                 "forward": true,
-                                 "forwardPayloadHeader":"X-Endpoint-API-UserInfo",
-                                 "fromHeaders":[
-                                    {
-                                       "name":"Authorization",
-                                       "valuePrefix":"Bearer "
-                                    },
-                                    {
-                                       "name":"X-Goog-Iap-Jwt-Assertion"
-                                    }
-                                 ],
-                                 "fromParams":[
-                                    "access_token"
-                                 ],
-                                 "issuer":"https://test_issuer.google.com/",
-                                 "payloadInMetadata":"jwt_payloads",
-                                 "remoteJwks":{
-                                    "cacheDuration":"300s",
-                                    "httpUri":{
-                                       "cluster":"$JWKSURI:443",
-                                       "timeout":"5s",
-                                       "uri":"$JWKSURI"
-                                    }
-                                 }
-                              }
-                           }
-                        }
-                     },
-                     {
-                        "name":"envoy.filters.http.grpc_web"
-                     },
-                     {
-                        "name":"envoy.filters.http.grpc_stats",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
-                           "emitFilterState":true,
-                           "statsForAllMethods":false
-                        }
-                     },
-                     {
-                        "name":"envoy.filters.http.router",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
-                       		 "suppressEnvoyHeaders": true
-                        }
-                     }
-                  ],
-                  "routeConfig":{
-                     "name":"local_route",
-                     "virtualHosts":[
-                        {
-                           "domains":[
-                              "*"
-                           ],
-                           "name":"backend",
-                           "routes":[
-                              {
-                                 "match":{
-                                    "prefix":"/"
-                                 },
-                                 "route":{
-                                    "cluster":"%s",
-                                    "timeout":"15s"
-                                 }
-                              }
-                           ]
-                        }
-                     ]
-                  },
-                  "upgradeConfigs": [{"upgradeType": "websocket"}],
-                  "statPrefix":"ingress_http",
-                  "commonHttpProtocolOptions":{"headersWithUnderscoresAction":"REJECT_REQUEST"},
-                  "useRemoteAddress":false,
-                  "xffNumTrustedHops":2
-               }
-            }
-         ]
-      }
-   ]
-}
-              `, testBackendClusterName),
+			desc:              "Success for grpc backend, with Jwt filter, with audiences, no Http Rules",
+			BackendAddress:    "grpc://127.0.0.1:80",
+			fakeServiceConfig: testdata.FakeServiceConfigForGrpcWithJwtFilterWithAuds,
+			wantedListeners:   testdata.WantedListsenerForGrpcWithJwtFilterWithAuds,
 		},
 		{
-			desc:           "Success for gRPC backend, with Jwt filter, without audiences",
-			BackendAddress: "grpc://127.0.0.1:80",
-			fakeServiceConfig: fmt.Sprintf(`{
-                "name":"bookstore.endpoints.project123.cloud.goog",
-                "id": "2017-05-01r0",
-                "apis":[
-                    {
-                        "name":"%s",
-                        "methods": [
-                          {
-                             "name": "ListShelves"
-                          },
-                          {
-                             "name": "CreateShelf"
-                          }
-                        ]
-                    }
-                ],
-                "endpoints": [{"name": "%s"}],
-                "http": {
-                    "rules": [
-                        {
-                            "selector": "endpoints.examples.bookstore.Bookstore.ListShelves",
-                            "get": "/v1/shelves"
-                        },
-                        {
-                            "selector": "endpoints.examples.bookstore.Bookstore.CreateShelf",
-                            "post": "/v1/shelves/{shelf}"
-                        }
-                    ]
-                },
-                "authentication": {
-                    "providers": [
-                        {
-                            "id": "firebase",
-                            "issuer": "https://test_issuer.google.com/",
-                            "jwks_uri": "$JWKSURI"
-                        }
-                    ],
-                    "rules": [
-                        {
-                            "selector": "endpoints.examples.bookstore.Bookstore.CreateShelf",
-                            "requirements": [
-                                {
-                                    "provider_id": "firebase"
-                                }
-                            ]
-                        },
-                        {
-                            "selector": "endpoints.examples.bookstore.Bookstore.ListShelves",
-                            "requirements": [
-                                {
-                                    "provider_id": "firebase"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            }`, testEndpointName, testEndpointName),
-			wantedListeners: fmt.Sprintf(`{
-   "address":{
-      "socketAddress":{
-         "address":"0.0.0.0",
-         "portValue":8080
-      }
-	 },
-	 "name": "ingress_listener",
-   "filterChains":[
-      {
-         "filters":[
-            {
-               "name":"envoy.filters.network.http_connection_manager",
-               "typedConfig":{
-                  "@type":"type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                  "httpFilters":[
-                     {
-                        "name":"com.google.espv2.filters.http.path_matcher",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/espv2.api.envoy.http.path_matcher.FilterConfig",
-                           "rules":[
-                              {
-                                 "operation":"endpoints.examples.bookstore.Bookstore.CreateShelf",
-                                 "pattern":{
-                                    "httpMethod":"POST",
-                                    "uriTemplate":"/v1/shelves/{shelf}"
-                                 }
-                              },
-                              {
-                                 "operation":"endpoints.examples.bookstore.Bookstore.CreateShelf",
-                                 "pattern":{
-                                    "httpMethod":"POST",
-                                    "uriTemplate":"/endpoints.examples.bookstore.Bookstore/CreateShelf"
-                                 }
-                              },
-                              {
-                                 "operation":"endpoints.examples.bookstore.Bookstore.ListShelves",
-                                 "pattern":{
-                                    "httpMethod":"GET",
-                                    "uriTemplate":"/v1/shelves"
-                                 }
-                              },
-                              {
-                                 "operation":"endpoints.examples.bookstore.Bookstore.ListShelves",
-                                 "pattern":{
-                                    "httpMethod":"POST",
-                                    "uriTemplate":"/endpoints.examples.bookstore.Bookstore/ListShelves"
-                                 }
-                              }
-                           ]
-                        }
-                     },
-                     {
-                        "name":"envoy.filters.http.jwt_authn",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication",
-                           "filterStateRules":{
-                              "name":"com.google.espv2.filters.http.path_matcher.operation",
-                              "requires":{
-                                 "endpoints.examples.bookstore.Bookstore.CreateShelf":{
-                                    "providerName":"firebase"
-                                 },
-                                 "endpoints.examples.bookstore.Bookstore.ListShelves":{
-                                    "providerName":"firebase"
-                                 }
-                              }
-                           },
-                           "providers":{
-                              "firebase":{
-                                 "audiences": [
-                                     "https://bookstore.endpoints.project123.cloud.goog"
-                                 ],
-                                 "forward": true,
-                                 "forwardPayloadHeader":"X-Endpoint-API-UserInfo",
-                                 "fromHeaders":[
-                                    {
-                                       "name":"Authorization",
-                                       "valuePrefix":"Bearer "
-                                    },
-                                    {
-                                       "name":"X-Goog-Iap-Jwt-Assertion"
-                                    }
-                                 ],
-                                 "fromParams":[
-                                    "access_token"
-                                 ],
-                                 "issuer":"https://test_issuer.google.com/",
-                                 "payloadInMetadata":"jwt_payloads",
-                                 "remoteJwks":{
-                                    "cacheDuration":"300s",
-                                    "httpUri":{
-                                       "cluster":"$JWKSURI:443",
-                                       "timeout":"5s",
-                                       "uri":"$JWKSURI"
-                                    }
-                                 }
-                              }
-                           }
-                        }
-                     },
-                     {
-                        "name":"envoy.filters.http.grpc_web"
-                     },
-                     {
-                        "name":"envoy.filters.http.grpc_stats",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
-                           "emitFilterState":true,
-                           "statsForAllMethods":false
-                        }
-                     },
-                     {
-                        "name":"envoy.filters.http.router",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
-                       		 "suppressEnvoyHeaders": true
-                        }
-                     }
-                  ],
-                  "routeConfig":{
-                     "name":"local_route",
-                     "virtualHosts":[
-                        {
-                           "domains":[
-                              "*"
-                           ],
-                           "name":"backend",
-                           "routes":[
-                              {
-                                 "match":{
-                                    "prefix":"/"
-                                 },
-                                 "route":{
-                                    "cluster":"%s",
-                                    "timeout":"15s"
-                                 }
-                              }
-                           ]
-                        }
-                     ]
-                  },
-                  "upgradeConfigs": [{"upgradeType": "websocket"}],
-                  "commonHttpProtocolOptions":{"headersWithUnderscoresAction":"REJECT_REQUEST"},
-                  "statPrefix":"ingress_http",
-                  "useRemoteAddress":false,
-                  "xffNumTrustedHops":2
-               }
-            }
-         ]
-      }
-   ]
-}`, testBackendClusterName),
+			desc:              "Success for gRPC backend, with Jwt filter, without audiences",
+			BackendAddress:    "grpc://127.0.0.1:80",
+			fakeServiceConfig: testdata.FakeServiceConfigForGrpcWithJwtFilterWithoutAuds,
+			wantedListeners:   testdata.WantedListsenerForGrpcWithJwtFilterWithoutAuds,
 		},
 		{
-			desc:           "Success for gRPC backend, with Jwt filter, with multi requirements, matching with regex",
-			BackendAddress: "grpc://127.0.0.1:80",
-			fakeServiceConfig: fmt.Sprintf(`{
-                "name":"bookstore.endpoints.project123.cloud.goog",
-                "id": "2017-05-01r0",
-                "apis":[
-                    {
-                        "name":"%s",
-                        "sourceContext": {
-                            "fileName": "bookstore.proto"
-                        },
-                        "methods": [
-                          {
-                             "name": "GetBook"
-                          },
-                          {
-                             "name": "DeleteBook"
-                          }
-                        ]
-                    }
-                ],
-                "http": {
-                    "rules": [
-                        {
-                            "selector": "endpoints.examples.bookstore.Bookstore.GetBook",
-                            "get": "/v1/shelves/{shelf}/books/{book}"
-                        },
-                        {
-                            "selector": "endpoints.examples.bookstore.Bookstore.DeleteBook",
-                            "delete": "/v1/shelves/{shelf}/books/{book}"
-                        }
-                    ]
-                },
-                "endpoints": [{"name": "%s"}],
-                "authentication": {
-                    "providers": [
-                        {
-                            "id": "firebase1",
-                            "issuer": "https://test_issuer.google.com/",
-                            "jwks_uri": "$JWKSURI"
-                        },
-                        {
-                            "id": "firebase2",
-                            "issuer": "https://test_issuer.google.com/",
-                            "jwks_uri": "$JWKSURI"
-                        }
-                    ],
-                    "rules": [
-                        {
-                            "selector": "endpoints.examples.bookstore.Bookstore.GetBook",
-                            "requirements": [
-                                {
-                                    "provider_id": "firebase1"
-                                },
-                                {
-                                    "provider_id": "firebase2"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            }`, testEndpointName, testEndpointName),
-			wantedListeners: fmt.Sprintf(`{
-   "address":{
-      "socketAddress":{
-         "address":"0.0.0.0",
-         "portValue":8080
-      }
-	 },
-	 "name": "ingress_listener",
-   "filterChains":[
-      {
-         "filters":[
-            {
-               "name":"envoy.filters.network.http_connection_manager",
-               "typedConfig":{
-                  "@type":"type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                  "httpFilters":[
-                     {
-                        "name":"com.google.espv2.filters.http.path_matcher",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/espv2.api.envoy.http.path_matcher.FilterConfig",
-                           "rules":[
-                              {
-                                 "operation":"endpoints.examples.bookstore.Bookstore.DeleteBook",
-                                 "pattern":{
-                                    "httpMethod":"DELETE",
-                                    "uriTemplate":"/v1/shelves/{shelf}/books/{book}"
-                                 }
-                              },
-                              {
-                                 "operation":"endpoints.examples.bookstore.Bookstore.DeleteBook",
-                                 "pattern":{
-                                    "httpMethod":"POST",
-                                    "uriTemplate":"/endpoints.examples.bookstore.Bookstore/DeleteBook"
-                                 }
-                              },
-                              {
-                                 "operation":"endpoints.examples.bookstore.Bookstore.GetBook",
-                                 "pattern":{
-                                    "httpMethod":"GET",
-                                    "uriTemplate":"/v1/shelves/{shelf}/books/{book}"
-                                 }
-                              },
-                              {
-                                 "operation":"endpoints.examples.bookstore.Bookstore.GetBook",
-                                 "pattern":{
-                                    "httpMethod":"POST",
-                                    "uriTemplate":"/endpoints.examples.bookstore.Bookstore/GetBook"
-                                 }
-                              }
-                           ]
-                        }
-                     },
-                     {
-                        "name":"envoy.filters.http.jwt_authn",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication",
-                           "filterStateRules":{
-                              "name":"com.google.espv2.filters.http.path_matcher.operation",
-                              "requires":{
-                                 "endpoints.examples.bookstore.Bookstore.GetBook":{
-                                    "requiresAny":{
-                                       "requirements":[
-                                          {
-                                             "providerName":"firebase1"
-                                          },
-                                          {
-                                             "providerName":"firebase2"
-                                          }
-                                       ]
-                                    }
-                                 }
-                              }
-                           },
-                           "providers":{
-                              "firebase1":{
-                                 "audiences": [
-                                     "https://bookstore.endpoints.project123.cloud.goog"
-                                 ],
-                                 "forward": true,
-                                 "forwardPayloadHeader":"X-Endpoint-API-UserInfo",
-                                 "fromHeaders":[
-                                    {
-                                       "name":"Authorization",
-                                       "valuePrefix":"Bearer "
-                                    },
-                                    {
-                                       "name":"X-Goog-Iap-Jwt-Assertion"
-                                    }
-                                 ],
-                                 "fromParams":[
-                                    "access_token"
-                                 ],
-                                 "issuer":"https://test_issuer.google.com/",
-                                 "payloadInMetadata":"jwt_payloads",
-                                 "remoteJwks":{
-                                    "cacheDuration":"300s",
-                                    "httpUri":{
-                                       "cluster":"$JWKSURI:443",
-                                       "timeout":"5s",
-                                       "uri":"$JWKSURI"
-                                    }
-                                 }
-                              },
-                              "firebase2":{
-                                 "audiences": [
-                                     "https://bookstore.endpoints.project123.cloud.goog"
-                                 ],
-                                 "forward": true,
-                                 "forwardPayloadHeader":"X-Endpoint-API-UserInfo",
-                                 "fromHeaders":[
-                                    {
-                                       "name":"Authorization",
-                                       "valuePrefix":"Bearer "
-                                    },
-                                    {
-                                       "name":"X-Goog-Iap-Jwt-Assertion"
-                                    }
-                                 ],
-                                 "fromParams":[
-                                    "access_token"
-                                 ],
-                                 "issuer":"https://test_issuer.google.com/",
-                                 "payloadInMetadata":"jwt_payloads",
-                                 "remoteJwks":{
-                                    "cacheDuration":"300s",
-                                    "httpUri":{
-                                       "cluster":"$JWKSURI:443",
-                                       "timeout":"5s",
-                                       "uri":"$JWKSURI"
-                                    }
-                                 }
-                              }
-                           }
-                        }
-                     },
-                     {
-                        "name":"envoy.filters.http.grpc_web"
-                     },
-                     {
-                        "name":"envoy.filters.http.grpc_stats",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
-                           "emitFilterState":true,
-                           "statsForAllMethods":false
-                        }
-                     },
-                     {
-                        "name":"envoy.filters.http.router",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
-                       		 "suppressEnvoyHeaders": true
-                        }
-                     }
-                  ],
-                  "routeConfig":{
-                     "name":"local_route",
-                     "virtualHosts":[
-                        {
-                           "domains":[
-                              "*"
-                           ],
-                           "name":"backend",
-                           "routes":[
-                              {
-                                 "match":{
-                                    "prefix":"/"
-                                 },
-                                 "route":{
-                                    "cluster":"%s",
-                                    "timeout":"15s"
-                                 }
-                              }
-                           ]
-                        }
-                     ]
-                  },
-                  "upgradeConfigs": [{"upgradeType": "websocket"}],
-                  "commonHttpProtocolOptions":{"headersWithUnderscoresAction":"REJECT_REQUEST"},
-                  "statPrefix":"ingress_http",
-                  "useRemoteAddress":false,
-                  "xffNumTrustedHops":2
-               }
-            }
-         ]
-      }
-   ]
-}`, testBackendClusterName),
+			desc:              "Success for gRPC backend, with Jwt filter, with multi requirements, matching with regex",
+			BackendAddress:    "grpc://127.0.0.1:80",
+			fakeServiceConfig: testdata.FakeServiceConfigForGrpcWithJwtFilterWithMultiReqs,
+			wantedListeners:   testdata.WantedListenerForGrpcWithJwtFilterWithMultiReqs,
 		},
 		{
-			desc:           "Success for gRPC backend with Service Control",
-			BackendAddress: "grpc://127.0.0.1:80",
-			fakeServiceConfig: fmt.Sprintf(`{
-                "name":"%s",
-                "id": "2017-05-01r0",
-                "endpoints" : [{"name": "%s"}],
-                "producer_project_id":"%s",
-                "control" : {
-                    "environment": "servicecontrol.googleapis.com"
-                },
-                "logging": {
-                    "producerDestinations": [{
-                    "logs": [
-                          "endpoints_log"
-                       ],
-                    "monitoredResource": "api"
-                   }
-                   ]
-                },
-                "logs": [
-                    {
-                       "name": "endpoints_log"
-                    }
-                ],
-                "apis":[
-                    {
-                        "name":"%s",
-                        "version":"v1",
-                        "syntax":"SYNTAX_PROTO3",
-                        "sourceContext": {
-                            "fileName": "bookstore.proto"
-                        },
-                        "methods":[
-                            {
-                                "name": "ListShelves"
-                            },
-                            {
-                                "name": "CreateShelf"
-                            }
-                        ]
-                    }
-                ],
-                "http": {
-                    "rules": [
-                        {
-                            "selector": "endpoints.examples.bookstore.Bookstore.ListShelves",
-                            "get": "/v1/shelves"
-                        },
-                        {
-                            "selector": "endpoints.examples.bookstore.Bookstore.CreateShelf",
-                            "post": "/v1/shelves",
-                            "body": "shelf"
-                        }
-                    ]
-                }
-            }`, testProjectName, testEndpointName, testProjectID, testEndpointName),
-			wantedListeners: fmt.Sprintf(`{
-   "address":{
-      "socketAddress":{
-         "address":"0.0.0.0",
-         "portValue":8080
-      }
-	 },
-	 "name": "ingress_listener",
-   "filterChains":[
-      {
-         "filters":[
-            {
-               "name":"envoy.filters.network.http_connection_manager",
-               "typedConfig":{
-                  "@type":"type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                  "httpFilters":[
-                     {
-                        "name":"com.google.espv2.filters.http.path_matcher",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/espv2.api.envoy.http.path_matcher.FilterConfig",
-                           "rules":[
-                              {
-                                 "operation":"endpoints.examples.bookstore.Bookstore.CreateShelf",
-                                 "pattern":{
-                                    "httpMethod":"POST",
-                                    "uriTemplate":"/v1/shelves"
-                                 }
-                              },
-                              {
-                                 "operation":"endpoints.examples.bookstore.Bookstore.CreateShelf",
-                                 "pattern":{
-                                    "httpMethod":"POST",
-                                    "uriTemplate":"/endpoints.examples.bookstore.Bookstore/CreateShelf"
-                                 }
-                              },
-                              {
-                                 "operation":"endpoints.examples.bookstore.Bookstore.ListShelves",
-                                 "pattern":{
-                                    "httpMethod":"GET",
-                                    "uriTemplate":"/v1/shelves"
-                                 }
-                              },
-                              {
-                                 "operation":"endpoints.examples.bookstore.Bookstore.ListShelves",
-                                 "pattern":{
-                                    "httpMethod":"POST",
-                                    "uriTemplate":"/endpoints.examples.bookstore.Bookstore/ListShelves"
-                                 }
-                              }
-                           ]
-                        }
-                     },
-                     {
-                        "name":"com.google.espv2.filters.http.service_control",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/espv2.api.envoy.http.service_control.FilterConfig",
-                           "generatedHeaderPrefix": "X-Endpoint-",
-                           "imdsToken":{
-                              "cluster":"metadata-cluster",
-                              "timeout":"5s",
-                              "uri":"http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token"
-                           },
-                           "gcpAttributes":{
-                              "platform":"GCE(ESPv2)"
-                           },
-                           "requirements":[
-                              {
-                                 "apiName":"endpoints.examples.bookstore.Bookstore",
-                                 "apiVersion":"v1",
-                                 "operationName":"endpoints.examples.bookstore.Bookstore.CreateShelf",
-                                 "serviceName":"bookstore.endpoints.project123.cloud.goog"
-                              },
-                              {
-                                 "apiName":"endpoints.examples.bookstore.Bookstore",
-                                 "apiVersion":"v1",
-                                 "operationName":"endpoints.examples.bookstore.Bookstore.ListShelves",
-                                 "serviceName":"bookstore.endpoints.project123.cloud.goog"
-                              }
-                           ],
-                           "scCallingConfig":{
-                              "networkFailOpen":true
-                           },
-                           "serviceControlUri":{
-                              "cluster":"service-control-cluster",
-                              "timeout":"5s",
-                              "uri":"https://servicecontrol.googleapis.com/v1/services/"
-                           },
-                           "services":[
-                              {
-                                 "backendProtocol":"grpc",
-                                 "jwtPayloadMetadataName":"jwt_payloads",
-                                 "producerProjectId":"%v",
-                                 "serviceConfig":{
-                                    "logging":{
-                                       "producerDestinations":[
-                                          {
-                                             "logs":[
-                                                "endpoints_log"
-                                             ],
-                                             "monitoredResource":"api"
-                                          }
-                                       ]
-                                    },
-                                    "logs":[
-                                       {
-                                          "name":"endpoints_log"
-                                       }
-                                    ]
-                                 },
-                                 "serviceConfigId":"%v",
-                                 "serviceName":"%v"
-                              }
-                           ]
-                        }
-                     },
-                     {
-                        "name":"envoy.filters.http.grpc_web"
-                     },
-                     {
-                        "name":"envoy.filters.http.grpc_stats",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
-                           "emitFilterState":true,
-                           "statsForAllMethods":false
-                        }
-                     },
-                     {
-                        "name":"envoy.filters.http.router",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
-                       		 "suppressEnvoyHeaders": true
-                        }
-                     }
-                  ],
-                  "routeConfig":{
-                     "name":"local_route",
-                     "virtualHosts":[
-                        {
-                           "domains":[
-                              "*"
-                           ],
-                           "name":"backend",
-                           "routes":[
-                              {
-                                 "match":{
-                                    "prefix":"/"
-                                 },
-                                 "route":{
-                                    "cluster":"%s",
-                                    "timeout":"15s"
-                                 }
-                              }
-                           ]
-                        }
-                     ]
-                  },
-                  "upgradeConfigs": [{"upgradeType": "websocket"}],
-                  "statPrefix":"ingress_http",
-                  "commonHttpProtocolOptions":{"headersWithUnderscoresAction":"REJECT_REQUEST"},
-                  "useRemoteAddress":false,
-                  "xffNumTrustedHops":2
-               }
-            }
-         ]
-      }
-   ]
-}`, testProjectID, testConfigID, testProjectName, testBackendClusterName),
+			desc:              "Success for gRPC backend with Service Control",
+			BackendAddress:    "grpc://127.0.0.1:80",
+			fakeServiceConfig: testdata.FakeServiceConfigForGrpcWithServiceControl,
+			wantedListeners:   testdata.WantedListenerForGrpcWithServiceControl,
 		},
 		{
-			desc:           "Success for http backend, with Jwt filter, with audiences",
-			BackendAddress: "http://127.0.0.1:80",
-			fakeServiceConfig: fmt.Sprintf(`{
-                "name":"bookstore.endpoints.project123.cloud.goog",
-                "id": "2017-05-01r0",
-                "apis":[
-                    {
-                        "name": "1.echo_api_endpoints_cloudesf_testing_cloud_goog",
-                        "methods": [
-                          {
-                             "name": "Echo_Auth_Jwt"
-                          },
-                          {
-                             "name": "Echo"
-                          }
-                        ]
-                    }
-                ],
-                "endpoints": [{"name": "%s"}],
-                "http": {
-                    "rules": [
-                        {
-                            "selector": "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo_Auth_Jwt",
-                            "get": "/auth/info/googlejwt"
-                        },
-                        {
-                            "selector": "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo",
-                            "post": "/echo",
-                            "body": "message"
-                        }
-                    ]
-                },
-                "authentication": {
-                    "providers": [
-                        {
-                            "id": "firebase",
-                            "issuer": "https://test_issuer.google.com/",
-                            "jwks_uri": "$JWKSURI",
-                            "audiences": "test_audience1, test_audience2 "
-                        }
-                    ],
-                    "rules": [
-                        {
-                            "selector": "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo"
-                        },
-                        {
-                            "selector": "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo_Auth_Jwt",
-                            "requirements": [
-                                {
-                                    "provider_id": "firebase",
-                                    "audiences": "test_audience1"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            }`, testEndpointName),
-			wantedListeners: fmt.Sprintf(`{
-   "address":{
-      "socketAddress":{
-         "address":"0.0.0.0",
-         "portValue":8080
-      }
-   },
-	 "name": "ingress_listener",
-   "filterChains":[
-      {
-         "filters":[
-            {
-               "name":"envoy.filters.network.http_connection_manager",
-               "typedConfig":{
-                  "@type":"type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                  "httpFilters":[
-                     {
-                        "name":"com.google.espv2.filters.http.path_matcher",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/espv2.api.envoy.http.path_matcher.FilterConfig",
-                           "rules":[
-                              {
-                                 "operation":"1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo",
-                                 "pattern":{
-                                    "httpMethod":"POST",
-                                    "uriTemplate":"/echo"
-                                 }
-                              },
-                              {
-                                 "operation":"1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo_Auth_Jwt",
-                                 "pattern":{
-                                    "httpMethod":"GET",
-                                    "uriTemplate":"/auth/info/googlejwt"
-                                 }
-                              }
-                           ]
-                        }
-                     },
-                     {
-                        "name":"envoy.filters.http.jwt_authn",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication",
-                           "filterStateRules":{
-                              "name":"com.google.espv2.filters.http.path_matcher.operation",
-                              "requires":{
-                                 "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo_Auth_Jwt":{
-                                    "providerAndAudiences":{
-                                       "audiences":[
-                                          "test_audience1"
-                                       ],
-                                       "providerName":"firebase"
-                                    }
-                                 }
-                              }
-                           },
-                           "providers":{
-                              "firebase":{
-                                 "audiences":[
-                                    "test_audience1",
-                                    "test_audience2"
-                                 ],
-                                 "forward": true,
-                                 "forwardPayloadHeader":"X-Endpoint-API-UserInfo",
-                                 "fromHeaders":[
-                                    {
-                                       "name":"Authorization",
-                                       "valuePrefix":"Bearer "
-                                    },
-                                    {
-                                       "name":"X-Goog-Iap-Jwt-Assertion"
-                                    }
-                                 ],
-                                 "fromParams":[
-                                    "access_token"
-                                 ],
-                                 "issuer":"https://test_issuer.google.com/",
-                                 "payloadInMetadata":"jwt_payloads",
-                                 "remoteJwks":{
-                                    "cacheDuration":"300s",
-                                    "httpUri":{
-                                       "cluster":"$JWKSURI:443",
-                                       "timeout":"5s",
-                                       "uri":"$JWKSURI"
-                                    }
-                                 }
-                              }
-                           }
-                        }
-                     },
-                     {
-                        "name":"envoy.filters.http.router",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
-                       		 "suppressEnvoyHeaders": true
-                        }
-                     }
-                  ],
-                  "routeConfig":{
-                     "name":"local_route",
-                     "virtualHosts":[
-                        {
-                           "domains":[
-                              "*"
-                           ],
-                           "name":"backend",
-                           "routes":[
-                              {
-                                 "match":{
-                                    "prefix":"/"
-                                 },
-                                 "route":{
-                                    "cluster":"%s",
-                                    "timeout":"15s"
-                                 }
-                              }
-                           ]
-                        }
-                     ]
-                  },
-                  "upgradeConfigs": [{"upgradeType": "websocket"}],
-                  "statPrefix":"ingress_http",
-                  "commonHttpProtocolOptions":{"headersWithUnderscoresAction":"REJECT_REQUEST"},
-                  "useRemoteAddress":false,
-                  "xffNumTrustedHops":2
-               }
-            }
-         ]
-      }
-   ]
-}`, testBackendClusterName),
+			desc:              "Success for http backend, with Jwt filter, with audiences",
+			BackendAddress:    "http://127.0.0.1:80",
+			fakeServiceConfig: testdata.FakeServiceConfigForHttp,
+			wantedListeners:   testdata.WantedListenerForHttp,
 		},
 		{
-			desc:           "Success for backend that allow CORS, with tracing and debug enabled",
-			enableTracing:  true,
-			enableDebug:    true,
-			BackendAddress: "http://127.0.0.1:80",
-			fakeServiceConfig: fmt.Sprintf(`{
-                "name":"%s",
-                "id": "2017-05-01r0",
-                "producer_project_id":"%s",
-                "control" : {
-                    "environment": "servicecontrol.googleapis.com"
-                },
-                "apis":[
-                    {
-                        "name":"1.echo_api_endpoints_cloudesf_testing_cloud_goog",
-                        "methods":[
-                            {
-                                "name": "Simplegetcors"
-                            }
-                        ]
-                    }
-                ],
-                "http": {
-                    "rules": [
-                        {
-                            "selector": "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Simplegetcors",
-                            "get": "/simplegetcors"
-                        }
-                    ]
-                },
-                "endpoints": [
-                    {
-                        "name": "%s",
-                        "allow_cors": true
-                    }
-                ]
-            }`, testProjectName, testProjectID, testProjectName),
-			wantedListeners: `{
-   "address":{
-      "socketAddress":{
-         "address":"0.0.0.0",
-         "portValue":8080
-      }
-	 },
-	 "name": "ingress_listener",
-   "filterChains":[
-      {
-         "filters":[
-            {
-               "name":"envoy.filters.network.http_connection_manager",
-               "typedConfig":{
-                  "@type":"type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                  "httpFilters":[
-                     {
-                        "name":"com.google.espv2.filters.http.path_matcher",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/espv2.api.envoy.http.path_matcher.FilterConfig",
-                           "rules":[
-                              {
-                                 "operation":"1.echo_api_endpoints_cloudesf_testing_cloud_goog.CORS_simplegetcors",
-                                 "pattern":{
-                                    "httpMethod":"OPTIONS",
-                                    "uriTemplate":"/simplegetcors"
-                                 }
-                              },
-                              {
-                                 "operation":"1.echo_api_endpoints_cloudesf_testing_cloud_goog.Simplegetcors",
-                                 "pattern":{
-                                    "httpMethod":"GET",
-                                    "uriTemplate":"/simplegetcors"
-                                 }
-                              }
-                           ]
-                        }
-                     },
-                     {
-                        "name":"com.google.espv2.filters.http.service_control",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/espv2.api.envoy.http.service_control.FilterConfig",
-                           "generatedHeaderPrefix": "X-Endpoint-",
-                           "imdsToken":{
-                              "cluster":"metadata-cluster",
-                              "timeout":"5s",
-                              "uri":"http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token"
-                           },
-                           "gcpAttributes":{
-                              "platform":"GCE(ESPv2)"
-                           },
-                           "requirements":[
-                              {
-                                 "apiKey":{
-                                    "allowWithoutApiKey":true
-                                 },
-                                 "apiName": "1.echo_api_endpoints_cloudesf_testing_cloud_goog",
-                                 "operationName":"1.echo_api_endpoints_cloudesf_testing_cloud_goog.CORS_simplegetcors",
-                                 "serviceName":"bookstore.endpoints.project123.cloud.goog"
-                              },
-                              {
-                                 "apiName": "1.echo_api_endpoints_cloudesf_testing_cloud_goog",
-                                 "operationName":"1.echo_api_endpoints_cloudesf_testing_cloud_goog.Simplegetcors",
-                                 "serviceName":"bookstore.endpoints.project123.cloud.goog"
-                              }
-                           ],
-                           "scCallingConfig":{
-                              "networkFailOpen":true
-                           },
-                           "serviceControlUri":{
-                              "cluster":"service-control-cluster",
-                              "timeout":"5s",
-                              "uri":"https://servicecontrol.googleapis.com/v1/services/"
-                           },
-                           "services":[
-                              {
-                                 "backendProtocol":"http1",
-                                 "jwtPayloadMetadataName":"jwt_payloads",
-                                 "producerProjectId":"project123",
-                                 "serviceConfig":{},
-                                 "serviceConfigId":"2017-05-01r0",
-                                 "serviceName":"bookstore.endpoints.project123.cloud.goog"
-                              }
-                           ]
-                        }
-                     },
-                     {
-                        "name":"envoy.filters.http.router",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
-                           "startChildSpan":true
-                        }
-                     }
-                  ],
-                  "routeConfig":{
-                     "name":"local_route",
-                     "virtualHosts":[
-                        {
-                           "domains":[
-                              "*"
-                           ],
-                           "name":"backend",
-                           "routes":[
-                              {
-                                 "match":{
-                                    "prefix":"/"
-                                 },
-                                 "route":{
-                                    "cluster":"bookstore.endpoints.project123.cloud.goog_local",
-                                    "timeout":"15s"
-                                 }
-                              }
-                           ]
-                        }
-                     ]
-                  },
-                  "upgradeConfigs": [{"upgradeType": "websocket"}],
-                  "statPrefix":"ingress_http",
-                  "commonHttpProtocolOptions":{"headersWithUnderscoresAction":"REJECT_REQUEST"},
-                  "tracing":{
-
-                  },
-                  "useRemoteAddress":false,
-                  "xffNumTrustedHops":2
-               }
-            }
-         ]
-      }
-   ]
-}`,
+			desc:              "Success for backend that allow CORS, with tracing and debug enabled",
+			enableTracing:     true,
+			enableDebug:       true,
+			BackendAddress:    "http://127.0.0.1:80",
+			fakeServiceConfig: testdata.FakeServiceConfigAllowCorsTracingDebug,
+			wantedListeners:   testdata.WantedListenersAllowCorsTracingDebug,
 		},
 	}
 
 	for i, tc := range testData {
 		// Overrides fakeConfig for the test case.
-		var err error
-		if fakeConfig, err = genFakeConfig(tc.fakeServiceConfig); err != nil {
-			t.Fatalf("genFakeConfig failed: %v", err)
+
+		if err := genProtoBinary(tc.fakeServiceConfig, new(confpb.Service), &fakeConfig); err != nil {
+			t.Fatalf("generate fake service config failed: %v", err)
 		}
 
 		opts := options.DefaultConfigGeneratorOptions()
@@ -1442,13 +112,9 @@ func TestFetchListeners(t *testing.T) {
 		opts.DisableTracing = !tc.enableTracing
 		opts.SuppressEnvoyHeaders = !tc.enableDebug
 
-		_ = flag.Set("service", testProjectName)
-		_ = flag.Set("service_config_id", testConfigID)
-		_ = flag.Set("rollout_strategy", util.FixedRolloutStrategy)
-		_ = flag.Set("check_rollout_interval", "100ms")
-		_ = flag.Set("service_json_path", "")
+		setFlags(testdata.TestFetchListenersProjectName, testdata.TestFetchListenersConfigID, util.FixedRolloutStrategy, "100ms", "")
 
-		runTest(t, opts, func(env *testEnv) {
+		runTest(t, &fakeScReport, &fakeRollouts, &fakeConfig, opts, func(configManager *ConfigManager) {
 			ctx := context.Background()
 			// First request, VersionId should be empty.
 			req := discoverypb.DiscoveryRequest{
@@ -1457,7 +123,7 @@ func TestFetchListeners(t *testing.T) {
 				},
 				TypeUrl: resource.ListenerType,
 			}
-			resp, err := env.configManager.cache.Fetch(ctx, req)
+			resp, err := configManager.cache.Fetch(ctx, req)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1469,8 +135,8 @@ func TestFetchListeners(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if resp.Version != testConfigID {
-				t.Errorf("Test Desc(%d): %s, snapshot cache fetch got version: %v, want: %v", i, tc.desc, resp.Version, testConfigID)
+			if resp.Version != testdata.TestFetchListenersConfigID {
+				t.Errorf("Test Desc(%d): %s, snapshot cache fetch got version: %v, want: %v", i, tc.desc, resp.Version, testdata.TestFetchListenersConfigID)
 			}
 			if !proto.Equal(&resp.Request, &req) {
 				t.Errorf("Test Desc(%d): %s, snapshot cache fetch got request: %v, want: %v", i, tc.desc, resp.Request, req)
@@ -1560,8 +226,8 @@ func TestFixedModeDynamicRouting(t *testing.T) {
 			t.Error(err)
 			continue
 		}
-		if respForListener.Version != testConfigID {
-			t.Errorf("Test Desc(%d): %s, snapshot cache fetch got version: %v, want: %v", i, tc.desc, respForListener.Version, testConfigID)
+		if respForListener.Version != testdata.TestFetchListenersConfigID {
+			t.Errorf("Test Desc(%d): %s, snapshot cache fetch got version: %v, want: %v", i, tc.desc, respForListener.Version, testdata.TestFetchListenersConfigID)
 			continue
 		}
 		if !proto.Equal(&respForListener.Request, &reqForListener) {
@@ -1581,12 +247,19 @@ func TestFixedModeDynamicRouting(t *testing.T) {
 }
 
 func TestServiceConfigAutoUpdate(t *testing.T) {
+	var fakeConfig, fakeScReport, fakeRollouts safeData
+
 	var oldConfigID, oldRolloutID, newConfigID, newRolloutID string
 	oldConfigID = "2018-12-05r0"
 	oldRolloutID = oldConfigID
 	newConfigID = "2018-12-05r1"
 	newRolloutID = newConfigID
-	testCase := struct {
+
+	testProjectName := "bookstore.endpoints.project123.cloud.goog"
+	testEndpointName := "endpoints.examples.bookstore.Bookstore"
+	testConfigID := "2017-05-01r0"
+
+	tc := struct {
 		desc                  string
 		fakeOldScReport       string
 		fakeNewScReport       string
@@ -1692,28 +365,25 @@ func TestServiceConfigAutoUpdate(t *testing.T) {
 
 	// Overrides fakeConfig with fakeOldServiceConfig for the test case.
 	var err error
-	if fakeScReport, err = genFakeScReport(testCase.fakeOldScReport); err != nil {
-		t.Fatalf("genFakeScReport failed: %v", err)
+
+	if err = genProtoBinary(tc.fakeOldScReport, new(servicecontrolpb.ReportResponse), &fakeScReport); err != nil {
+		t.Fatalf("generate fake service control report failed: %v", err)
 	}
 
-	if fakeRollouts, err = genFakeRollouts(testCase.fakeOldServiceRollout); err != nil {
-		t.Fatalf("genFakeRollouts failed: %v", err)
+	if err = genProtoBinary(tc.fakeOldServiceRollout, new(smpb.ListServiceRolloutsResponse), &fakeRollouts); err != nil {
+		t.Fatalf("generate fake service rollout failed: %v", err)
 	}
 
-	if fakeConfig, err = genFakeConfig(testCase.fakeOldServiceConfig); err != nil {
-		t.Fatalf("genFakeConfig failed: %v", err)
+	if err = genProtoBinary(tc.fakeOldServiceConfig, new(confpb.Service), &fakeConfig); err != nil {
+		t.Fatalf("generate fake service config failed: %v", err)
 	}
 
 	opts := options.DefaultConfigGeneratorOptions()
-	opts.BackendAddress = testCase.BackendAddress
+	opts.BackendAddress = tc.BackendAddress
 
-	_ = flag.Set("service", testProjectName)
-	_ = flag.Set("service_config_id", testConfigID)
-	_ = flag.Set("rollout_strategy", util.ManagedRolloutStrategy)
-	_ = flag.Set("check_rollout_interval", "100ms")
-	_ = flag.Set("service_json_path", "")
+	setFlags(testProjectName, testConfigID, util.ManagedRolloutStrategy, "100ms", "")
 
-	runTest(t, opts, func(env *testEnv) {
+	runTest(t, &fakeScReport, &fakeRollouts, &fakeConfig, opts, func(configManager *ConfigManager) {
 		var resp *cache.Response
 		var err error
 		ctx := context.Background()
@@ -1723,66 +393,62 @@ func TestServiceConfigAutoUpdate(t *testing.T) {
 			},
 			TypeUrl: resource.ListenerType,
 		}
-		resp, err = env.configManager.cache.Fetch(ctx, req)
+		resp, err = configManager.cache.Fetch(ctx, req)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		if resp.Version != oldConfigID {
-			t.Errorf("Test Desc: %s, snapshot cache fetch got version: %v, want: %v", testCase.desc, resp.Version, oldConfigID)
+			t.Errorf("Test Desc: %s, snapshot cache fetch got version: %v, want: %v", tc.desc, resp.Version, oldConfigID)
 		}
 		if !proto.Equal(&resp.Request, &req) {
-			t.Errorf("Test Desc: %s, snapshot cache fetch got request: %v, want: %v", testCase.desc, resp.Request, req)
+			t.Errorf("Test Desc: %s, snapshot cache fetch got request: %v, want: %v", tc.desc, resp.Request, req)
 		}
 
-		if fakeScReport, err = genFakeScReport(testCase.fakeNewScReport); err != nil {
-			t.Fatalf("genFakeScReport failed: %v", err)
-		}
-		if fakeRollouts, err = genFakeRollouts(testCase.fakeNewServiceRollout); err != nil {
-			t.Fatalf("genFakeRollouts failed: %v", err)
-		}
-		if fakeConfig, err = genFakeConfig(testCase.fakeNewServiceConfig); err != nil {
-			t.Fatalf("genFakeConfig failed: %v", err)
+		if err = genProtoBinary(tc.fakeNewScReport, new(servicecontrolpb.ReportResponse), &fakeScReport); err != nil {
+			t.Fatalf("generate fake service control report failed: %v", err)
 		}
 
-		time.Sleep(time.Duration(*checkNewRolloutInterval + time.Second))
+		if err = genProtoBinary(tc.fakeNewServiceRollout, new(smpb.ListServiceRolloutsResponse), &fakeRollouts); err != nil {
+			t.Fatalf("generate fake service rollout failed: %v", err)
+		}
 
-		resp, err = env.configManager.cache.Fetch(ctx, req)
+		if err = genProtoBinary(tc.fakeNewServiceConfig, new(confpb.Service), &fakeConfig); err != nil {
+			t.Fatalf("generate fake service config failed: %v", err)
+		}
+
+		time.Sleep(*checkNewRolloutInterval + time.Second)
+
+		resp, err = configManager.cache.Fetch(ctx, req)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if resp.Version != newConfigID || env.configManager.curConfigId() != newConfigID {
-			t.Errorf("Test Desc: %s, snapshot cache fetch got version: %v, want: %v", testCase.desc, resp.Version, newConfigID)
+		if resp.Version != newConfigID || configManager.curConfigId() != newConfigID {
+			t.Errorf("Test Desc: %s, snapshot cache fetch got version: %v, want: %v", tc.desc, resp.Version, newConfigID)
 		}
 
 		if !proto.Equal(&resp.Request, &req) {
-			t.Errorf("Test Desc: %s, snapshot cache fetch got request: %v, want: %v", testCase.desc, resp.Request, req)
+			t.Errorf("Test Desc: %s, snapshot cache fetch got request: %v, want: %v", tc.desc, resp.Request, req)
 		}
 	})
 }
 
-// Test Environment setup.
-
-type testEnv struct {
-	configManager *ConfigManager
-}
-
-func runTest(t *testing.T, opts options.ConfigGeneratorOptions, f func(*testEnv)) {
-
-	mockServiceControl := initMockScReportServer(t)
+func runTest(t *testing.T, fakeScReport, fakeRollouts, fakeConfig *safeData, opts options.ConfigGeneratorOptions, f func(configManager *ConfigManager)) {
+	fakeToken := `{"access_token": "ya29.new", "expires_in":3599, "token_type":"Bearer"}`
+	mockServiceControl := initMockServer(t, fakeScReport)
 	defer mockServiceControl.Close()
 	util.FetchRolloutIdURL = func(serviceControlUrl, serviceName string) string {
 		return mockServiceControl.URL
 	}
 
-	mockRollout := initMockRolloutServer(t)
+	mockRollout := initMockServer(t, fakeRollouts)
 	defer mockRollout.Close()
 	util.FetchRolloutsURL = func(serviceManagementUrl, serviceName string) string {
 		return mockRollout.URL
 	}
 
-	mockConfig := initMockConfigServer(t)
+	mockConfig := initMockServer(t, fakeConfig)
 	defer mockConfig.Close()
 	util.FetchConfigURL = func(serviceManagementUrl, serviceName, configId string) string {
 		return mockConfig.URL
@@ -1800,37 +466,36 @@ func runTest(t *testing.T, opts options.ConfigGeneratorOptions, f func(*testEnv)
 	if err != nil {
 		t.Fatal("fail to initialize Config Manager: ", err)
 	}
-	env := &testEnv{
-		configManager: manager,
-	}
-	f(env)
+
+	f(manager)
 }
 
-func initMockConfigServer(t *testing.T) *httptest.Server {
+type safeData struct {
+	mutex sync.Mutex
+	data  []byte
+}
+
+func (s *safeData) write(src []byte) {
+	s.mutex.Lock()
+	s.data = make([]byte, len(src))
+	copy(s.data, src)
+	s.mutex.Unlock()
+}
+
+func (s *safeData) read() []byte {
+	s.mutex.Lock()
+	ret := make([]byte, len(s.data))
+	copy(ret, s.data)
+	s.mutex.Unlock()
+	return ret
+}
+
+func initMockServer(t *testing.T, config *safeData) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, err := w.Write(fakeConfig)
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write(config.read())
 		if err != nil {
 			t.Fatal("fail to write config: ", err)
-		}
-	}))
-}
-
-func initMockRolloutServer(t *testing.T) *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, err := w.Write(fakeRollouts)
-		if err != nil {
-			t.Fatal("fail to write rollout config: ", err)
-		}
-	}))
-}
-
-func initMockScReportServer(t *testing.T) *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, err := w.Write(fakeScReport)
-		if err != nil {
-			t.Fatal("fail to write service control report: ", err)
 		}
 	}))
 }
@@ -1845,45 +510,50 @@ func sortResources(response *cache.Response) []types.Resource {
 	return sortedResources
 }
 
-func genFakeConfig(input string) ([]byte, error) {
+func unmarshalJsonTestToPbMessage(input string, output proto.Message) error {
 	unmarshaler := &jsonpb.Unmarshaler{
 		AnyResolver: util.Resolver,
 	}
-	service := new(confpb.Service)
-	if err := unmarshaler.Unmarshal(strings.NewReader(input), service); err != nil {
-		return nil, err
+
+	switch t := output.(type) {
+	case *confpb.Service:
+		if err := unmarshaler.Unmarshal(strings.NewReader(input), output.(*confpb.Service)); err != nil {
+			return fmt.Errorf("fail to unmarshal %T: %v", t, err)
+		}
+	case *smpb.ListServiceRolloutsResponse:
+		if err := unmarshaler.Unmarshal(strings.NewReader(input), output.(*smpb.ListServiceRolloutsResponse)); err != nil {
+			return fmt.Errorf("fail to unmarshal %T: %v", t, err)
+		}
+	case *servicecontrolpb.ReportResponse:
+		if err := unmarshaler.Unmarshal(strings.NewReader(input), output.(*servicecontrolpb.ReportResponse)); err != nil {
+			return fmt.Errorf("fail to unmarshal %T: %v", t, err)
+		}
+		return nil
+	default:
+		return fmt.Errorf("not support unmarshalling %T", t)
 	}
-	protoBytesArray, err := proto.Marshal(service)
-	if err != nil {
-		return nil, err
-	}
-	return protoBytesArray, nil
+	return nil
 }
 
-func genFakeScReport(input string) ([]byte, error) {
-	unmarshaler := &jsonpb.Unmarshaler{}
-	scReport := new(servicecontrolpb.ReportResponse)
-	if err := unmarshaler.Unmarshal(strings.NewReader(input), scReport); err != nil {
-		return nil, err
+func genProtoBinary(input string, msg proto.Message, dest *safeData) error {
+	if err := unmarshalJsonTestToPbMessage(input, msg); err != nil {
+		return err
 	}
 
-	protoBytesArray, err := proto.Marshal(scReport)
+	protoBytesArray, err := proto.Marshal(msg)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return protoBytesArray, nil
+
+	dest.write(protoBytesArray)
+
+	return nil
 }
 
-func genFakeRollouts(input string) ([]byte, error) {
-	unmarshaler := &jsonpb.Unmarshaler{}
-	rollouts := new(smpb.ListServiceRolloutsResponse)
-	if err := unmarshaler.Unmarshal(strings.NewReader(input), rollouts); err != nil {
-		return nil, err
-	}
-
-	protoBytesArray, err := proto.Marshal(rollouts)
-	if err != nil {
-		return nil, err
-	}
-	return protoBytesArray, nil
+func setFlags(service, serviceConfigId, rolloutStrategy, checkRolloutInterval, serviceJsonPath string) {
+	_ = flag.Set("service", service)
+	_ = flag.Set("service_config_id", serviceConfigId)
+	_ = flag.Set("rollout_strategy", rolloutStrategy)
+	_ = flag.Set("check_rollout_interval", checkRolloutInterval)
+	_ = flag.Set("service_json_path", serviceJsonPath)
 }

--- a/src/go/configmanager/testdata/test_fetch_listeners.go
+++ b/src/go/configmanager/testdata/test_fetch_listeners.go
@@ -1,0 +1,1376 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testdata
+
+import (
+	"encoding/base64"
+	"fmt"
+)
+
+const (
+	TestFetchListenersProjectName  = "bookstore.endpoints.project123.cloud.goog"
+	TestFetchListenersEndpointName = "endpoints.examples.bookstore.Bookstore"
+	TestFetchListenersConfigID     = "2017-05-01r0"
+	testProjectID                  = "project123"
+)
+
+var (
+	fakeProtoDescriptor    = base64.StdEncoding.EncodeToString([]byte("rawDescriptor"))
+	testBackendClusterName = fmt.Sprintf("%s_local", TestFetchListenersProjectName)
+)
+
+var (
+	FakeServiceConfigForGrpcWithTranscoding = fmt.Sprintf(`{
+                "name":"%s",
+                "id": "2017-05-01r0",
+                "apis":[
+                    {
+                        "name":"%s",
+                        "version":"v1",
+                        "syntax":"SYNTAX_PROTO3",
+                    "methods": [
+                          {
+                             "name": "CreateShelf"
+                          }
+                        ]
+                    }
+                ],
+                "endpoints": [{"name": "%s"}],
+                "sourceInfo":{
+                    "sourceFiles":[
+                        {
+                            "@type":"type.googleapis.com/google.api.servicemanagement.v1.ConfigFile",
+                            "filePath":"api_descriptor.pb",
+                            "fileContents":"%s",
+                            "fileType":"FILE_DESCRIPTOR_SET_PROTO"
+                        }
+                    ]
+                }
+            }`, TestFetchListenersProjectName, TestFetchListenersEndpointName, TestFetchListenersEndpointName, fakeProtoDescriptor)
+
+	WantedListsenerForGrpcWithTranscoding = fmt.Sprintf(`
+{
+   "address":{
+      "socketAddress":{
+         "address":"0.0.0.0",
+         "portValue":8080
+      }
+	 },
+	 "name": "ingress_listener",
+   "filterChains":[
+      {
+         "filters":[
+            {
+               "name":"envoy.filters.network.http_connection_manager",
+               "typedConfig":{
+                  "@type":"type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "httpFilters":[
+                     {
+                        "name":"com.google.espv2.filters.http.path_matcher",
+                        "typedConfig":{
+                           "@type":"type.googleapis.com/espv2.api.envoy.http.path_matcher.FilterConfig",
+                           "rules":[
+                              {
+                                 "operation":"endpoints.examples.bookstore.Bookstore.CreateShelf",
+                                 "pattern":{
+                                    "httpMethod":"POST",
+                                    "uriTemplate":"/endpoints.examples.bookstore.Bookstore/CreateShelf"
+                                 }
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "name":"envoy.filters.http.grpc_web"
+                     },
+                     {
+                        "name":"envoy.filters.http.grpc_json_transcoder",
+                        "typedConfig":{
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder",
+                           "autoMapping":true,
+                           "convertGrpcStatus":true,
+                           "ignoredQueryParameters":[
+                              "api_key",
+                              "key"
+                           ],
+                           "printOptions":{},
+                           "protoDescriptorBin":"%s",
+                           "services":[
+                              "%s"
+                           ]
+                        }
+                     },
+                     {
+                        "name":"envoy.filters.http.grpc_stats",
+                        "typedConfig":{
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
+                           "emitFilterState":true,
+                           "statsForAllMethods":false
+                        }
+                     },
+                     {
+                        "name":"envoy.filters.http.router",
+                        "typedConfig":{
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
+                       		 "suppressEnvoyHeaders": true
+                        }
+                     }
+                  ],
+                  "routeConfig":{
+                     "name":"local_route",
+                     "virtualHosts":[
+                        {
+                           "domains":[
+                              "*"
+                           ],
+                           "name":"backend",
+                           "routes":[
+                              {
+                                 "match":{
+                                    "prefix":"/"
+                                 },
+                                 "route":{
+                                    "cluster":"%s",
+                                    "timeout":"15s"
+                                 }
+                              }
+                           ]
+                        }
+                     ]
+                  },
+                  "upgradeConfigs": [{"upgradeType": "websocket"}],
+                  "statPrefix":"ingress_http",
+                  "commonHttpProtocolOptions":{"headersWithUnderscoresAction":"REJECT_REQUEST"},
+                  "useRemoteAddress":false,
+                  "xffNumTrustedHops":2
+               }
+            }
+         ]
+      }
+   ]
+}
+`,
+		fakeProtoDescriptor, TestFetchListenersEndpointName, testBackendClusterName)
+
+	FakeServiceConfigForGrpcWithJwtFilterWithAuds = fmt.Sprintf(`{
+                "name":"bookstore.endpoints.project123.cloud.goog",
+                "id": "2017-05-01r0",
+                "apis":[
+                    {
+                        "name":"%s",
+                        "methods": [
+                           {
+                                "name": "CreateShelf"
+                           }
+                        ]
+                    }
+                ],
+                "endpoints": [{"name": "%s"}],
+                "authentication": {
+                    "providers": [
+                        {
+                            "id": "firebase",
+                            "issuer": "https://test_issuer.google.com/",
+                            "jwks_uri": "$JWKSURI",
+                            "audiences": "test_audience1, test_audience2 "
+                        }
+                    ],
+                    "rules": [
+                        {
+                            "selector": "endpoints.examples.bookstore.Bookstore.CreateShelf",
+                            "requirements": [
+                                {
+                                    "provider_id": "firebase",
+                                    "audiences": "test_audience1"
+                                }
+                            ]
+                        },
+                        {
+                            "selector": "endpoints.examples.bookstore.Bookstore.ListShelves"
+                        }
+                    ]
+                }
+            }`, TestFetchListenersEndpointName, TestFetchListenersEndpointName)
+
+	WantedListsenerForGrpcWithJwtFilterWithAuds = fmt.Sprintf(`
+{
+   "address":{
+      "socketAddress":{
+         "address":"0.0.0.0",
+         "portValue":8080
+      }
+   },
+	 "name": "ingress_listener",
+   "filterChains":[
+      {
+         "filters":[
+            {
+               "name":"envoy.filters.network.http_connection_manager",
+               "typedConfig":{
+                  "@type":"type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "httpFilters":[
+                     {
+                        "name":"com.google.espv2.filters.http.path_matcher",
+                        "typedConfig":{
+                           "@type":"type.googleapis.com/espv2.api.envoy.http.path_matcher.FilterConfig",
+                           "rules":[
+                              {
+                                 "operation":"endpoints.examples.bookstore.Bookstore.CreateShelf",
+                                 "pattern":{
+                                    "httpMethod":"POST",
+                                    "uriTemplate":"/endpoints.examples.bookstore.Bookstore/CreateShelf"
+                                 }
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "name":"envoy.filters.http.jwt_authn",
+                        "typedConfig":{
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication",
+                           "filterStateRules":{
+                              "name":"com.google.espv2.filters.http.path_matcher.operation",
+                              "requires":{
+                                 "endpoints.examples.bookstore.Bookstore.CreateShelf":{
+                                    "providerAndAudiences":{
+                                       "audiences":[
+                                          "test_audience1"
+                                       ],
+                                       "providerName":"firebase"
+                                    }
+                                 }
+                              }
+                           },
+                           "providers":{
+                              "firebase":{
+                                 "audiences":[
+                                    "test_audience1",
+                                    "test_audience2"
+                                 ],
+                                 "forward": true,
+                                 "forwardPayloadHeader":"X-Endpoint-API-UserInfo",
+                                 "fromHeaders":[
+                                    {
+                                       "name":"Authorization",
+                                       "valuePrefix":"Bearer "
+                                    },
+                                    {
+                                       "name":"X-Goog-Iap-Jwt-Assertion"
+                                    }
+                                 ],
+                                 "fromParams":[
+                                    "access_token"
+                                 ],
+                                 "issuer":"https://test_issuer.google.com/",
+                                 "payloadInMetadata":"jwt_payloads",
+                                 "remoteJwks":{
+                                    "cacheDuration":"300s",
+                                    "httpUri":{
+                                       "cluster":"$JWKSURI:443",
+                                       "timeout":"5s",
+                                       "uri":"$JWKSURI"
+                                    }
+                                 }
+                              }
+                           }
+                        }
+                     },
+                     {
+                        "name":"envoy.filters.http.grpc_web"
+                     },
+                     {
+                        "name":"envoy.filters.http.grpc_stats",
+                        "typedConfig":{
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
+                           "emitFilterState":true,
+                           "statsForAllMethods":false
+                        }
+                     },
+                     {
+                        "name":"envoy.filters.http.router",
+                        "typedConfig":{
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
+                       		 "suppressEnvoyHeaders": true
+                        }
+                     }
+                  ],
+                  "routeConfig":{
+                     "name":"local_route",
+                     "virtualHosts":[
+                        {
+                           "domains":[
+                              "*"
+                           ],
+                           "name":"backend",
+                           "routes":[
+                              {
+                                 "match":{
+                                    "prefix":"/"
+                                 },
+                                 "route":{
+                                    "cluster":"%s",
+                                    "timeout":"15s"
+                                 }
+                              }
+                           ]
+                        }
+                     ]
+                  },
+                  "upgradeConfigs": [{"upgradeType": "websocket"}],
+                  "statPrefix":"ingress_http",
+                  "commonHttpProtocolOptions":{"headersWithUnderscoresAction":"REJECT_REQUEST"},
+                  "useRemoteAddress":false,
+                  "xffNumTrustedHops":2
+               }
+            }
+         ]
+      }
+   ]
+}
+              `, testBackendClusterName)
+
+	FakeServiceConfigForGrpcWithJwtFilterWithoutAuds = fmt.Sprintf(`{
+                "name":"bookstore.endpoints.project123.cloud.goog",
+                "id": "2017-05-01r0",
+                "apis":[
+                    {
+                        "name":"%s",
+                        "methods": [
+                          {
+                             "name": "ListShelves"
+                          },
+                          {
+                             "name": "CreateShelf"
+                          }
+                        ]
+                    }
+                ],
+                "endpoints": [{"name": "%s"}],
+                "http": {
+                    "rules": [
+                        {
+                            "selector": "endpoints.examples.bookstore.Bookstore.ListShelves",
+                            "get": "/v1/shelves"
+                        },
+                        {
+                            "selector": "endpoints.examples.bookstore.Bookstore.CreateShelf",
+                            "post": "/v1/shelves/{shelf}"
+                        }
+                    ]
+                },
+                "authentication": {
+                    "providers": [
+                        {
+                            "id": "firebase",
+                            "issuer": "https://test_issuer.google.com/",
+                            "jwks_uri": "$JWKSURI"
+                        }
+                    ],
+                    "rules": [
+                        {
+                            "selector": "endpoints.examples.bookstore.Bookstore.CreateShelf",
+                            "requirements": [
+                                {
+                                    "provider_id": "firebase"
+                                }
+                            ]
+                        },
+                        {
+                            "selector": "endpoints.examples.bookstore.Bookstore.ListShelves",
+                            "requirements": [
+                                {
+                                    "provider_id": "firebase"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }`, TestFetchListenersEndpointName, TestFetchListenersEndpointName)
+
+	WantedListsenerForGrpcWithJwtFilterWithoutAuds = fmt.Sprintf(`{
+   "address":{
+      "socketAddress":{
+         "address":"0.0.0.0",
+         "portValue":8080
+      }
+	 },
+	 "name": "ingress_listener",
+   "filterChains":[
+      {
+         "filters":[
+            {
+               "name":"envoy.filters.network.http_connection_manager",
+               "typedConfig":{
+                  "@type":"type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "httpFilters":[
+                     {
+                        "name":"com.google.espv2.filters.http.path_matcher",
+                        "typedConfig":{
+                           "@type":"type.googleapis.com/espv2.api.envoy.http.path_matcher.FilterConfig",
+                           "rules":[
+                              {
+                                 "operation":"endpoints.examples.bookstore.Bookstore.CreateShelf",
+                                 "pattern":{
+                                    "httpMethod":"POST",
+                                    "uriTemplate":"/v1/shelves/{shelf}"
+                                 }
+                              },
+                              {
+                                 "operation":"endpoints.examples.bookstore.Bookstore.CreateShelf",
+                                 "pattern":{
+                                    "httpMethod":"POST",
+                                    "uriTemplate":"/endpoints.examples.bookstore.Bookstore/CreateShelf"
+                                 }
+                              },
+                              {
+                                 "operation":"endpoints.examples.bookstore.Bookstore.ListShelves",
+                                 "pattern":{
+                                    "httpMethod":"GET",
+                                    "uriTemplate":"/v1/shelves"
+                                 }
+                              },
+                              {
+                                 "operation":"endpoints.examples.bookstore.Bookstore.ListShelves",
+                                 "pattern":{
+                                    "httpMethod":"POST",
+                                    "uriTemplate":"/endpoints.examples.bookstore.Bookstore/ListShelves"
+                                 }
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "name":"envoy.filters.http.jwt_authn",
+                        "typedConfig":{
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication",
+                           "filterStateRules":{
+                              "name":"com.google.espv2.filters.http.path_matcher.operation",
+                              "requires":{
+                                 "endpoints.examples.bookstore.Bookstore.CreateShelf":{
+                                    "providerName":"firebase"
+                                 },
+                                 "endpoints.examples.bookstore.Bookstore.ListShelves":{
+                                    "providerName":"firebase"
+                                 }
+                              }
+                           },
+                           "providers":{
+                              "firebase":{
+                                 "audiences": [
+                                     "https://bookstore.endpoints.project123.cloud.goog"
+                                 ],
+                                 "forward": true,
+                                 "forwardPayloadHeader":"X-Endpoint-API-UserInfo",
+                                 "fromHeaders":[
+                                    {
+                                       "name":"Authorization",
+                                       "valuePrefix":"Bearer "
+                                    },
+                                    {
+                                       "name":"X-Goog-Iap-Jwt-Assertion"
+                                    }
+                                 ],
+                                 "fromParams":[
+                                    "access_token"
+                                 ],
+                                 "issuer":"https://test_issuer.google.com/",
+                                 "payloadInMetadata":"jwt_payloads",
+                                 "remoteJwks":{
+                                    "cacheDuration":"300s",
+                                    "httpUri":{
+                                       "cluster":"$JWKSURI:443",
+                                       "timeout":"5s",
+                                       "uri":"$JWKSURI"
+                                    }
+                                 }
+                              }
+                           }
+                        }
+                     },
+                     {
+                        "name":"envoy.filters.http.grpc_web"
+                     },
+                     {
+                        "name":"envoy.filters.http.grpc_stats",
+                        "typedConfig":{
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
+                           "emitFilterState":true,
+                           "statsForAllMethods":false
+                        }
+                     },
+                     {
+                        "name":"envoy.filters.http.router",
+                        "typedConfig":{
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
+                       		 "suppressEnvoyHeaders": true
+                        }
+                     }
+                  ],
+                  "routeConfig":{
+                     "name":"local_route",
+                     "virtualHosts":[
+                        {
+                           "domains":[
+                              "*"
+                           ],
+                           "name":"backend",
+                           "routes":[
+                              {
+                                 "match":{
+                                    "prefix":"/"
+                                 },
+                                 "route":{
+                                    "cluster":"%s",
+                                    "timeout":"15s"
+                                 }
+                              }
+                           ]
+                        }
+                     ]
+                  },
+                  "upgradeConfigs": [{"upgradeType": "websocket"}],
+                  "commonHttpProtocolOptions":{"headersWithUnderscoresAction":"REJECT_REQUEST"},
+                  "statPrefix":"ingress_http",
+                  "useRemoteAddress":false,
+                  "xffNumTrustedHops":2
+               }
+            }
+         ]
+      }
+   ]
+}`, testBackendClusterName)
+
+	FakeServiceConfigForGrpcWithJwtFilterWithMultiReqs = fmt.Sprintf(`{
+                "name":"bookstore.endpoints.project123.cloud.goog",
+                "id": "2017-05-01r0",
+                "apis":[
+                    {
+                        "name":"%s",
+                        "sourceContext": {
+                            "fileName": "bookstore.proto"
+                        },
+                        "methods": [
+                          {
+                             "name": "GetBook"
+                          },
+                          {
+                             "name": "DeleteBook"
+                          }
+                        ]
+                    }
+                ],
+                "http": {
+                    "rules": [
+                        {
+                            "selector": "endpoints.examples.bookstore.Bookstore.GetBook",
+                            "get": "/v1/shelves/{shelf}/books/{book}"
+                        },
+                        {
+                            "selector": "endpoints.examples.bookstore.Bookstore.DeleteBook",
+                            "delete": "/v1/shelves/{shelf}/books/{book}"
+                        }
+                    ]
+                },
+                "endpoints": [{"name": "%s"}],
+                "authentication": {
+                    "providers": [
+                        {
+                            "id": "firebase1",
+                            "issuer": "https://test_issuer.google.com/",
+                            "jwks_uri": "$JWKSURI"
+                        },
+                        {
+                            "id": "firebase2",
+                            "issuer": "https://test_issuer.google.com/",
+                            "jwks_uri": "$JWKSURI"
+                        }
+                    ],
+                    "rules": [
+                        {
+                            "selector": "endpoints.examples.bookstore.Bookstore.GetBook",
+                            "requirements": [
+                                {
+                                    "provider_id": "firebase1"
+                                },
+                                {
+                                    "provider_id": "firebase2"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }`, TestFetchListenersEndpointName, TestFetchListenersEndpointName)
+	WantedListenerForGrpcWithJwtFilterWithMultiReqs = fmt.Sprintf(`{
+   "address":{
+      "socketAddress":{
+         "address":"0.0.0.0",
+         "portValue":8080
+      }
+	 },
+	 "name": "ingress_listener",
+   "filterChains":[
+      {
+         "filters":[
+            {
+               "name":"envoy.filters.network.http_connection_manager",
+               "typedConfig":{
+                  "@type":"type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "httpFilters":[
+                     {
+                        "name":"com.google.espv2.filters.http.path_matcher",
+                        "typedConfig":{
+                           "@type":"type.googleapis.com/espv2.api.envoy.http.path_matcher.FilterConfig",
+                           "rules":[
+                              {
+                                 "operation":"endpoints.examples.bookstore.Bookstore.DeleteBook",
+                                 "pattern":{
+                                    "httpMethod":"DELETE",
+                                    "uriTemplate":"/v1/shelves/{shelf}/books/{book}"
+                                 }
+                              },
+                              {
+                                 "operation":"endpoints.examples.bookstore.Bookstore.DeleteBook",
+                                 "pattern":{
+                                    "httpMethod":"POST",
+                                    "uriTemplate":"/endpoints.examples.bookstore.Bookstore/DeleteBook"
+                                 }
+                              },
+                              {
+                                 "operation":"endpoints.examples.bookstore.Bookstore.GetBook",
+                                 "pattern":{
+                                    "httpMethod":"GET",
+                                    "uriTemplate":"/v1/shelves/{shelf}/books/{book}"
+                                 }
+                              },
+                              {
+                                 "operation":"endpoints.examples.bookstore.Bookstore.GetBook",
+                                 "pattern":{
+                                    "httpMethod":"POST",
+                                    "uriTemplate":"/endpoints.examples.bookstore.Bookstore/GetBook"
+                                 }
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "name":"envoy.filters.http.jwt_authn",
+                        "typedConfig":{
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication",
+                           "filterStateRules":{
+                              "name":"com.google.espv2.filters.http.path_matcher.operation",
+                              "requires":{
+                                 "endpoints.examples.bookstore.Bookstore.GetBook":{
+                                    "requiresAny":{
+                                       "requirements":[
+                                          {
+                                             "providerName":"firebase1"
+                                          },
+                                          {
+                                             "providerName":"firebase2"
+                                          }
+                                       ]
+                                    }
+                                 }
+                              }
+                           },
+                           "providers":{
+                              "firebase1":{
+                                 "audiences": [
+                                     "https://bookstore.endpoints.project123.cloud.goog"
+                                 ],
+                                 "forward": true,
+                                 "forwardPayloadHeader":"X-Endpoint-API-UserInfo",
+                                 "fromHeaders":[
+                                    {
+                                       "name":"Authorization",
+                                       "valuePrefix":"Bearer "
+                                    },
+                                    {
+                                       "name":"X-Goog-Iap-Jwt-Assertion"
+                                    }
+                                 ],
+                                 "fromParams":[
+                                    "access_token"
+                                 ],
+                                 "issuer":"https://test_issuer.google.com/",
+                                 "payloadInMetadata":"jwt_payloads",
+                                 "remoteJwks":{
+                                    "cacheDuration":"300s",
+                                    "httpUri":{
+                                       "cluster":"$JWKSURI:443",
+                                       "timeout":"5s",
+                                       "uri":"$JWKSURI"
+                                    }
+                                 }
+                              },
+                              "firebase2":{
+                                 "audiences": [
+                                     "https://bookstore.endpoints.project123.cloud.goog"
+                                 ],
+                                 "forward": true,
+                                 "forwardPayloadHeader":"X-Endpoint-API-UserInfo",
+                                 "fromHeaders":[
+                                    {
+                                       "name":"Authorization",
+                                       "valuePrefix":"Bearer "
+                                    },
+                                    {
+                                       "name":"X-Goog-Iap-Jwt-Assertion"
+                                    }
+                                 ],
+                                 "fromParams":[
+                                    "access_token"
+                                 ],
+                                 "issuer":"https://test_issuer.google.com/",
+                                 "payloadInMetadata":"jwt_payloads",
+                                 "remoteJwks":{
+                                    "cacheDuration":"300s",
+                                    "httpUri":{
+                                       "cluster":"$JWKSURI:443",
+                                       "timeout":"5s",
+                                       "uri":"$JWKSURI"
+                                    }
+                                 }
+                              }
+                           }
+                        }
+                     },
+                     {
+                        "name":"envoy.filters.http.grpc_web"
+                     },
+                     {
+                        "name":"envoy.filters.http.grpc_stats",
+                        "typedConfig":{
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
+                           "emitFilterState":true,
+                           "statsForAllMethods":false
+                        }
+                     },
+                     {
+                        "name":"envoy.filters.http.router",
+                        "typedConfig":{
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
+                       		 "suppressEnvoyHeaders": true
+                        }
+                     }
+                  ],
+                  "routeConfig":{
+                     "name":"local_route",
+                     "virtualHosts":[
+                        {
+                           "domains":[
+                              "*"
+                           ],
+                           "name":"backend",
+                           "routes":[
+                              {
+                                 "match":{
+                                    "prefix":"/"
+                                 },
+                                 "route":{
+                                    "cluster":"%s",
+                                    "timeout":"15s"
+                                 }
+                              }
+                           ]
+                        }
+                     ]
+                  },
+                  "upgradeConfigs": [{"upgradeType": "websocket"}],
+                  "commonHttpProtocolOptions":{"headersWithUnderscoresAction":"REJECT_REQUEST"},
+                  "statPrefix":"ingress_http",
+                  "useRemoteAddress":false,
+                  "xffNumTrustedHops":2
+               }
+            }
+         ]
+      }
+   ]
+}`, testBackendClusterName)
+
+	FakeServiceConfigForGrpcWithServiceControl = fmt.Sprintf(`{
+                "name":"%s",
+                "id": "2017-05-01r0",
+                "endpoints" : [{"name": "%s"}],
+                "producer_project_id":"%s",
+                "control" : {
+                    "environment": "servicecontrol.googleapis.com"
+                },
+                "logging": {
+                    "producerDestinations": [{
+                    "logs": [
+                          "endpoints_log"
+                       ],
+                    "monitoredResource": "api"
+                   }
+                   ]
+                },
+                "logs": [
+                    {
+                       "name": "endpoints_log"
+                    }
+                ],
+                "apis":[
+                    {
+                        "name":"%s",
+                        "version":"v1",
+                        "syntax":"SYNTAX_PROTO3",
+                        "sourceContext": {
+                            "fileName": "bookstore.proto"
+                        },
+                        "methods":[
+                            {
+                                "name": "ListShelves"
+                            },
+                            {
+                                "name": "CreateShelf"
+                            }
+                        ]
+                    }
+                ],
+                "http": {
+                    "rules": [
+                        {
+                            "selector": "endpoints.examples.bookstore.Bookstore.ListShelves",
+                            "get": "/v1/shelves"
+                        },
+                        {
+                            "selector": "endpoints.examples.bookstore.Bookstore.CreateShelf",
+                            "post": "/v1/shelves",
+                            "body": "shelf"
+                        }
+                    ]
+                }
+            }`, TestFetchListenersProjectName, TestFetchListenersEndpointName, testProjectID, TestFetchListenersEndpointName)
+
+	WantedListenerForGrpcWithServiceControl = fmt.Sprintf(`{
+   "address":{
+      "socketAddress":{
+         "address":"0.0.0.0",
+         "portValue":8080
+      }
+	 },
+	 "name": "ingress_listener",
+   "filterChains":[
+      {
+         "filters":[
+            {
+               "name":"envoy.filters.network.http_connection_manager",
+               "typedConfig":{
+                  "@type":"type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "httpFilters":[
+                     {
+                        "name":"com.google.espv2.filters.http.path_matcher",
+                        "typedConfig":{
+                           "@type":"type.googleapis.com/espv2.api.envoy.http.path_matcher.FilterConfig",
+                           "rules":[
+                              {
+                                 "operation":"endpoints.examples.bookstore.Bookstore.CreateShelf",
+                                 "pattern":{
+                                    "httpMethod":"POST",
+                                    "uriTemplate":"/v1/shelves"
+                                 }
+                              },
+                              {
+                                 "operation":"endpoints.examples.bookstore.Bookstore.CreateShelf",
+                                 "pattern":{
+                                    "httpMethod":"POST",
+                                    "uriTemplate":"/endpoints.examples.bookstore.Bookstore/CreateShelf"
+                                 }
+                              },
+                              {
+                                 "operation":"endpoints.examples.bookstore.Bookstore.ListShelves",
+                                 "pattern":{
+                                    "httpMethod":"GET",
+                                    "uriTemplate":"/v1/shelves"
+                                 }
+                              },
+                              {
+                                 "operation":"endpoints.examples.bookstore.Bookstore.ListShelves",
+                                 "pattern":{
+                                    "httpMethod":"POST",
+                                    "uriTemplate":"/endpoints.examples.bookstore.Bookstore/ListShelves"
+                                 }
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "name":"com.google.espv2.filters.http.service_control",
+                        "typedConfig":{
+                           "@type":"type.googleapis.com/espv2.api.envoy.http.service_control.FilterConfig",
+                           "imdsToken":{
+                              "cluster":"metadata-cluster",
+                              "timeout":"5s",
+                              "uri":"http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token"
+                           },
+                           "gcpAttributes":{
+                              "platform":"GCE(ESPv2)"
+                           },
+                           "generatedHeaderPrefix":"X-Endpoint-",
+                           "requirements":[
+                              {
+                                 "apiName":"endpoints.examples.bookstore.Bookstore",
+                                 "apiVersion":"v1",
+                                 "operationName":"endpoints.examples.bookstore.Bookstore.CreateShelf",
+                                 "serviceName":"bookstore.endpoints.project123.cloud.goog"
+                              },
+                              {
+                                 "apiName":"endpoints.examples.bookstore.Bookstore",
+                                 "apiVersion":"v1",
+                                 "operationName":"endpoints.examples.bookstore.Bookstore.ListShelves",
+                                 "serviceName":"bookstore.endpoints.project123.cloud.goog"
+                              }
+                           ],
+                           "scCallingConfig":{
+                              "networkFailOpen":true
+                           },
+                           "serviceControlUri":{
+                              "cluster":"service-control-cluster",
+                              "timeout":"5s",
+                              "uri":"https://servicecontrol.googleapis.com/v1/services/"
+                           },
+                           "services":[
+                              {
+                                 "backendProtocol":"grpc",
+                                 "jwtPayloadMetadataName":"jwt_payloads",
+                                 "producerProjectId":"%v",
+                                 "serviceConfig":{
+                                    "logging":{
+                                       "producerDestinations":[
+                                          {
+                                             "logs":[
+                                                "endpoints_log"
+                                             ],
+                                             "monitoredResource":"api"
+                                          }
+                                       ]
+                                    },
+                                    "logs":[
+                                       {
+                                          "name":"endpoints_log"
+                                       }
+                                    ]
+                                 },
+                                 "serviceConfigId":"%v",
+                                 "serviceName":"%v"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "name":"envoy.filters.http.grpc_web"
+                     },
+                     {
+                        "name":"envoy.filters.http.grpc_stats",
+                        "typedConfig":{
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
+                           "emitFilterState":true,
+                           "statsForAllMethods":false
+                        }
+                     },
+                     {
+                        "name":"envoy.filters.http.router",
+                        "typedConfig":{
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
+                       		 "suppressEnvoyHeaders": true
+                        }
+                     }
+                  ],
+                  "routeConfig":{
+                     "name":"local_route",
+                     "virtualHosts":[
+                        {
+                           "domains":[
+                              "*"
+                           ],
+                           "name":"backend",
+                           "routes":[
+                              {
+                                 "match":{
+                                    "prefix":"/"
+                                 },
+                                 "route":{
+                                    "cluster":"%s",
+                                    "timeout":"15s"
+                                 }
+                              }
+                           ]
+                        }
+                     ]
+                  },
+                  "upgradeConfigs": [{"upgradeType": "websocket"}],
+                  "statPrefix":"ingress_http",
+                  "commonHttpProtocolOptions":{"headersWithUnderscoresAction":"REJECT_REQUEST"},
+                  "useRemoteAddress":false,
+                  "xffNumTrustedHops":2
+               }
+            }
+         ]
+      }
+   ]
+}`, testProjectID, TestFetchListenersConfigID, TestFetchListenersProjectName, testBackendClusterName)
+
+	FakeServiceConfigForHttp = fmt.Sprintf(`{
+                "name":"bookstore.endpoints.project123.cloud.goog",
+                "id": "2017-05-01r0",
+                "apis":[
+                    {
+                        "name": "1.echo_api_endpoints_cloudesf_testing_cloud_goog",
+                        "methods": [
+                          {
+                             "name": "Echo_Auth_Jwt"
+                          },
+                          {
+                             "name": "Echo"
+                          }
+                        ]
+                    }
+                ],
+                "endpoints": [{"name": "%s"}],
+                "http": {
+                    "rules": [
+                        {
+                            "selector": "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo_Auth_Jwt",
+                            "get": "/auth/info/googlejwt"
+                        },
+                        {
+                            "selector": "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo",
+                            "post": "/echo",
+                            "body": "message"
+                        }
+                    ]
+                },
+                "authentication": {
+                    "providers": [
+                        {
+                            "id": "firebase",
+                            "issuer": "https://test_issuer.google.com/",
+                            "jwks_uri": "$JWKSURI",
+                            "audiences": "test_audience1, test_audience2 "
+                        }
+                    ],
+                    "rules": [
+                        {
+                            "selector": "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo"
+                        },
+                        {
+                            "selector": "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo_Auth_Jwt",
+                            "requirements": [
+                                {
+                                    "provider_id": "firebase",
+                                    "audiences": "test_audience1"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }`, TestFetchListenersEndpointName)
+
+	WantedListenerForHttp = fmt.Sprintf(`{
+   "address":{
+      "socketAddress":{
+         "address":"0.0.0.0",
+         "portValue":8080
+      }
+   },
+	 "name": "ingress_listener",
+   "filterChains":[
+      {
+         "filters":[
+            {
+               "name":"envoy.filters.network.http_connection_manager",
+               "typedConfig":{
+                  "@type":"type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "httpFilters":[
+                     {
+                        "name":"com.google.espv2.filters.http.path_matcher",
+                        "typedConfig":{
+                           "@type":"type.googleapis.com/espv2.api.envoy.http.path_matcher.FilterConfig",
+                           "rules":[
+                              {
+                                 "operation":"1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo",
+                                 "pattern":{
+                                    "httpMethod":"POST",
+                                    "uriTemplate":"/echo"
+                                 }
+                              },
+                              {
+                                 "operation":"1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo_Auth_Jwt",
+                                 "pattern":{
+                                    "httpMethod":"GET",
+                                    "uriTemplate":"/auth/info/googlejwt"
+                                 }
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "name":"envoy.filters.http.jwt_authn",
+                        "typedConfig":{
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication",
+                           "filterStateRules":{
+                              "name":"com.google.espv2.filters.http.path_matcher.operation",
+                              "requires":{
+                                 "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo_Auth_Jwt":{
+                                    "providerAndAudiences":{
+                                       "audiences":[
+                                          "test_audience1"
+                                       ],
+                                       "providerName":"firebase"
+                                    }
+                                 }
+                              }
+                           },
+                           "providers":{
+                              "firebase":{
+                                 "audiences":[
+                                    "test_audience1",
+                                    "test_audience2"
+                                 ],
+                                 "forward": true,
+                                 "forwardPayloadHeader":"X-Endpoint-API-UserInfo",
+                                 "fromHeaders":[
+                                    {
+                                       "name":"Authorization",
+                                       "valuePrefix":"Bearer "
+                                    },
+                                    {
+                                       "name":"X-Goog-Iap-Jwt-Assertion"
+                                    }
+                                 ],
+                                 "fromParams":[
+                                    "access_token"
+                                 ],
+                                 "issuer":"https://test_issuer.google.com/",
+                                 "payloadInMetadata":"jwt_payloads",
+                                 "remoteJwks":{
+                                    "cacheDuration":"300s",
+                                    "httpUri":{
+                                       "cluster":"$JWKSURI:443",
+                                       "timeout":"5s",
+                                       "uri":"$JWKSURI"
+                                    }
+                                 }
+                              }
+                           }
+                        }
+                     },
+                     {
+                        "name":"envoy.filters.http.router",
+                        "typedConfig":{
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
+                       		 "suppressEnvoyHeaders": true
+                        }
+                     }
+                  ],
+                  "routeConfig":{
+                     "name":"local_route",
+                     "virtualHosts":[
+                        {
+                           "domains":[
+                              "*"
+                           ],
+                           "name":"backend",
+                           "routes":[
+                              {
+                                 "match":{
+                                    "prefix":"/"
+                                 },
+                                 "route":{
+                                    "cluster":"%s",
+                                    "timeout":"15s"
+                                 }
+                              }
+                           ]
+                        }
+                     ]
+                  },
+                  "upgradeConfigs": [{"upgradeType": "websocket"}],
+                  "statPrefix":"ingress_http",
+                  "commonHttpProtocolOptions":{"headersWithUnderscoresAction":"REJECT_REQUEST"},
+                  "useRemoteAddress":false,
+                  "xffNumTrustedHops":2
+               }
+            }
+         ]
+      }
+   ]
+}`, testBackendClusterName)
+
+	FakeServiceConfigAllowCorsTracingDebug = fmt.Sprintf(`{
+                "name":"%s",
+                "id": "2017-05-01r0",
+                "producer_project_id":"%s",
+                "control" : {
+                    "environment": "servicecontrol.googleapis.com"
+                },
+                "apis":[
+                    {
+                        "name":"1.echo_api_endpoints_cloudesf_testing_cloud_goog",
+                        "methods":[
+                            {
+                                "name": "Simplegetcors"
+                            }
+                        ]
+                    }
+                ],
+                "http": {
+                    "rules": [
+                        {
+                            "selector": "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Simplegetcors",
+                            "get": "/simplegetcors"
+                        }
+                    ]
+                },
+                "endpoints": [
+                    {
+                        "name": "%s",
+                        "allow_cors": true
+                    }
+                ]
+            }`, TestFetchListenersProjectName, testProjectID, TestFetchListenersProjectName)
+
+	WantedListenersAllowCorsTracingDebug = `{
+   "address":{
+      "socketAddress":{
+         "address":"0.0.0.0",
+         "portValue":8080
+      }
+	 },
+	 "name": "ingress_listener",
+   "filterChains":[
+      {
+         "filters":[
+            {
+               "name":"envoy.filters.network.http_connection_manager",
+               "typedConfig":{
+                  "@type":"type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "httpFilters":[
+                     {
+                        "name":"com.google.espv2.filters.http.path_matcher",
+                        "typedConfig":{
+                           "@type":"type.googleapis.com/espv2.api.envoy.http.path_matcher.FilterConfig",
+                           "rules":[
+                              {
+                                 "operation":"1.echo_api_endpoints_cloudesf_testing_cloud_goog.CORS_simplegetcors",
+                                 "pattern":{
+                                    "httpMethod":"OPTIONS",
+                                    "uriTemplate":"/simplegetcors"
+                                 }
+                              },
+                              {
+                                 "operation":"1.echo_api_endpoints_cloudesf_testing_cloud_goog.Simplegetcors",
+                                 "pattern":{
+                                    "httpMethod":"GET",
+                                    "uriTemplate":"/simplegetcors"
+                                 }
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "name":"com.google.espv2.filters.http.service_control",
+                        "typedConfig":{
+                           "@type":"type.googleapis.com/espv2.api.envoy.http.service_control.FilterConfig",
+                           "imdsToken":{
+                              "cluster":"metadata-cluster",
+                              "timeout":"5s",
+                              "uri":"http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token"
+                           },
+                           "gcpAttributes":{
+                              "platform":"GCE(ESPv2)"
+                           },
+                           "generatedHeaderPrefix":"X-Endpoint-",
+                           "requirements":[
+                              {
+                                 "apiKey":{
+                                    "allowWithoutApiKey":true
+                                 },
+                                 "apiName": "1.echo_api_endpoints_cloudesf_testing_cloud_goog",
+                                 "operationName":"1.echo_api_endpoints_cloudesf_testing_cloud_goog.CORS_simplegetcors",
+                                 "serviceName":"bookstore.endpoints.project123.cloud.goog"
+                              },
+                              {
+                                 "apiName": "1.echo_api_endpoints_cloudesf_testing_cloud_goog",
+                                 "operationName":"1.echo_api_endpoints_cloudesf_testing_cloud_goog.Simplegetcors",
+                                 "serviceName":"bookstore.endpoints.project123.cloud.goog"
+                              }
+                           ],
+                           "scCallingConfig":{
+                              "networkFailOpen":true
+                           },
+                           "serviceControlUri":{
+                              "cluster":"service-control-cluster",
+                              "timeout":"5s",
+                              "uri":"https://servicecontrol.googleapis.com/v1/services/"
+                           },
+                           "services":[
+                              {
+                                 "backendProtocol":"http1",
+                                 "jwtPayloadMetadataName":"jwt_payloads",
+                                 "producerProjectId":"project123",
+                                 "serviceConfig":{},
+                                 "serviceConfigId":"2017-05-01r0",
+                                 "serviceName":"bookstore.endpoints.project123.cloud.goog"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "name":"envoy.filters.http.router",
+                        "typedConfig":{
+                           "@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
+                           "startChildSpan":true
+                        }
+                     }
+                  ],
+                  "routeConfig":{
+                     "name":"local_route",
+                     "virtualHosts":[
+                        {
+                           "domains":[
+                              "*"
+                           ],
+                           "name":"backend",
+                           "routes":[
+                              {
+                                 "match":{
+                                    "prefix":"/"
+                                 },
+                                 "route":{
+                                    "cluster":"bookstore.endpoints.project123.cloud.goog_local",
+                                    "timeout":"15s"
+                                 }
+                              }
+                           ]
+                        }
+                     ]
+                  },
+                  "upgradeConfigs": [{"upgradeType": "websocket"}],
+                  "statPrefix":"ingress_http",
+                  "commonHttpProtocolOptions":{"headersWithUnderscoresAction":"REJECT_REQUEST"},
+                  "tracing":{
+
+                  },
+                  "useRemoteAddress":false,
+                  "xffNumTrustedHops":2
+               }
+            }
+         ]
+      }
+   ]
+}`
+)

--- a/src/go/configmanager/testdata/test_fixed_mode_dynamic_routing.go
+++ b/src/go/configmanager/testdata/test_fixed_mode_dynamic_routing.go
@@ -16,8 +16,7 @@ package testdata
 
 var (
 	// These resources must be ordered in alphabetic order by name
-	FakeWantedClustersForDynamicRouting = []string{
-		`
+	FakeWantedClustersForDynamicRouting = []string{`
 {
   "name": "echo-api.endpoints.cloudesf-testing.cloud.goog_local",
   "type": "LOGICAL_DNS",


### PR DESCRIPTION
Unit tests of configmanagers failed with data racing on the [global data](https://github.com/GoogleCloudPlatform/esp-v2/blob/f08675f8efcc78190eabfbe000ed557d99b26c7d/src/go/configmanager/config_manager_test.go#L1809) and they are read by mockServer to serve requests and written by test in the same time.

So, make the raced data protected by mutex.
    
Details:
- add `safeData` to guard data with mutex
- cleanup until functions
- put literal testData into `testdata` folder
