### PR TITLE
Fix C++ unit test timeouts by increasing test size

### DIFF
--- a/src/api_proxy/path_matcher/BUILD
+++ b/src/api_proxy/path_matcher/BUILD
@@ -30,7 +30,6 @@ envoy_basic_cc_library(
 
 envoy_cc_test(
     name = "http_template_test",
-    size = "small",
     srcs = ["http_template_test.cc"],
     repository = "@envoy",
     deps = [
@@ -40,7 +39,6 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "path_matcher_test",
-    size = "small",
     srcs = ["path_matcher_test.cc"],
     repository = "@envoy",
     deps = [
@@ -65,7 +63,6 @@ envoy_basic_cc_library(
 
 envoy_cc_test(
     name = "variable_binding_utils_test",
-    size = "small",
     srcs = [
         "variable_binding_utils_test.cc",
     ],

--- a/src/api_proxy/service_control/BUILD
+++ b/src/api_proxy/service_control/BUILD
@@ -29,7 +29,6 @@ envoy_basic_cc_library(
 
 envoy_cc_test(
     name = "check_response_test",
-    size = "small",
     srcs = [
         "check_response_test.cc",
     ],
@@ -41,7 +40,6 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "request_builder_test",
-    size = "small",
     srcs = [
         "request_builder_test.cc",
     ],
@@ -66,7 +64,6 @@ envoy_basic_cc_library(
 
 envoy_cc_test(
     name = "logs_metrics_loader_test",
-    size = "small",
     srcs = [
         "logs_metrics_loader_test.cc",
     ],

--- a/src/api_proxy/utils/BUILD
+++ b/src/api_proxy/utils/BUILD
@@ -39,7 +39,6 @@ envoy_basic_cc_library(
 
 envoy_cc_test(
     name = "version_test",
-    size = "small",
     srcs = [
         "version_test.cc",
     ],

--- a/src/envoy/http/backend_auth/BUILD
+++ b/src/envoy/http/backend_auth/BUILD
@@ -56,7 +56,6 @@ envoy_cc_library(
 
 envoy_cc_test(
     name = "config_parser_impl_test",
-    size = "small",
     srcs = [
         "config_parser_impl_test.cc",
     ],
@@ -100,7 +99,6 @@ envoy_cc_library(
 
 envoy_cc_test(
     name = "filter_test",
-    size = "small",
     srcs = [
         "filter_test.cc",
     ],

--- a/src/envoy/http/backend_routing/BUILD
+++ b/src/envoy/http/backend_routing/BUILD
@@ -45,7 +45,6 @@ envoy_cc_library(
 
 envoy_cc_test(
     name = "filter_test",
-    size = "small",
     srcs = [
         "filter_test.cc",
     ],
@@ -61,7 +60,6 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "filter_config_test",
-    size = "small",
     srcs = [
         "filter_config_test.cc",
     ],

--- a/src/envoy/http/path_matcher/BUILD
+++ b/src/envoy/http/path_matcher/BUILD
@@ -56,7 +56,6 @@ envoy_cc_library(
 
 envoy_cc_test(
     name = "filter_config_test",
-    size = "small",
     srcs = [
         "filter_config_test.cc",
     ],
@@ -71,7 +70,6 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "filter_test",
-    size = "small",
     srcs = [
         "filter_test.cc",
     ],

--- a/src/envoy/http/service_control/BUILD
+++ b/src/envoy/http/service_control/BUILD
@@ -94,7 +94,6 @@ envoy_cc_library(
 
 envoy_cc_test(
     name = "client_cache_test",
-    size = "small",
     srcs = [
         "client_cache_test.cc",
     ],
@@ -222,7 +221,6 @@ envoy_cc_library(
 
 envoy_cc_test(
     name = "config_parser_test",
-    size = "small",
     srcs = [
         "config_parser_test.cc",
     ],
@@ -236,7 +234,6 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "filter_test",
-    size = "small",
     srcs = [
         "filter_test.cc",
     ],
@@ -254,7 +251,6 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "filter_stats_test",
-    size = "small",
     srcs = [
         "filter_stats_test.cc",
     ],
@@ -268,7 +264,6 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "handler_test",
-    size = "small",
     srcs = [
         "handler_impl_test.cc",
         "handler_utils_test.cc",
@@ -289,7 +284,6 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "http_call_test",
-    size = "small",
     srcs = [
         "http_call_test.cc",
     ],

--- a/src/envoy/token/BUILD
+++ b/src/envoy/token/BUILD
@@ -136,7 +136,6 @@ envoy_cc_fuzz_test(
 
 envoy_cc_test(
     name = "imds_token_info_test",
-    size = "small",
     srcs = ["imds_token_info_test.cc"],
     repository = "@envoy",
     deps = [
@@ -159,7 +158,6 @@ envoy_cc_fuzz_test(
 
 envoy_cc_test(
     name = "iam_token_info_test",
-    size = "small",
     srcs = ["iam_token_info_test.cc"],
     repository = "@envoy",
     deps = [
@@ -171,7 +169,6 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "token_subscriber_test",
-    size = "small",
     srcs = ["token_subscriber_test.cc"],
     repository = "@envoy",
     deps = [
@@ -185,7 +182,6 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "service_account_token_test",
-    size = "small",
     srcs = ["sa_token_generator_test.cc"],
     repository = "@envoy",
     deps = [

--- a/src/envoy/utils/BUILD
+++ b/src/envoy/utils/BUILD
@@ -25,7 +25,6 @@ envoy_cc_library(
 
 envoy_cc_test(
     name = "json_struct_test",
-    size = "small",
     srcs = [
         "json_struct_test.cc",
     ],
@@ -66,7 +65,6 @@ envoy_cc_library(
 
 envoy_cc_test(
     name = "filter_state_utils_test",
-    size = "small",
     srcs = ["filter_state_utils_test.cc"],
     repository = "@envoy",
     deps = [
@@ -90,7 +88,6 @@ envoy_cc_library(
 
 envoy_cc_test(
     name = "http_header_utils_test",
-    size = "small",
     srcs = ["http_header_utils_test.cc"],
     repository = "@envoy",
     deps = [


### PR DESCRIPTION
Our asan presubmit is timing out most of the time: https://testgrid.k8s.io/googleoss-esp-v2-presubmit#presubmit-asan

Just remove the `small` size attribute for all tests. Envoy unit tests default to `medium`. This should increase the time limit to 300s instead of 60s.

Removed for all tests because I don't see the benefit of guessing test sizes per target.

Signed-off-by: Teju Nareddy <nareddyt@google.com>