### PR TITLE
b/161293641: Support ESP versions in `gcloud_build_image`

### DIFF
--- a/docker/serverless/gcloud_build_image
+++ b/docker/serverless/gcloud_build_image
@@ -12,9 +12,13 @@
 #   gcloud endpoints services list
 #   gcloud endpoints configs list --service=${SERVICE}
 # Use the latest one for the CONFIG_ID
+#
+# The script will use the latest ESPv2 version by default.
+# Use the -v option to pass in a custom version (example: -v 2.9).
 
-# Default to the release image if not specified
-BASE_IMAGE=gcr.io/endpoints-release/endpoints-runtime-serverless:2
+# Default to the latest released ESPv2 version.
+BASE_IMAGE_NAME="gcr.io/endpoints-release/endpoints-runtime-serverless"
+ESP_TAG="2"
 
 function error_exit() {
   # ${BASH_SOURCE[1]} is the file name of the caller.
@@ -22,12 +26,16 @@ function error_exit() {
   exit ${2:-1}
 }
 
-while getopts :c:s:p:i: arg; do
+while getopts :c:s:p:v:i: arg; do
   case ${arg} in
     c) CONFIG_ID="${OPTARG}";;
     s) SERVICE="${OPTARG}";;
     p) PROJECT="${OPTARG}";;
-    i) BASE_IMAGE="${OPTARG}";;
+    v) ESP_TAG="${OPTARG}";;
+    i)
+      BASE_IMAGE="${OPTARG}"
+      ESP_FULL_VERSION="custom"
+      ;;
     \?) error_exit "Unrecognized argument -${OPTARG}";;
   esac
 done
@@ -35,7 +43,33 @@ done
 [[ -n "${PROJECT}" ]] || error_exit "Missing required PROJECT"
 [[ -n "${SERVICE}" ]] || error_exit "Missing required SERVICE"
 [[ -n "${CONFIG_ID}" ]] || error_exit "Missing required CONFIG_ID"
+
+# If user did not pass in custom image, then form the fully-qualified base image.
+if [ -z "${BASE_IMAGE}" ]; then
+  BASE_IMAGE="${BASE_IMAGE_NAME}:${ESP_TAG}"
+fi;
 echo "Using base image: ${BASE_IMAGE}"
+
+# If user did not pass in a custom image, then determine the ESP version.
+if [ -z "${ESP_FULL_VERSION}" ]; then
+  echo "Determining fully-qualified ESP version for tag: ${ESP_TAG}"
+
+  ALL_TAGS=$(gcloud container images list-tags "${BASE_IMAGE_NAME}" \
+      --filter="tags~^${ESP_TAG}$" \
+      --format="value(tags)")
+  IFS=',' read -ra TAGS_ARRAY <<< "${ALL_TAGS}"
+
+  if [ ${#TAGS_ARRAY[@]} -eq 0 ]; then
+    error_exit "Did not find ESP version: ${ESP_TAG}"
+  fi;
+
+  # Get the longest tag by creating an array indexed by tag length. Then use the last element.
+  for item in "${TAGS_ARRAY[@]}"; do
+    TAGS_BY_LENGTH[${#item}]=$item
+  done
+  ESP_FULL_VERSION="${TAGS_BY_LENGTH[-1]}"
+fi
+echo "Building image for ESP version: ${ESP_FULL_VERSION}"
 
 cd "$(mktemp -d /tmp/docker.XXXX)"
 
@@ -59,7 +93,7 @@ USER envoy
 ENTRYPOINT ["/env_start_proxy.py"]
 EOF
 
-NEW_IMAGE="gcr.io/${PROJECT}/endpoints-runtime-serverless:${SERVICE}-${CONFIG_ID}"
+NEW_IMAGE="gcr.io/${PROJECT}/endpoints-runtime-serverless:${ESP_FULL_VERSION}-${SERVICE}-${CONFIG_ID}"
 gcloud builds submit --tag "${NEW_IMAGE}" . --project="${PROJECT}"
 )
 

--- a/prow/e2e-gcloud-build-image.sh
+++ b/prow/e2e-gcloud-build-image.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# E2E test for gcloud_build_image script.
+
+# Fail on any error.
+set -eo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROJECT_NAME="cloudesf-testing"
+
+# gcloud config
+gcloud config set project "${PROJECT_NAME}"
+export CLOUDSDK_CORE_DISABLE_PROMPTS=1
+
+# Use a service that is not used for any other tests.
+SERVICE_NAME="hellogrpc.endpoints.cloudesf-testing.cloud.goog"
+CONFIG_ID="2018-11-11r0"
+
+function error_exit() {
+  # ${BASH_SOURCE[1]} is the file name of the caller.
+  echo "${BASH_SOURCE[1]}: line ${BASH_LINENO[0]}: ${1:-Unknown Error.} (exit ${2:-1})" 1>&2
+  exit ${2:-1}
+}
+
+function formImageName() {
+  local expected_version=$1
+  echo "gcr.io/${PROJECT_NAME}/endpoints-runtime-serverless:${expected_version}-${SERVICE_NAME}-${CONFIG_ID}"
+}
+
+function cleanupOldImage() {
+  local image_name=$1
+  echo "Cleaning up old image if it exists (ignore any errors in the output here)."
+  if gcloud container images describe "${image_name}"; then
+    gcloud container images delete "${image_name}"
+  fi
+}
+
+function expectImage() {
+  local image_name=$1
+  gcloud container images describe "${image_name}" || error_exit "Failed to find image: ${image_name}"
+  echo "Successfully verified image exists: ${image_name}"
+}
+
+echo "=== Test 1: Specify a fully qualified version. ==="
+EXPECTED_IMAGE_NAME=$(formImageName "2.7.0")
+cleanupOldImage "${EXPECTED_IMAGE_NAME}"
+${ROOT}/docker/serverless/gcloud_build_image \
+    -s "${SERVICE_NAME}" \
+    -c "${CONFIG_ID}" \
+    -p "${PROJECT_NAME}" \
+    -v "2.7.0"
+expectImage "${EXPECTED_IMAGE_NAME}"
+
+echo "=== Test 2: Specify a minor version. ==="
+EXPECTED_IMAGE_NAME=$(formImageName "2.4.0")
+cleanupOldImage "${EXPECTED_IMAGE_NAME}"
+${ROOT}/docker/serverless/gcloud_build_image \
+    -s "${SERVICE_NAME}" \
+    -c "${CONFIG_ID}" \
+    -p "${PROJECT_NAME}" \
+    -v "2.4"
+expectImage "${EXPECTED_IMAGE_NAME}"
+
+echo "=== Test 3: Sepcify an invalid version fails. ==="
+if ${ROOT}/docker/serverless/gcloud_build_image \
+    -s "${SERVICE_NAME}" \
+    -c "${CONFIG_ID}" \
+    -p "${PROJECT_NAME}" \
+    -v "2.11.47"; then
+  error_exit "Script should fail for invalid version."
+else
+  echo "Script failed as expected."
+fi
+
+echo "=== Test 4: Specify a custom image. ==="
+EXPECTED_IMAGE_NAME=$(formImageName "custom")
+cleanupOldImage "${EXPECTED_IMAGE_NAME}"
+${ROOT}/docker/serverless/gcloud_build_image \
+    -s "${SERVICE_NAME}" \
+    -c "${CONFIG_ID}" \
+    -p "${PROJECT_NAME}" \
+    -i "gcr.io/cloudesf-testing/apiproxy-serverless:gcloud-build-image-test"
+expectImage "${EXPECTED_IMAGE_NAME}"
+
+echo "=== Test 5: When no ESP version is specified, the script uses the latest ESPv2 release. ==="
+# Knowing the latest ESP version number is hard, it depends on what is tagged in GCR.
+# This is a chicken and egg problem, because `gcloud_build_image` uses that.
+# That means we don't have a reliable way of checking if the output is correct.
+# So just test the script passes, and allow the developer to manually verify the output.
+${ROOT}/docker/serverless/gcloud_build_image \
+    -s "${SERVICE_NAME}" \
+    -c "${CONFIG_ID}" \
+    -p "${PROJECT_NAME}"
+echo ">>> WARNING: For the test above, manually verify the output version of the image is expected."

--- a/prow/e2e-gcloud-build-image.sh
+++ b/prow/e2e-gcloud-build-image.sh
@@ -2,6 +2,20 @@
 
 # E2E test for gcloud_build_image script.
 
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Fail on any error.
 set -eo pipefail
 
@@ -13,8 +27,8 @@ gcloud config set project "${PROJECT_NAME}"
 export CLOUDSDK_CORE_DISABLE_PROMPTS=1
 
 # Use a service that is not used for any other tests.
-SERVICE_NAME="hellogrpc.endpoints.cloudesf-testing.cloud.goog"
-CONFIG_ID="2018-11-11r0"
+SERVICE_NAME="gcloud-build-image-e2e-test.endpoints.cloudesf-testing.cloud.goog"
+CONFIG_ID="2020-07-20r1"
 
 function error_exit() {
   # ${BASH_SOURCE[1]} is the file name of the caller.

--- a/tests/e2e/scripts/cloud-run/deploy.sh
+++ b/tests/e2e/scripts/cloud-run/deploy.sh
@@ -305,7 +305,7 @@ function setup() {
     echo "Deploying ESPv2 ${BACKEND_SERVICE_NAME} on Cloud Run(Anthos)"
   fi
 
-  deployProxy "gcr.io/${PROJECT_ID}/endpoints-runtime-serverless:${ENDPOINTS_SERVICE_NAME}-${endpoints_service_config_id}"  "${proxy_args}"
+  deployProxy "gcr.io/${PROJECT_ID}/endpoints-runtime-serverless:custom-${ENDPOINTS_SERVICE_NAME}-${endpoints_service_config_id}"  "${proxy_args}"
 }
 
 function test_disable_auth() {


### PR DESCRIPTION
Changes:
- When building the custom image, include the fully-qualified ESP version number in the tag.
- Allow the user to specify a ESP version via `-v` flag. If not specified, defaults to `2` (latest release).

Examples:
```
./gcloud_build_image -s service -c config -p project
gcr.io/project/endpoints-runtime-serverless:2.13.0-service-config
```
```
./gcloud_build_image -s service -c config -p project -v 2.11
gcr.io/project/endpoints-runtime-serverless:2.11.0-service-config
```
```
./gcloud_build_image -s service -c config -p project -i gcr.io/cloudesf-testing/apiproxy-serverless:dev-fdc79992f0db0af82dc0f5848ec196b753f4668f
gcr.io/project/endpoints-runtime-serverless:custom-service-config
```

Ref: https://groups.google.com/g/google-cloud-endpoints/c/MsQIqfwbJ74
Signed-off-by: Teju Nareddy <nareddyt@google.com>