### PR TITLE
b/157896907: More stats for Backend Auth, handle rejections properly.

### DIFF
--- a/src/envoy/http/backend_auth/README.md
+++ b/src/envoy/http/backend_auth/README.md
@@ -18,3 +18,17 @@ This filter is designed to strongly integrate with the following filters:
 
 View the [backend auth configuration proto](../../../../api/envoy/http/backend_auth/config.proto)
 for inline documentation.
+
+## Statistics
+
+This filter records statistics.
+
+### Counters
+
+- `denied_by_no_token`: Number of API Consumer requests that are denied due to the filter
+ missing a token needed for the request.
+- `denied_by_no_operation`: Number of API Consumer requests that are denied due to missing filter state.
+- `allowed_by_no_configured_rules`: Number of API Consumer requests that are allowed through
+ without modification. Occurs when the operation is not configured for auth rewrite.
+- `token_added`: Number of API Consumer requests that are allowed through with
+ modification for backend authentication.

--- a/src/envoy/http/backend_auth/filter.h
+++ b/src/envoy/http/backend_auth/filter.h
@@ -37,6 +37,9 @@ class Filter : public Envoy::Http::PassThroughDecoderFilter,
                                                  bool) override;
 
  private:
+  void rejectRequest(Envoy::Http::Code code, absl::string_view error_msg,
+                     absl::string_view details);
+
   const FilterConfigSharedPtr config_;
 };
 

--- a/src/envoy/http/backend_auth/filter_config.h
+++ b/src/envoy/http/backend_auth/filter_config.h
@@ -26,11 +26,11 @@ namespace backend_auth {
 /**
  * All stats for the backend auth filter. @see stats_macros.h
  */
-
-// clang-format off
-#define ALL_BACKEND_AUTH_FILTER_STATS(COUNTER)     \
-  COUNTER(token_added)                             \
-// clang-format on
+#define ALL_BACKEND_AUTH_FILTER_STATS(COUNTER) \
+  COUNTER(denied_by_no_operation)              \
+  COUNTER(denied_by_no_token)                  \
+  COUNTER(allowed_by_no_configured_rules)      \
+  COUNTER(token_added)
 
 /**
  * Wrapper struct for backend auth filter stats. @see stats_macros.h
@@ -38,7 +38,6 @@ namespace backend_auth {
 struct FilterStats {
   ALL_BACKEND_AUTH_FILTER_STATS(GENERATE_COUNTER_STRUCT)
 };
-
 
 class FilterConfig {
  public:
@@ -52,6 +51,6 @@ class FilterConfig {
 using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;
 
 }  // namespace backend_auth
-}  // namespace HttpFilters
-}  // namespace Extensions
-}  // namespace Envoy
+}  // namespace http_filters
+}  // namespace envoy
+}  // namespace espv2

--- a/src/envoy/http/backend_routing/README.md
+++ b/src/envoy/http/backend_routing/README.md
@@ -31,7 +31,7 @@ This filter records statistics.
 - `denied_by_no_path`: Number of API Consumer requests that are denied due to invalid path header.
 - `denied_by_no_operation`: Number of API Consumer requests that are denied due to missing filter state.
 - `allowed_by_no_configured_rules`: Number of API Consumer requests that are allowed through
- without modification. Occurs when the operation is not configured for dynamic routing.
+ without modification. Occurs when the operation is not configured for path rewrite.
 - `append_path_to_address_request`: Number of API Consumer requests that are
  accepted and translated as APPEND_PATH_TO_ADDRESS.
 - `constant_address_request`: Number of API Consumer requests that are


### PR DESCRIPTION
Very similar to #164, but for Backend Auth.
- Reject request when filter state is missing.
- Increment counters for different code paths.
- Test and document stats.

Signed-off-by: Teju Nareddy <nareddyt@google.com>