### PR TITLE
b/161168963: Add StatsConfig and StatsSink to Resolver

### DIFF
--- a/src/go/util/marshal.go
+++ b/src/go/util/marshal.go
@@ -106,12 +106,8 @@ var Resolver = FuncResolver(func(url string) (proto.Message, error) {
 		return new(accessgrpcpb.CommonGrpcAccessLogConfig), nil
 	case "type.googleapis.com/envoy.config.metrics.v3.StatsConfig":
 		return new(statspb.StatsConfig), nil
-	case "type.googleapis.com/envoy.config.metrics.v3.StatsMatcher":
-		return new(statspb.StatsMatcher), nil
 	case "type.googleapis.com/envoy.config.metrics.v3.StatsSink":
 		return new(statspb.StatsSink), nil
-	case "type.googleapis.com/envoy.config.metrics.v3.TagSpecifier":
-		return new(statspb.TagSpecifier), nil
 	default:
 		return nil, fmt.Errorf("unexpected protobuf.Any with url: %s", url)
 	}

--- a/src/go/util/marshal.go
+++ b/src/go/util/marshal.go
@@ -108,6 +108,8 @@ var Resolver = FuncResolver(func(url string) (proto.Message, error) {
 		return new(statspb.StatsConfig), nil
 	case "type.googleapis.com/envoy.config.metrics.v3.StatsSink":
 		return new(statspb.StatsSink), nil
+	case "type.googleapis.com/envoy.config.metrics.v3.StatsdSink":
+		return new(statspb.StatsdSink), nil
 	default:
 		return nil, fmt.Errorf("unexpected protobuf.Any with url: %s", url)
 	}

--- a/src/go/util/marshal.go
+++ b/src/go/util/marshal.go
@@ -26,6 +26,7 @@ import (
 	pmpb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/v7/http/path_matcher"
 	scpb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/v7/http/service_control"
 
+	statspb "github.com/envoyproxy/go-control-plane/envoy/config/metrics/v3"
 	accessfilepb "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/file/v3"
 	accessgrpcpb "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/grpc/v3"
 	transcoderpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/grpc_json_transcoder/v3"
@@ -103,6 +104,14 @@ var Resolver = FuncResolver(func(url string) (proto.Message, error) {
 		return new(accessgrpcpb.TcpGrpcAccessLogConfig), nil
 	case "type.googleapis.com/envoy.extensions.access_loggers.grpc.v3.CommonGrpcAccessLogConfig":
 		return new(accessgrpcpb.CommonGrpcAccessLogConfig), nil
+	case "type.googleapis.com/envoy.config.metrics.v3.StatsConfig":
+		return new(statspb.StatsConfig), nil
+	case "type.googleapis.com/envoy.config.metrics.v3.StatsMatcher":
+		return new(statspb.StatsMatcher), nil
+	case "type.googleapis.com/envoy.config.metrics.v3.StatsSink":
+		return new(statspb.StatsSink), nil
+	case "type.googleapis.com/envoy.config.metrics.v3.TagSpecifier":
+		return new(statspb.TagSpecifier), nil
 	default:
 		return nil, fmt.Errorf("unexpected protobuf.Any with url: %s", url)
 	}

--- a/src/go/util/marshal_test.go
+++ b/src/go/util/marshal_test.go
@@ -40,6 +40,7 @@ func TestResolver(t *testing.T) {
 		{msg: &accessgrpcpb.TcpGrpcAccessLogConfig{}},
 		{msg: &accessgrpcpb.CommonGrpcAccessLogConfig{}},
 		{msg: &statspb.StatsSink{}},
+		{msg: &statspb.StatsdSink{}},
 		{msg: &statspb.StatsConfig{}},
 	}
 

--- a/src/go/util/marshal_test.go
+++ b/src/go/util/marshal_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 
+	statspb "github.com/envoyproxy/go-control-plane/envoy/config/metrics/v3"
 	accessfilepb "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/file/v3"
 	accessgrpcpb "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/grpc/v3"
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
@@ -34,17 +35,16 @@ func TestResolver(t *testing.T) {
 	tests := []struct {
 		msg proto.Message
 	}{
+		{msg: &accessfilepb.FileAccessLog{}},
+		{msg: &accessgrpcpb.HttpGrpcAccessLogConfig{}},
+		{msg: &accessgrpcpb.TcpGrpcAccessLogConfig{}},
+		{msg: &accessgrpcpb.CommonGrpcAccessLogConfig{}},
+		{msg: &statspb.StatsSink{}},
 		{
-			msg: &accessfilepb.FileAccessLog{},
-		},
-		{
-			msg: &accessgrpcpb.HttpGrpcAccessLogConfig{},
-		},
-		{
-			msg: &accessgrpcpb.TcpGrpcAccessLogConfig{},
-		},
-		{
-			msg: &accessgrpcpb.CommonGrpcAccessLogConfig{},
+			msg: &statspb.StatsConfig{
+				StatsTags:    []*statspb.TagSpecifier{},
+				StatsMatcher: &statspb.StatsMatcher{},
+			},
 		},
 	}
 

--- a/src/go/util/marshal_test.go
+++ b/src/go/util/marshal_test.go
@@ -40,12 +40,7 @@ func TestResolver(t *testing.T) {
 		{msg: &accessgrpcpb.TcpGrpcAccessLogConfig{}},
 		{msg: &accessgrpcpb.CommonGrpcAccessLogConfig{}},
 		{msg: &statspb.StatsSink{}},
-		{
-			msg: &statspb.StatsConfig{
-				StatsTags:    []*statspb.TagSpecifier{},
-				StatsMatcher: &statspb.StatsMatcher{},
-			},
-		},
+		{msg: &statspb.StatsConfig{}},
 	}
 
 	marshaler := &jsonpb.Marshaler{


### PR DESCRIPTION
These are more configs that the Resolver fails to resolve, although it's odd as it's not an extension.

TESTED=Added the test cases first to reproduce the error; adding the Resolver code fixes this.