### PR TITLE
Handle unknown enums properly

### DIFF
--- a/api/envoy/http/backend_routing/config.proto
+++ b/api/envoy/http/backend_routing/config.proto
@@ -34,7 +34,7 @@ message BackendRoutingRule {
   }
 
   PathTranslation path_translation = 4
-      [(validate.rules).enum = { not_in: [ 0 ] }];
+      [(validate.rules).enum = { in: [ 1, 2 ] }];
 
   // Prefix used when re-writing the path for the backend.
   string path_prefix = 3 [(validate.rules).string = {

--- a/tests/fuzz/corpus/backend_routing_filter/crash-bad-path-translation.prototxt
+++ b/tests/fuzz/corpus/backend_routing_filter/crash-bad-path-translation.prototxt
@@ -1,0 +1,10 @@
+config {
+  rules {
+    operation: "&"
+    path_prefix: ";;;;;;;;;;;;;;;;;;;;;;;google.protobuf.Enu;C;;"
+    path_translation: 1197
+  }
+}
+binding_query_params: ";;;;;;;;;;;;;;;;;;;;;;;;C;;"
+downstream_request {
+}


### PR DESCRIPTION
[Proto documentation](https://developers.google.com/protocol-buffers/docs/reference/cpp-generated#enum) explains that unknown enum values will be preserved. Use `protoc-gen-validate` to force only valid proto configs.

Ref: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=23098
Signed-off-by: Teju Nareddy <nareddyt@google.com>