### PR TITLE
SC Config Path - Security review #7 fixes

### DIFF
--- a/api/envoy/http/service_control/config.proto
+++ b/api/envoy/http/service_control/config.proto
@@ -80,7 +80,7 @@ message Service {
 
   // Minimum amount of time (milliseconds) between sending intermediate
   // reports on a stream.
-  uint64 min_stream_report_interval_ms = 8 [(validate.rules).uint64.gte = 100];
+  uint64 min_stream_report_interval_ms = 8;
 
   // The array of jwt payloads demanded to be logged
   repeated string log_jwt_payloads = 9;

--- a/api/envoy/http/service_control/config.proto
+++ b/api/envoy/http/service_control/config.proto
@@ -80,7 +80,7 @@ message Service {
 
   // Minimum amount of time (milliseconds) between sending intermediate
   // reports on a stream.
-  uint64 min_stream_report_interval_ms = 8;
+  uint64 min_stream_report_interval_ms = 8 [(validate.rules).uint64.gte = 100];
 
   // The array of jwt payloads demanded to be logged
   repeated string log_jwt_payloads = 9;
@@ -131,8 +131,7 @@ message FilterConfig {
 
   // The prefix added to generated headers
   string generated_header_prefix = 9 [(validate.rules).string = {
-    well_known_regex: HTTP_HEADER_VALUE,
-    strict: false,
+    well_known_regex: HTTP_HEADER_NAME,
     min_len: 1,
   }];
 }

--- a/src/api_proxy/service_control/request_builder.cc
+++ b/src/api_proxy/service_control/request_builder.cc
@@ -1154,14 +1154,12 @@ Status RequestBuilder::FillAllocateQuotaRequest(
   (*labels)[kServiceControlUserAgent] = kUserAgent;
   (*labels)[kServiceControlServiceAgent] = get_service_agent();
 
-  if (info.metric_cost_vector) {
-    for (auto metric : *info.metric_cost_vector) {
-      MetricValueSet* value_set = operation->add_quota_metrics();
-      value_set->set_metric_name(metric.first);
-      MetricValue* value = value_set->add_metric_values();
-      const auto& cost = metric.second;
-      value->set_int64_value(cost <= 0 ? 1 : cost);
-    }
+  for (auto metric : info.metric_cost_vector) {
+    MetricValueSet* value_set = operation->add_quota_metrics();
+    value_set->set_metric_name(metric.first);
+    MetricValue* value = value_set->add_metric_values();
+    const auto& cost = metric.second;
+    value->set_int64_value(cost <= 0 ? 1 : cost);
   }
 
   return Status::OK;

--- a/src/api_proxy/service_control/request_builder_test.cc
+++ b/src/api_proxy/service_control/request_builder_test.cc
@@ -190,8 +190,7 @@ TEST_F(RequestBuilderTest, FillGoodAllocateQuotaRequestTest) {
   std::vector<std::pair<std::string, int>> metric_cost_vector = {
       {"metric_first", 1}, {"metric_second", 2}};
 
-  QuotaRequestInfo info;
-  info.metric_cost_vector = &metric_cost_vector;
+  QuotaRequestInfo info{metric_cost_vector};
 
   FillOperationInfo(&info);
   FillAllocateQuotaRequestInfo(&info);
@@ -208,9 +207,8 @@ TEST_F(RequestBuilderTest, FillAllocateQuotaRequestNoMethodNameTest) {
   std::vector<std::pair<std::string, int>> metric_cost_vector = {
       {"metric_first", 1}, {"metric_second", 2}};
 
-  QuotaRequestInfo info;
+  QuotaRequestInfo info{metric_cost_vector};
   FillOperationInfo(&info);
-  info.metric_cost_vector = &metric_cost_vector;
   info.client_ip = "1.2.3.4";
   info.referer = "referer";
   info.method_name = "";

--- a/src/api_proxy/service_control/request_info.h
+++ b/src/api_proxy/service_control/request_info.h
@@ -122,7 +122,10 @@ struct CheckResponseInfo {
 struct QuotaRequestInfo : public OperationInfo {
   std::string method_name;
 
-  const std::vector<std::pair<std::string, int>>* metric_cost_vector;
+  const std::vector<std::pair<std::string, int>>& metric_cost_vector;
+
+  QuotaRequestInfo(const std::vector<std::pair<std::string, int>>& metric_costs)
+      : metric_cost_vector(metric_costs) {}
 };
 
 // Stores the information extracted from the quota response.

--- a/src/envoy/http/service_control/BUILD
+++ b/src/envoy/http/service_control/BUILD
@@ -122,6 +122,7 @@ envoy_cc_library(
         "//src/api_proxy/service_control:logs_metrics_loader_lib",
         "//src/envoy/token:token_subscriber_factory_lib",
         "@envoy//include/envoy/server:filter_config_interface",
+        "@envoy//source/common/common:assert_lib",
         "@envoy//source/common/common:empty_string",
         "@envoy//source/common/protobuf:utility_lib",
     ],

--- a/src/envoy/http/service_control/config_parser.h
+++ b/src/envoy/http/service_control/config_parser.h
@@ -64,6 +64,7 @@ class RequirementContext {
       const ::google::api::envoy::http::service_control::Requirement& config,
       const ServiceContext& service_ctx)
       : config_(config), service_ctx_(service_ctx) {
+    metric_costs_.reserve(config.metric_costs().size());
     for (const auto& metric_cost : config.metric_costs()) {
       metric_costs_.push_back(
           std::make_pair(metric_cost.name(), metric_cost.cost()));
@@ -77,8 +78,8 @@ class RequirementContext {
 
   const ServiceContext& service_ctx() const { return service_ctx_; }
 
-  const std::vector<std::pair<std::string, int>>* metric_costs() const {
-    return &metric_costs_;
+  const std::vector<std::pair<std::string, int>>& metric_costs() const {
+    return metric_costs_;
   }
 
  private:
@@ -98,7 +99,8 @@ class FilterConfigParser {
       const {
     return config_;
   }
-  const RequirementContext* FindRequirement(absl::string_view operation) const {
+  const RequirementContext* find_requirement(
+      absl::string_view operation) const {
     const auto requirement_it = requirements_map_.find(operation);
     if (requirement_it == requirements_map_.end()) {
       return nullptr;

--- a/src/envoy/http/service_control/config_parser.h
+++ b/src/envoy/http/service_control/config_parser.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <common/protobuf/utility.h>
 #include "absl/container/flat_hash_map.h"
 #include "absl/strings/string_view.h"
 
@@ -21,13 +22,19 @@
 #include "api/envoy/http/service_control/requirement.pb.h"
 #include "src/envoy/http/service_control/service_control_call.h"
 
-// Default minimum interval (milliseconds) for streaming reports.
-#define kDefaultMinStreamReportIntervalMs 10000
-
 namespace espv2 {
 namespace envoy {
 namespace http_filters {
 namespace service_control {
+
+namespace {
+// Default minimum interval (milliseconds) for streaming reports.
+constexpr int64_t kDefaultMinStreamReportIntervalMs = 10000;
+
+// The lower bound a user can configure the interval too.
+// This represents a realistic round-trip time for SC Report from GCP.
+constexpr int64_t kLowerBoundMinStreamReportIntervalMs = 100;
+}  // namespace
 
 class ServiceContext {
  public:
@@ -38,6 +45,12 @@ class ServiceContext {
     min_stream_report_interval_ms_ = config_.min_stream_report_interval_ms();
     if (!min_stream_report_interval_ms_) {
       min_stream_report_interval_ms_ = kDefaultMinStreamReportIntervalMs;
+    }
+    if (min_stream_report_interval_ms_ < kLowerBoundMinStreamReportIntervalMs) {
+      throw Envoy::ProtoValidationException(
+          absl::StrCat("min_stream_report_interval_ms must be larger than: ",
+                       kLowerBoundMinStreamReportIntervalMs),
+          config);
     }
   }
 

--- a/src/envoy/http/service_control/config_parser_test.cc
+++ b/src/envoy/http/service_control/config_parser_test.cc
@@ -131,6 +131,24 @@ requirements {
                           "Invalid service name");
 }
 
+TEST(ConfigParserTest, InvalidMinReportInterval) {
+  FilterConfig config;
+  const char kFilterInvalidService[] = R"(
+services {
+  service_name: "echo"
+  min_stream_report_interval_ms: 50
+}
+requirements {
+  service_name: "echo"
+  operation_name: "get_foo"
+})";
+  ASSERT_TRUE(TextFormat::ParseFromString(kFilterInvalidService, &config));
+  testing::NiceMock<MockServiceControlCallFactory> mock_factory;
+  EXPECT_THROW_WITH_REGEX(FilterConfigParser parser(config, mock_factory),
+                          Envoy::ProtoValidationException,
+                          "min_stream_report_interval_ms");
+}
+
 }  // namespace
 }  // namespace service_control
 }  // namespace http_filters

--- a/src/envoy/http/service_control/config_parser_test.cc
+++ b/src/envoy/http/service_control/config_parser_test.cc
@@ -58,19 +58,21 @@ requirements {
   testing::NiceMock<MockServiceControlCallFactory> mock_factory;
   FilterConfigParser parser(config, mock_factory);
 
-  EXPECT_EQ(parser.FindRequirement("get_foo")->config().operation_name(),
+  EXPECT_EQ(parser.find_requirement("get_foo")->config().operation_name(),
             "get_foo");
   EXPECT_EQ(
-      parser.FindRequirement("get_foo")->service_ctx().config().service_name(),
+      parser.find_requirement("get_foo")->service_ctx().config().service_name(),
       "echo");
 
-  EXPECT_EQ(parser.FindRequirement("post_bar")->config().operation_name(),
+  EXPECT_EQ(parser.find_requirement("post_bar")->config().operation_name(),
             "post_bar");
-  EXPECT_EQ(
-      parser.FindRequirement("post_bar")->service_ctx().config().service_name(),
-      "echo111");
+  EXPECT_EQ(parser.find_requirement("post_bar")
+                ->service_ctx()
+                .config()
+                .service_name(),
+            "echo111");
 
-  EXPECT_FALSE(parser.FindRequirement("non-existing-operation"));
+  EXPECT_FALSE(parser.find_requirement("non-existing-operation"));
 }
 
 TEST(ConfigParserTest, DuplicatedServiceNames) {

--- a/src/envoy/http/service_control/filter_stats.h
+++ b/src/envoy/http/service_control/filter_stats.h
@@ -24,7 +24,9 @@ namespace http_filters {
 namespace service_control {
 
 /**
- * General service control filter stats. @see stats_macros.h
+ * General service control filter stats.
+ * For description of each stat, @see the README.md for this filter.
+ * @see stats_macros.h
  */
 #define FILTER_STATS(COUNTER, HISTOGRAM) \
   COUNTER(allowed)                       \
@@ -40,7 +42,10 @@ namespace service_control {
   HISTOGRAM(overhead_time, Milliseconds)
 
 /**
- * Service control call status stats. @see stats_macros.h
+ * Service control call status stats.
+ * These match the canonical RPC status codes.
+ * https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
+ * @see stats_macros.h
  */
 #define CALL_STATUS_STATS(COUNTER) \
   COUNTER(OK)                      \

--- a/src/envoy/http/service_control/handler_impl.cc
+++ b/src/envoy/http/service_control/handler_impl.cc
@@ -83,7 +83,7 @@ ServiceControlHandlerImpl::ServiceControlHandlerImpl(
     return;
   }
 
-  require_ctx_ = cfg_parser_.FindRequirement(operation);
+  require_ctx_ = cfg_parser_.find_requirement(operation);
   if (!require_ctx_) {
     ENVOY_LOG(debug, "No requirement matched!");
     // Extract api-key to be used for Report for an operation without
@@ -211,11 +211,10 @@ void ServiceControlHandlerImpl::callQuota() {
     return;
   }
 
-  ::espv2::api_proxy::service_control::QuotaRequestInfo info;
-  fillOperationInfo(info);
-
+  ::espv2::api_proxy::service_control::QuotaRequestInfo info{
+      require_ctx_->metric_costs()};
   info.method_name = require_ctx_->config().operation_name();
-  info.metric_cost_vector = require_ctx_->metric_costs();
+  fillOperationInfo(info);
 
   // TODO: if quota cache is disabled, need to use in-flight
   // transport, need to save its cancel function.

--- a/src/envoy/http/service_control/service_control_call_impl.cc
+++ b/src/envoy/http/service_control/service_control_call_impl.cc
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "common/common/assert.h"
 #include "src/api_proxy/service_control/logs_metrics_loader.h"
 #include "src/envoy/http/service_control/service_control_call_impl.h"
 
@@ -138,18 +139,17 @@ ServiceControlCallImpl::ServiceControlCallImpl(
   });
 
   switch (filter_config_.access_token_case()) {
-    case FilterConfig::kImdsToken: {
+    case FilterConfig::kImdsToken:
       createImdsTokenSub();
-    } break;
-    case FilterConfig::kServiceAccountSecret: {
-      createTokenGen();
-    } break;
-    case FilterConfig::kIamToken: {
-      createIamTokenSub();
-    } break;
-    default:
-      ENVOY_LOG(error, "No access token set!");
       break;
+    case FilterConfig::kServiceAccountSecret:
+      createTokenGen();
+      break;
+    case FilterConfig::kIamToken:
+      createIamTokenSub();
+      break;
+    default:
+      NOT_REACHED_GCOVR_EXCL_LINE;
   }
 
   if (config.has_service_config()) {


### PR DESCRIPTION
Various minor changes based on comments:
- `min_stream_report_interval_ms` should have a realistic minimum value enforced. Do this in our `ConfigParser` instead of proto config because we allow 0 value as default.
- `generated_header_prefix` is a header name, not value. Stricter validation here.
- `metric_cost_vector` should be stored as reference not array. It will never be null. Testing will be easier (test the values match, not the pointers).
- Rename `find_requirement` to match naming in the file. Seems we have some conflicting naming across filters, we can fix later.
- Clarify filter stats.
- Exception invalid access token case (already validated by protoc-gen-validate, so it should never be reached).

Signed-off-by: Teju Nareddy <nareddyt@google.com>