### PR TITLE
Validate against negative timeouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,15 +133,15 @@ test-debug: format
 	@echo "--> running unit tests"
 	@go test -v ./src/go/... --logtostderr
 
-test-envoy: format
+test-envoy: clang-format
 	@echo "--> running envoy's unit tests"
 	@CC=clang-8 CXX=clang++-8  bazel test //src/...
 
-test-envoy-asan: format
+test-envoy-asan: clang-format
 	@echo "--> running envoy's unit tests (asan)"
 	@CC=clang-8 CXX=clang++-8 ASAN_SYMBOLIZER_PATH=$(which llvm-symbolizer-8) bazel test --config=clang-asan  --test_output=errors //src/...
 
-test-envoy-tsan: format
+test-envoy-tsan: clang-format
 	@echo "--> running envoy's unit tests (tsan)"
 	@CC=clang-8 CXX=clang++-8 ASAN_SYMBOLIZER_PATH=$(which llvm-symbolizer-8) bazel test --config=clang-tsan  --test_output=errors  //src/...
 

--- a/api/envoy/http/common/base.proto
+++ b/api/envoy/http/common/base.proto
@@ -61,8 +61,10 @@ message HttpUri {
   string cluster = 2 [(validate.rules).string.min_bytes = 1];
 
   // The timeout.
-  google.protobuf.Duration timeout = 3
-      [(validate.rules).duration.required = true];
+  google.protobuf.Duration timeout = 3 [(validate.rules).duration = {
+    required: true,
+    gte: { seconds: 0 }
+  }];
 }
 
 // Duplicate DataSource from envoy for self containment.

--- a/tests/fuzz/corpus/service_control_filter/crash-negative-timeout.prototxt
+++ b/tests/fuzz/corpus/service_control_filter/crash-negative-timeout.prototxt
@@ -1,0 +1,38 @@
+config {
+  services {
+    service_name: "echo-api.endpoints.cloudesf-testing.cloud.goog"
+    service_config_id: ","
+    producer_project_id: "producer-project"
+    backend_protocol: "]"
+    log_request_headers: ":path"
+    log_request_headers: "api"
+    log_request_headers: ":path"
+    min_stream_report_interval_ms: 8575352176
+    log_jwt_payloads: "\014Q1\000\000\000\000\000"
+    jwt_payload_metadata_name: "jwt_payloads"
+  }
+  requirements {
+    service_name: "echo-api.endpoints.cloudesf-testing.cloud.goog"
+    operation_name: "205*"
+    api_version: "]WWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWWW"
+  }
+  gcp_attributes {
+  }
+  imds_token {
+    uri: "]"
+    cluster: "["
+    timeout {
+      seconds: -6148914383199002583
+    }
+  }
+  generated_header_prefix: "api"
+}
+downstream_request {
+}
+upstream_response {
+}
+stream_info {
+  start_time: 13565952
+}
+sidestream_response {
+}


### PR DESCRIPTION
Now that we use the timeout variable, we should ensure it's not negative. Otherwise, crash will occur.

Ref: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=23618&q=esp-v2&can=2

Signed-off-by: Teju Nareddy <nareddyt@google.com>