### PR TITLE
b/161168963: Include Access Loggers in JSON Any resolver

### DIFF
--- a/src/go/util/marshal.go
+++ b/src/go/util/marshal.go
@@ -26,6 +26,8 @@ import (
 	pmpb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/v6/http/path_matcher"
 	scpb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/v6/http/service_control"
 
+	accessfilepb "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/file/v3"
+	accessgrpcpb "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/grpc/v3"
 	transcoderpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/grpc_json_transcoder/v3"
 	gspb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/grpc_stats/v3"
 	jwtpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/jwt_authn/v3"
@@ -93,6 +95,14 @@ var Resolver = FuncResolver(func(url string) (proto.Message, error) {
 		return new(routerpb.Router), nil
 	case "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext":
 		return new(tlspb.UpstreamTlsContext), nil
+	case "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog":
+		return new(accessfilepb.FileAccessLog), nil
+	case "type.googleapis.com/envoy.extensions.access_loggers.grpc.v3.HttpGrpcAccessLogConfig":
+		return new(accessgrpcpb.HttpGrpcAccessLogConfig), nil
+	case "type.googleapis.com/envoy.extensions.access_loggers.grpc.v3.TcpGrpcAccessLogConfig":
+		return new(accessgrpcpb.TcpGrpcAccessLogConfig), nil
+	case "type.googleapis.com/envoy.extensions.access_loggers.grpc.v3.CommonGrpcAccessLogConfig":
+		return new(accessgrpcpb.CommonGrpcAccessLogConfig), nil
 	default:
 		return nil, fmt.Errorf("unexpected protobuf.Any with url: %s", url)
 	}

--- a/src/go/util/marshal_test.go
+++ b/src/go/util/marshal_test.go
@@ -15,15 +15,55 @@
 package util
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
+	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
 
+	accessfilepb "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/file/v3"
+	accessgrpcpb "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/grpc/v3"
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
 	scpb "google.golang.org/genproto/googleapis/api/servicecontrol/v1"
 	smpb "google.golang.org/genproto/googleapis/api/servicemanagement/v1"
 )
+
+func TestResolver(t *testing.T) {
+	tests := []struct {
+		msg proto.Message
+	}{
+		{
+			msg: &accessfilepb.FileAccessLog{},
+		},
+		{
+			msg: &accessgrpcpb.HttpGrpcAccessLogConfig{},
+		},
+		{
+			msg: &accessgrpcpb.TcpGrpcAccessLogConfig{},
+		},
+		{
+			msg: &accessgrpcpb.CommonGrpcAccessLogConfig{},
+		},
+	}
+
+	marshaler := &jsonpb.Marshaler{
+		OrigName:    true,
+		AnyResolver: Resolver,
+	}
+
+	for _, tc := range tests {
+		any, err := ptypes.MarshalAny(tc.msg)
+		if err != nil {
+			t.Fatalf("MarshalAny(%v) failed: %v", tc.msg, err)
+		}
+		buf := &bytes.Buffer{}
+		if err := marshaler.Marshal(buf, any); err != nil {
+			t.Errorf("Marshal(_, %v) failed: %v", any, err)
+		}
+	}
+}
 
 func TestUnmarshalBytesToPbMessage(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
- Add unit test for Resolver which fails for these extensions.
- Add extensions to `marshal.go` so that these pass.

While access loggers are not added by configgenerator, GCS Runner will fail to parse configs which have these extensions. In the future, additional extensions may be needed.