### PR TITLE
Create FilterStats in client_cache

### DIFF
--- a/src/envoy/http/service_control/client_cache.cc
+++ b/src/envoy/http/service_control/client_cache.cc
@@ -189,24 +189,20 @@ void ClientCache::initHttpRequestSetting(const FilterConfig& filter_config) {
                         : kReportDefaultNumberOfRetries;
 }
 
-void ClientCache::collectCallStatus(CallStatusStats& filter_stats,
+void ClientCache::collectCallStatus(CallStatusStats& call_stats,
                                     const Code& code) {
-  if (destruct_mode_) {
-    return;
-  }
-  ServiceControlFilterStats::collectCallStatus(filter_stats, code);
+  ServiceControlFilterStats::collectCallStatus(call_stats, code);
 }
 
 ClientCache::ClientCache(
     const ::espv2::api::envoy::v6::http::service_control::Service& config,
-    const FilterConfig& filter_config, ServiceControlFilterStats& filter_stats,
-    Envoy::Upstream::ClusterManager& cm, Envoy::TimeSource& time_source,
-    Envoy::Event::Dispatcher& dispatcher,
+    const FilterConfig& filter_config, const std::string& stats_prefix,
+    Envoy::Stats::Scope& scope, Envoy::Upstream::ClusterManager& cm,
+    Envoy::TimeSource& time_source, Envoy::Event::Dispatcher& dispatcher,
     std::function<const std::string&()> sc_token_fn,
     std::function<const std::string&()> quota_token_fn)
     : config_(config),
-      filter_stats_(filter_stats),
-      destruct_mode_(false),
+      filter_stats_(ServiceControlFilterStats::create(stats_prefix, scope)),
       time_source_(time_source) {
   ServiceControlClientOptions options(getCheckAggregationOptions(),
                                       getQuotaAggregationOptions(),

--- a/src/envoy/http/service_control/client_cache.h
+++ b/src/envoy/http/service_control/client_cache.h
@@ -46,13 +46,11 @@ class ClientCache : public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
       const ::espv2::api::envoy::v6::http::service_control::Service& config,
       const ::espv2::api::envoy::v6::http::service_control::FilterConfig&
           filter_config,
-      ServiceControlFilterStats& filter_stats,
+      const std::string& stats_prefix, Envoy::Stats::Scope& scope,
       Envoy::Upstream::ClusterManager& cm, Envoy::TimeSource& time_source,
       Envoy::Event::Dispatcher& dispatcher,
       std::function<const std::string&()> sc_token_fn,
       std::function<const std::string&()> quota_token_fn);
-
-  ~ClientCache() { destruct_mode_ = true; };
 
   CancelFunc callCheck(
       const ::google::api::servicecontrol::v1::CheckRequest& request,
@@ -104,14 +102,10 @@ class ClientCache : public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
 
   const ::espv2::api::envoy::v6::http::service_control::Service& config_;
 
-  // Filter statistics. When service control client is destroyed in worker
-  // thread, filter_stats_ may have already been destructed in the main thread,
-  // so don't collect stats at this point.
-  ServiceControlFilterStats& filter_stats_;
+  // Filter statistics.
+  ServiceControlFilterStats filter_stats_;
 
-  // Whether the client_cache is being destructed.
-  bool destruct_mode_;
-
+  // network fail policy
   bool network_fail_open_;
 
   // the configurable timeouts

--- a/src/envoy/http/service_control/filter_stats.h
+++ b/src/envoy/http/service_control/filter_stats.h
@@ -97,19 +97,10 @@ struct ServiceControlFilterStats {
   static void collectCallStatus(
       CallStatusStats& filter_stats,
       const ::google::protobuf::util::error::Code& code);
-};
 
-class ServiceControlFilterStatBase {
- public:
-  ServiceControlFilterStatBase(const std::string& prefix,
-                               Envoy::Stats::Scope& scope)
-      : stats_(generateStats(prefix, scope)) {}
-
-  ServiceControlFilterStats& stats() { return stats_; }
-
- private:
-  static ServiceControlFilterStats generateStats(const std::string& prefix,
-                                                 Envoy::Stats::Scope& scope) {
+  // Create a stat struct.
+  static ServiceControlFilterStats create(const std::string& prefix,
+                                          Envoy::Stats::Scope& scope) {
     const std::string final_prefix = prefix + "service_control.";
 
     return {{FILTER_STATS(POOL_COUNTER_PREFIX(scope, final_prefix),
@@ -121,9 +112,6 @@ class ServiceControlFilterStatBase {
             {CALL_STATUS_STATS(
                 POOL_COUNTER_PREFIX(scope, final_prefix + "report."))}};
   }
-
-  // The stats for the filter.
-  ServiceControlFilterStats stats_;
 };
 
 }  // namespace service_control

--- a/src/envoy/http/service_control/filter_stats_test.cc
+++ b/src/envoy/http/service_control/filter_stats_test.cc
@@ -36,11 +36,9 @@ class FilterStatsTest : public ::testing::Test {
  public:
   FilterStatsTest()
       : context_(),
-        statBase_(ServiceControlFilterStatBase("", context_.scope_)),
-        stats_(statBase_.stats()) {}
+        stats_(ServiceControlFilterStats::create("", context_.scope_)) {}
 
   NiceMock<MockFactoryContext> context_;
-  ServiceControlFilterStatBase statBase_;
   ServiceControlFilterStats stats_;
 
   void runTest(

--- a/src/envoy/http/service_control/filter_test.cc
+++ b/src/envoy/http/service_control/filter_test.cc
@@ -46,11 +46,12 @@ const Status kBadStatus(Code::UNAUTHENTICATED, "test");
 class ServiceControlFilterTest : public ::testing::Test {
  protected:
   ServiceControlFilterTest()
-      : stats_base_(Envoy::EMPTY_STRING, mock_stats_scope_) {}
+      : stats_(ServiceControlFilterStats::create(Envoy::EMPTY_STRING,
+                                                 mock_stats_scope_)) {}
 
   void SetUp() override {
-    filter_ = std::make_unique<ServiceControlFilter>(stats_base_.stats(),
-                                                     mock_handler_factory_);
+    filter_ =
+        std::make_unique<ServiceControlFilter>(stats_, mock_handler_factory_);
     filter_->setDecoderFilterCallbacks(mock_decoder_callbacks_);
 
     mock_handler_ = new testing::NiceMock<MockServiceControlHandler>();
@@ -69,7 +70,7 @@ class ServiceControlFilterTest : public ::testing::Test {
   ServiceControlHandlerPtr mock_handler_ptr_;
   testing::NiceMock<Envoy::MockBuffer> mock_buffer_;
   testing::NiceMock<Envoy::Stats::MockIsolatedStatsStore> mock_stats_scope_;
-  ServiceControlFilterStatBase stats_base_;
+  ServiceControlFilterStats stats_;
   Envoy::Http::TestRequestHeaderMapImpl req_headers_;
   Envoy::Http::TestRequestTrailerMapImpl req_trailer_;
   Envoy::Http::TestResponseHeaderMapImpl resp_headers_;

--- a/src/envoy/http/service_control/handler_utils_test.cc
+++ b/src/envoy/http/service_control/handler_utils_test.cc
@@ -294,8 +294,8 @@ TEST(ServiceControlUtils, FillLatency) {
 
   const std::chrono::nanoseconds zero = std::chrono::nanoseconds(0);
   testing::NiceMock<Envoy::Stats::MockIsolatedStatsStore> mock_stats_scope;
-  ServiceControlFilterStatBase stats_base(Envoy::EMPTY_STRING,
-                                          mock_stats_scope);
+  ServiceControlFilterStats stats(
+      ServiceControlFilterStats::create(Envoy::EMPTY_STRING, mock_stats_scope));
 
   const TestCase test_cases[] = {
       // Test: If the stream has not ended, all stay their defaults.
@@ -376,7 +376,7 @@ TEST(ServiceControlUtils, FillLatency) {
     }
 
     LatencyInfo info;
-    fillLatency(mock_stream_info, info, stats_base.stats());
+    fillLatency(mock_stream_info, info, stats);
     EXPECT_EQ(test.expect_request_time_ms, info.request_time_ms);
     EXPECT_EQ(test.expect_backend_time_ms, info.backend_time_ms);
     EXPECT_EQ(test.expect_overhead_time_ms, info.overhead_time_ms);


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

asan test found a memory use-after-free case: the log is [here](https://storage.googleapis.com/oss-prow/pr-logs/pull/GoogleCloudPlatform_esp-v2/214/ESPv2-presubmit-asan/1278081084902346755/build-log.txt).  

Issue:
* FilterStat is owned by FilterConfig, but is used by client_cache.  
* FilterConfig is freed when a new Listener comes, but client_cache is stored in TLS(thread local slot) for each worker thread.
* client_cache may have some async operations, such as timer flushed out the cached items,  or cache destructor flushed out the cached items,  these items need to send to remote server, and its callback will update the filter_stats.  But filter_stats may be freed.

Changes:
* create filter_stats on client_cache.  This should be fine, as long as they are using the same stats_prefix and stat_scope,  they will be using the same stats. 

