### PR TITLE
b/158192303: #2 fix data race in rollout_id_change_fetcher_test.go

### DIFF
--- a/src/go/serviceconfig/rollout_id_change_fetcher_test.go
+++ b/src/go/serviceconfig/rollout_id_change_fetcher_test.go
@@ -17,6 +17,7 @@ package serviceconfig
 import (
 	"fmt"
 	"net/http"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -65,22 +66,29 @@ func TestRolloutIdChangeFetcherSetDetectRolloutIdChangeTimer(t *testing.T) {
 	accessToken := func() (string, time.Duration, error) { return "token", time.Duration(60), nil }
 	cif := NewRolloutIdChangeDetector(&http.Client{}, serviceControlServer.GetURL(), "service-name", accessToken)
 
-	cnt := 0
-	wantCnt := 3
+	// `unsafeCnt` will be accessed in muilti-goroutine so please access it using atomic
+	// library.
+	var unsafeCnt, wantCnt uint32
+	unsafeCnt = 0
+	wantCnt = 3
+
 	wantRolloutId := fmt.Sprintf("test-rollout-id-%v", wantCnt)
-	cif.SetDetectRolloutIdChangeTimer(time.Millisecond*100, func() {
-		cnt += 1
+	cif.SetDetectRolloutIdChangeTimer(time.Millisecond*50, func() {
+		atomic.AddUint32(&unsafeCnt, 1)
+
 		// Update rolloutId so the callback will be called.
 		// It will be updated only three times.
-		if cnt < wantCnt {
-			serviceRolloutId = fmt.Sprintf("test-rollout-id-%v", cnt+1)
+		curCnt := atomic.LoadUint32(&unsafeCnt)
+		if curCnt < wantCnt {
+			serviceRolloutId = fmt.Sprintf("test-rollout-id-%v", curCnt+1)
 			serviceControlServer.SetResp(genFakeReport(serviceRolloutId))
 		}
 	})
 
-	time.Sleep(time.Millisecond * 500)
-	if cnt != wantCnt {
-		t.Fatalf("want callback called by %v times, get %v times", wantCnt, cnt)
+	time.Sleep(time.Millisecond * 1500)
+	curCnt := atomic.LoadUint32(&unsafeCnt)
+	if curCnt != wantCnt {
+		t.Fatalf("want callback called by %v times, get %v times", wantCnt, curCnt)
 	}
 
 	if cif.curRolloutId != wantRolloutId {

--- a/src/go/serviceconfig/rollout_id_change_fetcher_test.go
+++ b/src/go/serviceconfig/rollout_id_change_fetcher_test.go
@@ -78,7 +78,11 @@ func TestRolloutIdChangeFetcherSetDetectRolloutIdChangeTimer(t *testing.T) {
 		}
 	})
 
+	// Sleep long enough to make sure the callback is called 3 times so that `cnt`
+	// won't be updated in callback since no update on rolloutId. Otherwise, it
+	// will cause data race on `cnt`.
 	time.Sleep(time.Millisecond * 1000)
+
 	if cnt != wantCnt {
 		t.Fatalf("want callback called by %v times, get %v times", wantCnt, cnt)
 	}


### PR DESCRIPTION
The root cause is the `cnt` is read and written in main goroutine and timer callback goroutine. Fix it by extending the sleep time.

Verify it in cl/316995062 by running the TSan Test 4k times.