### PR TITLE
replace typepb for genproto

### DIFF
--- a/src/go/configinfo/service_info.go
+++ b/src/go/configinfo/service_info.go
@@ -27,12 +27,12 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes"
-	"google.golang.org/protobuf/types/known/typepb"
 
 	commonpb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/v7/http/common"
 	scpb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/v7/http/service_control"
 	annotationspb "google.golang.org/genproto/googleapis/api/annotations"
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
+	typepb "google.golang.org/genproto/protobuf/ptype"
 )
 
 // ServiceInfo contains service level information.


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

To fix copybara problem:

Use google.golang.org/genproto/protobuf/ptype
to replace google.golang.org/protobuf/types/known/typepb

