### PR TITLE
b/161200191: add api_key in filter_state for access logging

### DIFF
--- a/src/envoy/http/backend_auth/filter.cc
+++ b/src/envoy/http/backend_auth/filter.cc
@@ -52,7 +52,7 @@ const Envoy::Http::LowerCaseString kXForwardedAuthorization{
 
 FilterHeadersStatus Filter::decodeHeaders(RequestHeaderMap& headers, bool) {
   absl::string_view operation = utils::getStringFilterState(
-      *decoder_callbacks_->streamInfo().filterState(), utils::kOperation);
+      *decoder_callbacks_->streamInfo().filterState(), utils::kFilterStateOperation);
   // NOTE: this shouldn't happen in practice because Path Matcher filter would
   // have already rejected the request.
   if (operation.empty()) {

--- a/src/envoy/http/backend_auth/filter.cc
+++ b/src/envoy/http/backend_auth/filter.cc
@@ -52,7 +52,8 @@ const Envoy::Http::LowerCaseString kXForwardedAuthorization{
 
 FilterHeadersStatus Filter::decodeHeaders(RequestHeaderMap& headers, bool) {
   absl::string_view operation = utils::getStringFilterState(
-      *decoder_callbacks_->streamInfo().filterState(), utils::kFilterStateOperation);
+      *decoder_callbacks_->streamInfo().filterState(),
+      utils::kFilterStateOperation);
   // NOTE: this shouldn't happen in practice because Path Matcher filter would
   // have already rejected the request.
   if (operation.empty()) {

--- a/src/envoy/http/backend_auth/filter_test.cc
+++ b/src/envoy/http/backend_auth/filter_test.cc
@@ -90,8 +90,8 @@ TEST_F(BackendAuthFilterTest, MissingAudienceAllowed) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
                                                 {":path", "/books/1"}};
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateOperation,
-      "operation-without-audience");
+      *mock_decoder_callbacks_.stream_info_.filter_state_,
+      utils::kFilterStateOperation, "operation-without-audience");
 
   EXPECT_CALL(*mock_filter_config_, cfg_parser)
       .Times(1)
@@ -118,8 +118,8 @@ TEST_F(BackendAuthFilterTest, HasAudienceButGetsEmptyTokenRejected) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
                                                 {":path", "/books/1"}};
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateOperation,
-      "operation-with-audience");
+      *mock_decoder_callbacks_.stream_info_.filter_state_,
+      utils::kFilterStateOperation, "operation-with-audience");
 
   EXPECT_CALL(*mock_filter_config_, cfg_parser)
       .WillRepeatedly(testing::ReturnRef(*mock_filter_config_parser_));
@@ -151,8 +151,8 @@ TEST_F(BackendAuthFilterTest, SucceedAppendToken) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
                                                 {":path", "/books/1"}};
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateOperation,
-      "operation-with-audience");
+      *mock_decoder_callbacks_.stream_info_.filter_state_,
+      utils::kFilterStateOperation, "operation-with-audience");
 
   EXPECT_CALL(*mock_filter_config_, cfg_parser)
       .WillRepeatedly(testing::ReturnRef(*mock_filter_config_parser_));
@@ -188,8 +188,8 @@ TEST_F(BackendAuthFilterTest, SucceedTokenCopied) {
       {":path", "/books/1"},
       {"authorization", "Bearer origin-token"}};
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateOperation,
-      "operation-with-audience");
+      *mock_decoder_callbacks_.stream_info_.filter_state_,
+      utils::kFilterStateOperation, "operation-with-audience");
 
   EXPECT_CALL(*mock_filter_config_, cfg_parser)
       .WillRepeatedly(testing::ReturnRef(*mock_filter_config_parser_));

--- a/src/envoy/http/backend_auth/filter_test.cc
+++ b/src/envoy/http/backend_auth/filter_test.cc
@@ -90,7 +90,7 @@ TEST_F(BackendAuthFilterTest, MissingAudienceAllowed) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
                                                 {":path", "/books/1"}};
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kOperation,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateOperation,
       "operation-without-audience");
 
   EXPECT_CALL(*mock_filter_config_, cfg_parser)
@@ -118,7 +118,7 @@ TEST_F(BackendAuthFilterTest, HasAudienceButGetsEmptyTokenRejected) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
                                                 {":path", "/books/1"}};
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kOperation,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateOperation,
       "operation-with-audience");
 
   EXPECT_CALL(*mock_filter_config_, cfg_parser)
@@ -151,7 +151,7 @@ TEST_F(BackendAuthFilterTest, SucceedAppendToken) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
                                                 {":path", "/books/1"}};
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kOperation,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateOperation,
       "operation-with-audience");
 
   EXPECT_CALL(*mock_filter_config_, cfg_parser)
@@ -188,7 +188,7 @@ TEST_F(BackendAuthFilterTest, SucceedTokenCopied) {
       {":path", "/books/1"},
       {"authorization", "Bearer origin-token"}};
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kOperation,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateOperation,
       "operation-with-audience");
 
   EXPECT_CALL(*mock_filter_config_, cfg_parser)

--- a/src/envoy/http/backend_routing/filter.cc
+++ b/src/envoy/http/backend_routing/filter.cc
@@ -51,7 +51,7 @@ FilterHeadersStatus Filter::decodeHeaders(
 
   const auto& filter_state = *decoder_callbacks_->streamInfo().filterState();
   absl::string_view operation =
-      utils::getStringFilterState(filter_state, utils::kOperation);
+      utils::getStringFilterState(filter_state, utils::kFilterStateOperation);
   // NOTE: this shouldn't happen in practice because Path Matcher filter would
   // have already rejected the request.
   if (operation.empty()) {
@@ -131,7 +131,7 @@ std::string Filter::translateConstPath(absl::string_view prefix,
                                        absl::string_view original_path) {
   const auto& filter_state = *decoder_callbacks_->streamInfo().filterState();
   const absl::string_view extracted_query_params =
-      utils::getStringFilterState(filter_state, utils::kQueryParams);
+      utils::getStringFilterState(filter_state, utils::kFilterStateQueryParams);
 
   const auto original_path_str = std::string(original_path);
   std::size_t originalQueryParamPos = original_path_str.find('?');

--- a/src/envoy/http/backend_routing/filter_fuzz_test.cc
+++ b/src/envoy/http/backend_routing/filter_fuzz_test.cc
@@ -44,12 +44,12 @@ DEFINE_PROTO_FUZZER(
 
   // Set the operation name using the first backend routing rule.
   utils::setStringFilterState(
-      *mock_decoder_callbacks.stream_info_.filter_state_, utils::kOperation,
+      *mock_decoder_callbacks.stream_info_.filter_state_, utils::kFilterStateOperation,
       input.config().rules(0).operation());
 
   // Set the variable binding query params.
   utils::setStringFilterState(
-      *mock_decoder_callbacks.stream_info_.filter_state_, utils::kQueryParams,
+      *mock_decoder_callbacks.stream_info_.filter_state_, utils::kFilterStateQueryParams,
       input.binding_query_params());
 
   // Create the filter.

--- a/src/envoy/http/backend_routing/filter_fuzz_test.cc
+++ b/src/envoy/http/backend_routing/filter_fuzz_test.cc
@@ -44,13 +44,13 @@ DEFINE_PROTO_FUZZER(
 
   // Set the operation name using the first backend routing rule.
   utils::setStringFilterState(
-      *mock_decoder_callbacks.stream_info_.filter_state_, utils::kFilterStateOperation,
-      input.config().rules(0).operation());
+      *mock_decoder_callbacks.stream_info_.filter_state_,
+      utils::kFilterStateOperation, input.config().rules(0).operation());
 
   // Set the variable binding query params.
   utils::setStringFilterState(
-      *mock_decoder_callbacks.stream_info_.filter_state_, utils::kFilterStateQueryParams,
-      input.binding_query_params());
+      *mock_decoder_callbacks.stream_info_.filter_state_,
+      utils::kFilterStateQueryParams, input.binding_query_params());
 
   // Create the filter.
   FilterConfigSharedPtr config;

--- a/src/envoy/http/backend_routing/filter_test.cc
+++ b/src/envoy/http/backend_routing/filter_test.cc
@@ -105,8 +105,8 @@ TEST_F(BackendRoutingFilterTest, OperationNotConfiguredAllowed) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
                                                 {":path", "/books/1"}};
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateOperation,
-      "unknown-operation-name");
+      *mock_decoder_callbacks_.stream_info_.filter_state_,
+      utils::kFilterStateOperation, "unknown-operation-name");
 
   // Call function under test
   Envoy::Http::FilterHeadersStatus status =
@@ -128,8 +128,8 @@ TEST_F(BackendRoutingFilterTest, OperationNotConfiguredAllowed) {
 TEST_F(BackendRoutingFilterTest, NoPathHeaderBlocked) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "GET"}};
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateOperation,
-      "const-operation");
+      *mock_decoder_callbacks_.stream_info_.filter_state_,
+      utils::kFilterStateOperation, "const-operation");
 
   // Call function under test
   Envoy::Http::FilterHeadersStatus status =
@@ -151,8 +151,8 @@ TEST_F(BackendRoutingFilterTest, InvalidPathHeaderWithFragmentBlocked) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
                                                 {":path", "/books/1#fragment"}};
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateOperation,
-      "const-operation");
+      *mock_decoder_callbacks_.stream_info_.filter_state_,
+      utils::kFilterStateOperation, "const-operation");
 
   // Call function under test
   Envoy::Http::FilterHeadersStatus status =
@@ -174,8 +174,8 @@ TEST_F(BackendRoutingFilterTest, ConstantAddress) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
                                                 {":path", "/books/1"}};
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateOperation,
-      "const-operation");
+      *mock_decoder_callbacks_.stream_info_.filter_state_,
+      utils::kFilterStateOperation, "const-operation");
 
   // Call function under test
   Envoy::Http::FilterHeadersStatus status =
@@ -198,11 +198,11 @@ TEST_F(BackendRoutingFilterTest, ConstantAddressWithPathMatcherQueryParams) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
                                                 {":path", "/books/1"}};
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateOperation,
-      "const-operation");
+      *mock_decoder_callbacks_.stream_info_.filter_state_,
+      utils::kFilterStateOperation, "const-operation");
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateQueryParams,
-      "id=1");
+      *mock_decoder_callbacks_.stream_info_.filter_state_,
+      utils::kFilterStateQueryParams, "id=1");
 
   // Call function under test
   Envoy::Http::FilterHeadersStatus status =
@@ -232,8 +232,8 @@ TEST_F(BackendRoutingFilterQueryParamInRequestTest,
   Envoy::Http::TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/books/1?view=summary&filter=deleted"}};
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateOperation,
-      "append-with-prefix-operation");
+      *mock_decoder_callbacks_.stream_info_.filter_state_,
+      utils::kFilterStateOperation, "append-with-prefix-operation");
 
   // Call function under test
   Envoy::Http::FilterHeadersStatus status =
@@ -257,8 +257,8 @@ TEST_F(BackendRoutingFilterQueryParamInRequestTest, ConstantAddress) {
   Envoy::Http::TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/books/1?view=summary&filter=deleted"}};
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateOperation,
-      "const-operation");
+      *mock_decoder_callbacks_.stream_info_.filter_state_,
+      utils::kFilterStateOperation, "const-operation");
 
   // Call function under test
   Envoy::Http::FilterHeadersStatus status =
@@ -283,11 +283,11 @@ TEST_F(BackendRoutingFilterQueryParamInRequestTest,
   Envoy::Http::TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/books/1?view=summary&filter=deleted"}};
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateOperation,
-      "const-operation");
+      *mock_decoder_callbacks_.stream_info_.filter_state_,
+      utils::kFilterStateOperation, "const-operation");
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateQueryParams,
-      "id=1");
+      *mock_decoder_callbacks_.stream_info_.filter_state_,
+      utils::kFilterStateQueryParams, "id=1");
 
   // Call function under test
   Envoy::Http::FilterHeadersStatus status =
@@ -312,11 +312,11 @@ TEST_F(BackendRoutingFilterQueryParamInRequestTest,
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
                                                 {":path", "/books/1?id=2"}};
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateOperation,
-      "const-operation");
+      *mock_decoder_callbacks_.stream_info_.filter_state_,
+      utils::kFilterStateOperation, "const-operation");
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateQueryParams,
-      "id=1");
+      *mock_decoder_callbacks_.stream_info_.filter_state_,
+      utils::kFilterStateQueryParams, "id=1");
 
   // Call function under test
   Envoy::Http::FilterHeadersStatus status =
@@ -341,8 +341,8 @@ TEST_F(BackendRoutingFilterQueryParamInRequestTest, ConstantAddressWithPrefix) {
   Envoy::Http::TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/books/1?view=summary&filter=deleted"}};
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateOperation,
-      "const-with-prefix-operation");
+      *mock_decoder_callbacks_.stream_info_.filter_state_,
+      utils::kFilterStateOperation, "const-with-prefix-operation");
 
   // Call function under test
   Envoy::Http::FilterHeadersStatus status =

--- a/src/envoy/http/backend_routing/filter_test.cc
+++ b/src/envoy/http/backend_routing/filter_test.cc
@@ -105,7 +105,7 @@ TEST_F(BackendRoutingFilterTest, OperationNotConfiguredAllowed) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
                                                 {":path", "/books/1"}};
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kOperation,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateOperation,
       "unknown-operation-name");
 
   // Call function under test
@@ -128,7 +128,7 @@ TEST_F(BackendRoutingFilterTest, OperationNotConfiguredAllowed) {
 TEST_F(BackendRoutingFilterTest, NoPathHeaderBlocked) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "GET"}};
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kOperation,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateOperation,
       "const-operation");
 
   // Call function under test
@@ -151,7 +151,7 @@ TEST_F(BackendRoutingFilterTest, InvalidPathHeaderWithFragmentBlocked) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
                                                 {":path", "/books/1#fragment"}};
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kOperation,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateOperation,
       "const-operation");
 
   // Call function under test
@@ -174,7 +174,7 @@ TEST_F(BackendRoutingFilterTest, ConstantAddress) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
                                                 {":path", "/books/1"}};
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kOperation,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateOperation,
       "const-operation");
 
   // Call function under test
@@ -198,10 +198,10 @@ TEST_F(BackendRoutingFilterTest, ConstantAddressWithPathMatcherQueryParams) {
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
                                                 {":path", "/books/1"}};
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kOperation,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateOperation,
       "const-operation");
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kQueryParams,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateQueryParams,
       "id=1");
 
   // Call function under test
@@ -232,7 +232,7 @@ TEST_F(BackendRoutingFilterQueryParamInRequestTest,
   Envoy::Http::TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/books/1?view=summary&filter=deleted"}};
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kOperation,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateOperation,
       "append-with-prefix-operation");
 
   // Call function under test
@@ -257,7 +257,7 @@ TEST_F(BackendRoutingFilterQueryParamInRequestTest, ConstantAddress) {
   Envoy::Http::TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/books/1?view=summary&filter=deleted"}};
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kOperation,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateOperation,
       "const-operation");
 
   // Call function under test
@@ -283,10 +283,10 @@ TEST_F(BackendRoutingFilterQueryParamInRequestTest,
   Envoy::Http::TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/books/1?view=summary&filter=deleted"}};
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kOperation,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateOperation,
       "const-operation");
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kQueryParams,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateQueryParams,
       "id=1");
 
   // Call function under test
@@ -312,10 +312,10 @@ TEST_F(BackendRoutingFilterQueryParamInRequestTest,
   Envoy::Http::TestRequestHeaderMapImpl headers{{":method", "GET"},
                                                 {":path", "/books/1?id=2"}};
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kOperation,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateOperation,
       "const-operation");
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kQueryParams,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateQueryParams,
       "id=1");
 
   // Call function under test
@@ -341,7 +341,7 @@ TEST_F(BackendRoutingFilterQueryParamInRequestTest, ConstantAddressWithPrefix) {
   Envoy::Http::TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/books/1?view=summary&filter=deleted"}};
   utils::setStringFilterState(
-      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kOperation,
+      *mock_decoder_callbacks_.stream_info_.filter_state_, utils::kFilterStateOperation,
       "const-with-prefix-operation");
 
   // Call function under test

--- a/src/envoy/http/path_matcher/filter.cc
+++ b/src/envoy/http/path_matcher/filter.cc
@@ -81,7 +81,7 @@ Envoy::Http::FilterHeadersStatus Filter::decodeHeaders(
   ENVOY_LOG(debug, "matched operation: {}", operation);
   Envoy::StreamInfo::FilterState& filter_state =
       *decoder_callbacks_->streamInfo().filterState();
-  utils::setStringFilterState(filter_state, utils::kOperation, operation);
+  utils::setStringFilterState(filter_state, utils::kFilterStateOperation, operation);
 
   if (rule->has_path_parameter_extraction()) {
     const PathParameterExtractionRule& param_rule =
@@ -93,7 +93,7 @@ Envoy::Http::FilterHeadersStatus Filter::decodeHeaders(
     if (!variable_bindings.empty()) {
       const std::string query_params = VariableBindingsToQueryParameters(
           variable_bindings, param_rule.snake_to_json_segments());
-      utils::setStringFilterState(filter_state, utils::kQueryParams,
+      utils::setStringFilterState(filter_state, utils::kFilterStateQueryParams,
                                   query_params);
     }
   }

--- a/src/envoy/http/path_matcher/filter.cc
+++ b/src/envoy/http/path_matcher/filter.cc
@@ -81,7 +81,8 @@ Envoy::Http::FilterHeadersStatus Filter::decodeHeaders(
   ENVOY_LOG(debug, "matched operation: {}", operation);
   Envoy::StreamInfo::FilterState& filter_state =
       *decoder_callbacks_->streamInfo().filterState();
-  utils::setStringFilterState(filter_state, utils::kFilterStateOperation, operation);
+  utils::setStringFilterState(filter_state, utils::kFilterStateOperation,
+                              operation);
 
   if (rule->has_path_parameter_extraction()) {
     const PathParameterExtractionRule& param_rule =

--- a/src/envoy/http/path_matcher/filter_fuzz_test.cc
+++ b/src/envoy/http/path_matcher/filter_fuzz_test.cc
@@ -63,7 +63,7 @@ DEFINE_PROTO_FUZZER(
 
   // Ensure the query param filter state is valid.
   absl::string_view query_params = utils::getStringFilterState(
-      *mock_decoder_callbacks.stream_info_.filter_state_, utils::kQueryParams);
+      *mock_decoder_callbacks.stream_info_.filter_state_, utils::kFilterStateQueryParams);
   ASSERT_TRUE(Envoy::Http::validHeaderString(query_params));
 }
 

--- a/src/envoy/http/path_matcher/filter_fuzz_test.cc
+++ b/src/envoy/http/path_matcher/filter_fuzz_test.cc
@@ -63,7 +63,8 @@ DEFINE_PROTO_FUZZER(
 
   // Ensure the query param filter state is valid.
   absl::string_view query_params = utils::getStringFilterState(
-      *mock_decoder_callbacks.stream_info_.filter_state_, utils::kFilterStateQueryParams);
+      *mock_decoder_callbacks.stream_info_.filter_state_,
+      utils::kFilterStateQueryParams);
   ASSERT_TRUE(Envoy::Http::validHeaderString(query_params));
 }
 

--- a/src/envoy/http/path_matcher/filter_test.cc
+++ b/src/envoy/http/path_matcher/filter_test.cc
@@ -87,10 +87,10 @@ TEST_F(PathMatcherFilterTest, DecodeHeadersWithOperation) {
             filter_->decodeHeaders(headers, false));
 
   EXPECT_EQ(utils::getStringFilterState(*mock_cb_.stream_info_.filter_state_,
-                                        utils::kOperation),
+                                        utils::kFilterStateOperation),
             "1.cloudesf_testing_cloud_goog.Bar");
   EXPECT_EQ(utils::getStringFilterState(*mock_cb_.stream_info_.filter_state_,
-                                        utils::kQueryParams),
+                                        utils::kFilterStateQueryParams),
             Envoy::EMPTY_STRING);
 
   EXPECT_EQ(1L, Envoy::TestUtility::findCounter(mock_factory_context_.scope_,
@@ -119,7 +119,7 @@ TEST_F(PathMatcherFilterTest, DecodeHeadersWithMethodOverride) {
             filter_->decodeHeaders(headers, true));
 
   EXPECT_EQ(utils::getStringFilterState(*mock_cb_.stream_info_.filter_state_,
-                                        utils::kOperation),
+                                        utils::kFilterStateOperation),
             "1.cloudesf_testing_cloud_goog.Bar");
 
   EXPECT_EQ(1L, Envoy::TestUtility::findCounter(mock_factory_context_.scope_,
@@ -138,10 +138,10 @@ TEST_F(PathMatcherFilterTest, DecodeHeadersExtractParameters) {
             filter_->decodeHeaders(headers, true));
 
   EXPECT_EQ(utils::getStringFilterState(*mock_cb_.stream_info_.filter_state_,
-                                        utils::kOperation),
+                                        utils::kFilterStateOperation),
             "1.cloudesf_testing_cloud_goog.Foo");
   EXPECT_EQ(utils::getStringFilterState(*mock_cb_.stream_info_.filter_state_,
-                                        utils::kQueryParams),
+                                        utils::kFilterStateQueryParams),
             "fooBar=123");
 
   EXPECT_EQ(1L, Envoy::TestUtility::findCounter(mock_factory_context_.scope_,
@@ -167,7 +167,7 @@ TEST_F(PathMatcherFilterTest, DecodeHeadersNoMatch) {
             filter_->decodeHeaders(headers, true));
 
   EXPECT_EQ(utils::getStringFilterState(*mock_cb_.stream_info_.filter_state_,
-                                        utils::kOperation),
+                                        utils::kFilterStateOperation),
             Envoy::EMPTY_STRING);
 
   EXPECT_EQ(0L, Envoy::TestUtility::findCounter(mock_factory_context_.scope_,
@@ -202,7 +202,7 @@ TEST_F(PathMatcherFilterTest, DecodeHeadersShortWildcard) {
             filter_->decodeHeaders(headers, true));
 
   EXPECT_EQ(utils::getStringFilterState(*mock_cb_.stream_info_.filter_state_,
-                                        utils::kOperation),
+                                        utils::kFilterStateOperation),
             "1.cloudesf_testing_cloud_goog.Long");
 }
 

--- a/src/envoy/http/service_control/BUILD
+++ b/src/envoy/http/service_control/BUILD
@@ -38,6 +38,7 @@ envoy_cc_library(
     deps = [
         ":filter_stats_lib",
         ":service_control_callback_func_lib",
+        "//src/envoy/utils:filter_state_utils_lib",
         "@envoy//include/envoy/http:header_map_interface",
         "@envoy//include/envoy/stream_info:stream_info_interface",
     ],

--- a/src/envoy/http/service_control/client_cache_test.cc
+++ b/src/envoy/http/service_control/client_cache_test.cc
@@ -58,7 +58,7 @@ using ::testing::Return;
 
 constexpr char kServiceName[] = "bookstore.endpoints.test";
 constexpr char kServiceConfigId[] = "2020-06-24r1";
-constexpr char kCheckOperationId[] = "test.check.operation";
+constexpr char kCheckFilterStateOperationId[] = "test.check.operation";
 
 class ClientCacheTestBase : public ::testing::Test {
  protected:
@@ -367,7 +367,7 @@ class ClientCacheCheckHttpRequestTest : public ClientCacheHttpRequestTest {
     request.set_service_name(kServiceName);
     request.set_service_config_id(kServiceConfigId);
     Operation* op = request.mutable_operation();
-    op->set_operation_id(kCheckOperationId);
+    op->set_operation_id(kCheckFilterStateOperationId);
     op->set_operation_name("test_check_operation_name");
     op->set_consumer_id("test-api-key");
     return request;
@@ -375,7 +375,7 @@ class ClientCacheCheckHttpRequestTest : public ClientCacheHttpRequestTest {
 
   CheckResponse getValidCheckResponse() {
     CheckResponse response;
-    response.set_operation_id(kCheckOperationId);
+    response.set_operation_id(kCheckFilterStateOperationId);
     response.set_service_config_id(kServiceConfigId);
     return response;
   }

--- a/src/envoy/http/service_control/filter.cc
+++ b/src/envoy/http/service_control/filter.cc
@@ -49,7 +49,7 @@ Envoy::Http::FilterHeadersStatus ServiceControlFilter::decodeHeaders(
 
   handler_ =
       factory_.createHandler(headers, decoder_callbacks_->streamInfo(), stats_);
-
+  handler_->fillFilterState(*decoder_callbacks_->streamInfo().filterState());
   state_ = Calling;
   stopped_ = false;
 

--- a/src/envoy/http/service_control/filter_fuzz_test.cc
+++ b/src/envoy/http/service_control/filter_fuzz_test.cc
@@ -147,7 +147,7 @@ DEFINE_PROTO_FUZZER(
     // and has configured metric costs.
     // This ensures both CHECK and QUOTA are called.
     utils::setStringFilterState(
-        *stream_info.filter_state_, utils::kOperation,
+        *stream_info.filter_state_, utils::kFilterStateOperation,
         input.config().requirements(0).operation_name());
 
     // Create filter.

--- a/src/envoy/http/service_control/filter_test.cc
+++ b/src/envoy/http/service_control/filter_test.cc
@@ -89,6 +89,7 @@ TEST_F(ServiceControlFilterTest, DecodeHeadersSyncOKStatus) {
                           ServiceControlHandler::CheckDoneCallback& callback) {
         callback.onCheckDone(Status::OK);
       }));
+  EXPECT_CALL(*mock_handler_, fillFilterState(_));
   EXPECT_EQ(Envoy::Http::FilterHeadersStatus::Continue,
             filter_->decodeHeaders(req_headers_, true));
 

--- a/src/envoy/http/service_control/handler.h
+++ b/src/envoy/http/service_control/handler.h
@@ -20,6 +20,7 @@
 #include "envoy/stream_info/stream_info.h"
 #include "src/api_proxy/service_control/request_info.h"
 #include "src/envoy/http/service_control/filter_stats.h"
+#include "src/envoy/utils/filter_state_utils.h"
 
 namespace espv2 {
 namespace envoy {
@@ -56,6 +57,10 @@ class ServiceControlHandler {
   // intermediate reports.
   virtual void processResponseHeaders(
       const Envoy::Http::ResponseHeaderMap& response_headers) PURE;
+
+  // Fill filter state with request information for access logging.
+  virtual void fillFilterState(
+      ::Envoy::StreamInfo::FilterState& filter_state) PURE;
 
   // The request is about to be destroyed need to cancel all async requests.
   virtual void onDestroy() PURE;

--- a/src/envoy/http/service_control/handler_impl.cc
+++ b/src/envoy/http/service_control/handler_impl.cc
@@ -108,7 +108,8 @@ ServiceControlHandlerImpl::ServiceControlHandlerImpl(
 ServiceControlHandlerImpl::~ServiceControlHandlerImpl() {}
 
 void ServiceControlHandlerImpl::fillFilterState(FilterState& filter_state) {
-  utils::setStringFilterState(filter_state, utils::kFilterStateApiKey, api_key_);
+  utils::setStringFilterState(filter_state, utils::kFilterStateApiKey,
+                              api_key_);
 }
 
 void ServiceControlHandlerImpl::onDestroy() {

--- a/src/envoy/http/service_control/handler_impl.cc
+++ b/src/envoy/http/service_control/handler_impl.cc
@@ -74,7 +74,7 @@ ServiceControlHandlerImpl::ServiceControlHandlerImpl(
   request_header_size_ = headers.byteSize();
 
   const absl::string_view operation = utils::getStringFilterState(
-      stream_info_.filterState(), utils::kOperation);
+      stream_info_.filterState(), utils::kFilterStateOperation);
 
   // NOTE: this shouldn't happen in practice because Path Matcher filter would
   // have already rejected the request.
@@ -108,7 +108,7 @@ ServiceControlHandlerImpl::ServiceControlHandlerImpl(
 ServiceControlHandlerImpl::~ServiceControlHandlerImpl() {}
 
 void ServiceControlHandlerImpl::fillFilterState(FilterState& filter_state) {
-  utils::setStringFilterState(filter_state, utils::kApiKey, api_key_);
+  utils::setStringFilterState(filter_state, utils::kFilterStateApiKey, api_key_);
 }
 
 void ServiceControlHandlerImpl::onDestroy() {

--- a/src/envoy/http/service_control/handler_impl.cc
+++ b/src/envoy/http/service_control/handler_impl.cc
@@ -27,6 +27,7 @@ namespace envoy {
 namespace http_filters {
 namespace service_control {
 
+using ::Envoy::StreamInfo::FilterState;
 using ::espv2::api_proxy::service_control::CheckResponseInfo;
 using ::espv2::api_proxy::service_control::OperationInfo;
 using ::espv2::api_proxy::service_control::ScResponseErrorType;
@@ -105,6 +106,10 @@ ServiceControlHandlerImpl::ServiceControlHandlerImpl(
 }
 
 ServiceControlHandlerImpl::~ServiceControlHandlerImpl() {}
+
+void ServiceControlHandlerImpl::fillFilterState(FilterState& filter_state) {
+  utils::setStringFilterState(filter_state, utils::kApiKey, api_key_);
+}
 
 void ServiceControlHandlerImpl::onDestroy() {
   if (cancel_fn_) {

--- a/src/envoy/http/service_control/handler_impl.h
+++ b/src/envoy/http/service_control/handler_impl.h
@@ -63,6 +63,8 @@ class ServiceControlHandlerImpl
   void processResponseHeaders(
       const Envoy::Http::ResponseHeaderMap& response_headers) override;
 
+  void fillFilterState(::Envoy::StreamInfo::FilterState& filter_state) override;
+
   void onDestroy() override;
 
  private:

--- a/src/envoy/http/service_control/handler_impl_test.cc
+++ b/src/envoy/http/service_control/handler_impl_test.cc
@@ -385,7 +385,8 @@ TEST_F(HandlerTest, HandlerNoRequirementMatched) {
   // Test: If no requirement is matched for the operation, check should 404
   // and report should do nothing
   utils::setStringFilterState(*mock_stream_info_.filter_state_,
-                              utils::kFilterStateOperation, "bad-operation-name");
+                              utils::kFilterStateOperation,
+                              "bad-operation-name");
   TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/echo"}};
   ServiceControlHandlerImpl handler(headers, mock_stream_info_, "test-uuid",
                                     *cfg_parser_, test_time_, stats_);
@@ -549,7 +550,8 @@ TEST_F(HandlerTest, HandlerSuccessfulCheckSyncWithoutApiKeyRestrictionFields) {
 TEST_F(HandlerTest, HandlerSuccessfulQuotaSync) {
   // Test: Quota is required and succeeds.
   utils::setStringFilterState(*mock_stream_info_.filter_state_,
-                              utils::kFilterStateOperation, "get_header_key_quota");
+                              utils::kFilterStateOperation,
+                              "get_header_key_quota");
   TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/echo"}, {"x-api-key", "foobar"}};
   TestResponseHeaderMapImpl response_headers{
@@ -585,7 +587,8 @@ TEST_F(HandlerTest, HandlerSuccessfulQuotaSync) {
 TEST_F(HandlerTest, HandlerCallQuotaWithoutCheck) {
   // Test: Quota is required but the Check is not
   utils::setStringFilterState(*mock_stream_info_.filter_state_,
-                              utils::kFilterStateOperation, "call_quota_without_check");
+                              utils::kFilterStateOperation,
+                              "call_quota_without_check");
   TestRequestHeaderMapImpl headers{{":method", "GET"},
                                    {":path", "/echo?key=foobar"}};
   TestResponseHeaderMapImpl response_headers{
@@ -657,7 +660,8 @@ TEST_F(HandlerTest, HandlerFailQuotaSync) {
   // Test: Check is required and a request is made, but service control
   // returns a bad status.
   utils::setStringFilterState(*mock_stream_info_.filter_state_,
-                              utils::kFilterStateOperation, "get_header_key_quota");
+                              utils::kFilterStateOperation,
+                              "get_header_key_quota");
   TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/echo"}, {"x-api-key", "foobar"}};
   TestResponseHeaderMapImpl response_headers{
@@ -739,7 +743,8 @@ TEST_F(HandlerTest, HandlerSuccessfulQuotaAsync) {
   // Test: Check is required and succeeds, even when the done callback is not
   // called until later.
   utils::setStringFilterState(*mock_stream_info_.filter_state_,
-                              utils::kFilterStateOperation, "get_header_key_quota");
+                              utils::kFilterStateOperation,
+                              "get_header_key_quota");
   TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/echo"}, {"x-api-key", "foobar"}};
   TestResponseHeaderMapImpl response_headers{
@@ -835,7 +840,8 @@ TEST_F(HandlerTest, HandlerFailQuotaAsync) {
   // Test: Quota is required and a request is made, but later on service
   // control returns a bad status.
   utils::setStringFilterState(*mock_stream_info_.filter_state_,
-                              utils::kFilterStateOperation, "get_header_key_quota");
+                              utils::kFilterStateOperation,
+                              "get_header_key_quota");
   TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/echo"}, {"x-api-key", "foobar"}};
   TestResponseHeaderMapImpl response_headers{

--- a/src/envoy/http/service_control/handler_impl_test.cc
+++ b/src/envoy/http/service_control/handler_impl_test.cc
@@ -385,7 +385,7 @@ TEST_F(HandlerTest, HandlerNoRequirementMatched) {
   // Test: If no requirement is matched for the operation, check should 404
   // and report should do nothing
   utils::setStringFilterState(*mock_stream_info_.filter_state_,
-                              utils::kOperation, "bad-operation-name");
+                              utils::kFilterStateOperation, "bad-operation-name");
   TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/echo"}};
   ServiceControlHandlerImpl handler(headers, mock_stream_info_, "test-uuid",
                                     *cfg_parser_, test_time_, stats_);
@@ -408,7 +408,7 @@ TEST_F(HandlerTest, HandlerNoRequirementMatched) {
 TEST_F(HandlerTest, HandlerCheckNotNeeded) {
   // Test: If the operation does not require check, check should return OK
   utils::setStringFilterState(*mock_stream_info_.filter_state_,
-                              utils::kOperation, "get_no_key");
+                              utils::kFilterStateOperation, "get_no_key");
   TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/echo"}};
   TestResponseHeaderMapImpl response_headers{
       {"content-type", "application/grpc"}};
@@ -435,7 +435,7 @@ TEST_F(HandlerTest, HandlerCheckMissingApiKey) {
   // Test: If the operation requires a check but none is found, check fails
   // and a report is made
   utils::setStringFilterState(*mock_stream_info_.filter_state_,
-                              utils::kOperation, "get_header_key");
+                              utils::kFilterStateOperation, "get_header_key");
   TestRequestHeaderMapImpl headers{{":method", "GET"}, {":path", "/echo"}};
   TestResponseHeaderMapImpl response_headers{
       {"content-type", "application/grpc"}};
@@ -469,7 +469,7 @@ TEST_F(HandlerTest, HandlerSuccessfulCheckSyncWithApiKeyRestrictionFields) {
   // Test: Check is required and succeeds, and api key restriction fields are
   // present on the check request
   utils::setStringFilterState(*mock_stream_info_.filter_state_,
-                              utils::kOperation, "get_header_key");
+                              utils::kFilterStateOperation, "get_header_key");
   TestRequestHeaderMapImpl headers{{":method", "GET"},
                                    {":path", "/echo"},
                                    {"x-api-key", "foobar"},
@@ -514,7 +514,7 @@ TEST_F(HandlerTest, HandlerSuccessfulCheckSyncWithoutApiKeyRestrictionFields) {
   // Test: Check is required and succeeds. The api key restriction fields are
   // left blank if not provided.
   utils::setStringFilterState(*mock_stream_info_.filter_state_,
-                              utils::kOperation, "get_header_key");
+                              utils::kFilterStateOperation, "get_header_key");
   TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/echo"}, {"x-api-key", "foobar"}};
   TestResponseHeaderMapImpl response_headers{
@@ -549,7 +549,7 @@ TEST_F(HandlerTest, HandlerSuccessfulCheckSyncWithoutApiKeyRestrictionFields) {
 TEST_F(HandlerTest, HandlerSuccessfulQuotaSync) {
   // Test: Quota is required and succeeds.
   utils::setStringFilterState(*mock_stream_info_.filter_state_,
-                              utils::kOperation, "get_header_key_quota");
+                              utils::kFilterStateOperation, "get_header_key_quota");
   TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/echo"}, {"x-api-key", "foobar"}};
   TestResponseHeaderMapImpl response_headers{
@@ -585,7 +585,7 @@ TEST_F(HandlerTest, HandlerSuccessfulQuotaSync) {
 TEST_F(HandlerTest, HandlerCallQuotaWithoutCheck) {
   // Test: Quota is required but the Check is not
   utils::setStringFilterState(*mock_stream_info_.filter_state_,
-                              utils::kOperation, "call_quota_without_check");
+                              utils::kFilterStateOperation, "call_quota_without_check");
   TestRequestHeaderMapImpl headers{{":method", "GET"},
                                    {":path", "/echo?key=foobar"}};
   TestResponseHeaderMapImpl response_headers{
@@ -616,7 +616,7 @@ TEST_F(HandlerTest, HandlerFailCheckSync) {
   // Test: Check is required and a request is made, but service control
   // returns a bad status.
   utils::setStringFilterState(*mock_stream_info_.filter_state_,
-                              utils::kOperation, "get_header_key");
+                              utils::kFilterStateOperation, "get_header_key");
   TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/echo"}, {"x-api-key", "foobar"}};
   TestResponseHeaderMapImpl response_headers{
@@ -657,7 +657,7 @@ TEST_F(HandlerTest, HandlerFailQuotaSync) {
   // Test: Check is required and a request is made, but service control
   // returns a bad status.
   utils::setStringFilterState(*mock_stream_info_.filter_state_,
-                              utils::kOperation, "get_header_key_quota");
+                              utils::kFilterStateOperation, "get_header_key_quota");
   TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/echo"}, {"x-api-key", "foobar"}};
   TestResponseHeaderMapImpl response_headers{
@@ -696,7 +696,7 @@ TEST_F(HandlerTest, HandlerSuccessfulCheckAsync) {
   // Test: Check is required and succeeds, even when the done callback is not
   // called until later.
   utils::setStringFilterState(*mock_stream_info_.filter_state_,
-                              utils::kOperation, "get_header_key");
+                              utils::kFilterStateOperation, "get_header_key");
   TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/echo"}, {"x-api-key", "foobar"}};
   TestResponseHeaderMapImpl response_headers{
@@ -739,7 +739,7 @@ TEST_F(HandlerTest, HandlerSuccessfulQuotaAsync) {
   // Test: Check is required and succeeds, even when the done callback is not
   // called until later.
   utils::setStringFilterState(*mock_stream_info_.filter_state_,
-                              utils::kOperation, "get_header_key_quota");
+                              utils::kFilterStateOperation, "get_header_key_quota");
   TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/echo"}, {"x-api-key", "foobar"}};
   TestResponseHeaderMapImpl response_headers{
@@ -788,7 +788,7 @@ TEST_F(HandlerTest, HandlerFailCheckAsync) {
   // Test: Check is required and a request is made, but later on service
   // control returns a bad status.
   utils::setStringFilterState(*mock_stream_info_.filter_state_,
-                              utils::kOperation, "get_header_key");
+                              utils::kFilterStateOperation, "get_header_key");
   TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/echo"}, {"x-api-key", "foobar"}};
   TestResponseHeaderMapImpl response_headers{
@@ -835,7 +835,7 @@ TEST_F(HandlerTest, HandlerFailQuotaAsync) {
   // Test: Quota is required and a request is made, but later on service
   // control returns a bad status.
   utils::setStringFilterState(*mock_stream_info_.filter_state_,
-                              utils::kOperation, "get_header_key_quota");
+                              utils::kFilterStateOperation, "get_header_key_quota");
   TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/echo"}, {"x-api-key", "foobar"}};
   TestResponseHeaderMapImpl response_headers{
@@ -885,7 +885,7 @@ TEST_F(HandlerTest, HandlerFailQuotaAsync) {
 TEST_F(HandlerTest, HandlerCancelFuncResetOnDone) {
   // Test: Cancel function will not be called if on_done is called
   utils::setStringFilterState(*mock_stream_info_.filter_state_,
-                              utils::kOperation, "get_header_key");
+                              utils::kFilterStateOperation, "get_header_key");
   TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/echo"}, {"x-api-key", "foobar"}};
   CheckDoneFunc stored_on_done;
@@ -914,7 +914,7 @@ TEST_F(HandlerTest, HandlerCancelFuncResetOnDone) {
 TEST_F(HandlerTest, HandlerCancelFuncCalledOnDestroy) {
   // Test: Cancel function will be called if on_done is not called
   utils::setStringFilterState(*mock_stream_info_.filter_state_,
-                              utils::kOperation, "get_header_key");
+                              utils::kFilterStateOperation, "get_header_key");
   TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/echo"}, {"x-api-key", "foobar"}};
   MockFunction<void()> mock_cancel;
@@ -936,7 +936,7 @@ TEST_F(HandlerTest, HandlerCancelFuncCalledOnDestroy) {
 TEST_F(HandlerTest, HandlerCancelFuncNotCalledOnDestroyForSyncOnDone) {
   // Test: Cancel function will not be called if on_done is called synchronously
   utils::setStringFilterState(*mock_stream_info_.filter_state_,
-                              utils::kOperation, "get_header_key");
+                              utils::kFilterStateOperation, "get_header_key");
   TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/echo"}, {"x-api-key", "foobar"}};
   MockFunction<void()> mock_cancel;
@@ -963,7 +963,7 @@ TEST_F(HandlerTest, HandlerCancelFuncNotCalledOnDestroyForSyncOnDone) {
 TEST_F(HandlerTest, HandlerReportWithoutCheck) {
   // Test: Test that callReport works when callCheck is not called first.
   utils::setStringFilterState(*mock_stream_info_.filter_state_,
-                              utils::kOperation, "get_header_key");
+                              utils::kFilterStateOperation, "get_header_key");
   TestRequestHeaderMapImpl headers{
       {":method", "GET"}, {":path", "/echo"}, {"x-api-key", "foobar"}};
   TestResponseHeaderMapImpl response_headers{
@@ -987,7 +987,7 @@ TEST_F(HandlerTest, HandlerReportWithoutCheck) {
 TEST_F(HandlerTest, TryIntermediateReport) {
   // CollectDecodeData test cases after the boilerplate
   utils::setStringFilterState(*mock_stream_info_.filter_state_,
-                              utils::kOperation, "get_header_key");
+                              utils::kFilterStateOperation, "get_header_key");
   TestRequestHeaderMapImpl headers{{":method", "GET"},
                                    {":path", "/echo"},
                                    {"x-api-key", "foobar"},
@@ -1065,7 +1065,7 @@ TEST_F(HandlerTest, TryIntermediateReport) {
 TEST_F(HandlerTest, FinalReports) {
   // CollectEncodeData test cases after the boilerplate
   utils::setStringFilterState(*mock_stream_info_.filter_state_,
-                              utils::kOperation, "get_header_key");
+                              utils::kFilterStateOperation, "get_header_key");
   TestRequestHeaderMapImpl headers{{":method", "GET"},
                                    {":path", "/echo"},
                                    {"x-api-key", "foobar"},

--- a/src/envoy/http/service_control/mocks.h
+++ b/src/envoy/http/service_control/mocks.h
@@ -45,6 +45,9 @@ class MockServiceControlHandler : public ServiceControlHandler {
               (override));
 
   MOCK_METHOD(void, onDestroy, (), (override));
+
+  MOCK_METHOD(void, fillFilterState,
+              (::Envoy::StreamInfo::FilterState & filter_state), (override));
 };
 
 class MockServiceControlHandlerFactory : public ServiceControlHandlerFactory {

--- a/src/envoy/utils/filter_state_utils.h
+++ b/src/envoy/utils/filter_state_utils.h
@@ -26,6 +26,8 @@ constexpr char kOperation[] =
     "com.google.espv2.filters.http.path_matcher.operation";
 constexpr char kQueryParams[] =
     "com.google.espv2.filters.http.path_matcher.query_params";
+constexpr char kApiKey[] =
+    "com.google.espv2.filters.http.service_control.api_key";
 
 // Sets a read only string value in the filter state.
 void setStringFilterState(Envoy::StreamInfo::FilterState& filter_state,

--- a/src/envoy/utils/filter_state_utils.h
+++ b/src/envoy/utils/filter_state_utils.h
@@ -22,11 +22,13 @@ namespace envoy {
 namespace utils {
 
 // Data names in `FilterState` set by Path Matcher filter:
-constexpr char kOperation[] =
+constexpr char kFilterStateOperation[] =
     "com.google.espv2.filters.http.path_matcher.operation";
-constexpr char kQueryParams[] =
+constexpr char kFilterStateQueryParams[] =
     "com.google.espv2.filters.http.path_matcher.query_params";
-constexpr char kApiKey[] =
+
+// Data name in `FilterState` set by Service Control filter:
+constexpr char kFilterStateApiKey[] =
     "com.google.espv2.filters.http.service_control.api_key";
 
 // Sets a read only string value in the filter state.

--- a/tests/integration_test/access_log_test.go
+++ b/tests/integration_test/access_log_test.go
@@ -58,7 +58,7 @@ func TestAccessLog(t *testing.T) {
 	}
 
 	// For the detailed format grammar, refer to
-	// https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log#command-operators
+	// https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators
 	accessLogFormat := "\"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\"" +
 		"%RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT%" +
 		"\"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\"" +
@@ -78,7 +78,7 @@ func TestAccessLog(t *testing.T) {
 	makeOneRequest(t, s)
 	s.TearDown(t)
 	expectAccessLog := fmt.Sprintf("\"POST /echo?key=api-key HTTP/1.1\"200"+
-		" - 20 19\"-\" \"Go-http-client/1.1\"\"localhost:%v\" \"127.0.0.1:%v\" " +
+		" - 20 19\"-\" \"Go-http-client/1.1\"\"localhost:%v\" \"127.0.0.1:%v\" "+
 		"\"1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo\" \"api-key\"\n",
 		s.Ports().ListenerPort, s.Ports().BackendServerPort)
 

--- a/tests/integration_test/access_log_test.go
+++ b/tests/integration_test/access_log_test.go
@@ -62,7 +62,9 @@ func TestAccessLog(t *testing.T) {
 	accessLogFormat := "\"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\"" +
 		"%RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT%" +
 		"\"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\"" +
-		"\"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\"\n"
+		"\"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" " +
+		"%FILTER_STATE(com.google.espv2.filters.http.path_matcher.operation):60% " +
+		"%FILTER_STATE(com.google.espv2.filters.http.service_control.api_key):30%\n"
 
 	configID := "test-config-id"
 	args := []string{"--service_config_id=" + configID,
@@ -76,7 +78,8 @@ func TestAccessLog(t *testing.T) {
 	makeOneRequest(t, s)
 	s.TearDown(t)
 	expectAccessLog := fmt.Sprintf("\"POST /echo?key=api-key HTTP/1.1\"200"+
-		" - 20 19\"-\" \"Go-http-client/1.1\"\"localhost:%v\" \"127.0.0.1:%v\"\n",
+		" - 20 19\"-\" \"Go-http-client/1.1\"\"localhost:%v\" \"127.0.0.1:%v\" " +
+		"\"1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo\" \"api-key\"\n",
 		s.Ports().ListenerPort, s.Ports().BackendServerPort)
 
 	bytes, err := ioutil.ReadFile(accessLog)

--- a/tests/integration_test/access_log_test.go
+++ b/tests/integration_test/access_log_test.go
@@ -37,7 +37,7 @@ func tryRemoveFile(path string) error {
 
 func makeOneRequest(t *testing.T, s *env.TestEnv) {
 	wantResp := `{"message":"hello"}`
-	url := fmt.Sprintf("http://localhost:%v/echo?key=api-key", s.Ports().ListenerPort)
+	url := fmt.Sprintf("http://localhost:%v/echo?key=test-api-key", s.Ports().ListenerPort)
 	resp, err := client.DoPost(url, "hello")
 
 	if err != nil {
@@ -77,9 +77,9 @@ func TestAccessLog(t *testing.T) {
 	}
 	makeOneRequest(t, s)
 	s.TearDown(t)
-	expectAccessLog := fmt.Sprintf("\"POST /echo?key=api-key HTTP/1.1\"200"+
+	expectAccessLog := fmt.Sprintf("\"POST /echo?key=test-api-key HTTP/1.1\"200"+
 		" - 20 19\"-\" \"Go-http-client/1.1\"\"localhost:%v\" \"127.0.0.1:%v\" "+
-		"\"1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo\" \"api-key\"\n",
+		"\"1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo\" \"test-api-key\"\n",
 		s.Ports().ListenerPort, s.Ports().BackendServerPort)
 
 	bytes, err := ioutil.ReadFile(accessLog)


### PR DESCRIPTION
Implement this by adding one method "fillFilterState" in handler's interface to inject `filterState`,since streamInfo in handler shared by check and report is `const` and it is required by `log` interface.