### PR TITLE
Document pass through filters, handle duplicate operation names

### DIFF
--- a/src/envoy/http/backend_auth/README.md
+++ b/src/envoy/http/backend_auth/README.md
@@ -4,6 +4,9 @@ This filter enables proxy-to-service authorization when sending requests to back
 via Dynamic Routing. If authentication is configured inside a backend rule,
 this filter overwrites the `Authorization` header with corresponding identity token.
 
+_Note_: this is a pass through filter. If the requested operation is not configured in the
+filter config, the request will pass through unmodified.
+
 ## Prerequisites
 
 This filter will not function unless the following filters appear earlier in the filter chain:

--- a/src/envoy/http/backend_auth/config_parser_impl_test.cc
+++ b/src/envoy/http/backend_auth/config_parser_impl_test.cc
@@ -44,6 +44,26 @@ class ConfigParserImplTest : public ::testing::Test {
   std::unique_ptr<FilterConfigParser> config_parser_;
 };
 
+TEST_F(ConfigParserImplTest, DuplicateOperationThrows) {
+  const char filter_config[] = R"(
+imds_token {
+  uri: "this-is-uri"
+  cluster: "this-is-cluster"
+}
+rules {
+  operation: "operation-dup"
+  jwt_audience: "audience-foo"
+}
+rules {
+  operation: "operation-dup"
+  jwt_audience: "audience-bar"
+}
+)";
+
+  EXPECT_THROW_WITH_REGEX(setUp(filter_config), Envoy::ProtoValidationException,
+                          "Duplicated operation");
+}
+
 TEST_F(ConfigParserImplTest, IamIdTokenWithServiceAccountAsAccessToken) {
   const char filter_config[] = R"(
 iam_token {

--- a/src/envoy/http/backend_auth/filter.cc
+++ b/src/envoy/http/backend_auth/filter.cc
@@ -66,8 +66,10 @@ FilterHeadersStatus Filter::decodeHeaders(RequestHeaderMap& headers, bool) {
   ENVOY_LOG(debug, "Found operation: {}", operation);
   absl::string_view audience = config_->cfg_parser().getAudience(operation);
   if (audience.empty()) {
-    // This filter does not need to set a JWT Token for this operation.
-    // If the request already has an Authorization header, it will be preserved.
+    // By design, we only want to apply the filter to operations that are in the
+    // configuration. Otherwise, let it pass through (no need to add a JWT for
+    // this request). If the request already has an Authorization header, it
+    // will be preserved.
     config_->stats().allowed_by_no_configured_rules_.inc();
     return FilterHeadersStatus::Continue;
   }

--- a/src/envoy/http/backend_routing/README.md
+++ b/src/envoy/http/backend_routing/README.md
@@ -7,6 +7,9 @@ this filter overwrites the `:path` header with corresponding remote backend addr
 For more information on configuration and usage, see
 [Understanding Path Translation](https://cloud.google.com/endpoints/docs/openapi/openapi-extensions#understanding_path_translation).
 
+_Note_: this is a pass through filter. If the requested operation is not configured in the
+filter config, the request will pass through unmodified.
+
 ## Prerequisites
 
 This filter will not function unless the following filters appear earlier in the filter chain:

--- a/src/envoy/http/backend_routing/filter_config.h
+++ b/src/envoy/http/backend_routing/filter_config.h
@@ -53,7 +53,12 @@ class FilterConfig : public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
       : proto_config_(proto_config),
         stats_(generateStats(stats_prefix, context.scope())) {
     for (const auto& rule : proto_config_.rules()) {
-      backend_routing_map_[rule.operation()] = &rule;
+      auto insert = backend_routing_map_.insert({rule.operation(), &rule});
+      if (!insert.second) {
+        throw Envoy::ProtoValidationException(
+            absl::StrCat("Duplicated operation: ", rule.operation()),
+            proto_config_);
+      }
     }
   }
 


### PR DESCRIPTION
Duplicate operation names should never happen in our control plane, but validation is recommended in security review.