### PR TITLE
Fix `glcoud_build_image`

### DIFF
--- a/docker/serverless/gcloud_build_image
+++ b/docker/serverless/gcloud_build_image
@@ -69,8 +69,7 @@ if [ -z "${ESP_FULL_VERSION}" ]; then
   # Find the tag with the longest length.
   ESP_FULL_VERSION=""
   for tag in "${TAGS_ARRAY[@]}"; do
-     if [ ${#tag} -gt ${#ESP_FULL_VERSION} ]
-     then
+     if [ ${#tag} -gt ${#ESP_FULL_VERSION} ]; then
         ESP_FULL_VERSION=${tag}
      fi
   done

--- a/docker/serverless/gcloud_build_image
+++ b/docker/serverless/gcloud_build_image
@@ -66,11 +66,14 @@ if [ -z "${ESP_FULL_VERSION}" ]; then
     error_exit "Did not find ESP version: ${ESP_TAG}"
   fi;
 
-  # Get the longest tag by creating an array indexed by tag length. Then use the last element.
-  for item in "${TAGS_ARRAY[@]}"; do
-    TAGS_BY_LENGTH[${#item}]=$item
+  # Find the tag with the longest length.
+  ESP_FULL_VERSION=""
+  for tag in "${TAGS_ARRAY[@]}"; do
+     if [ ${#tag} -gt ${#ESP_FULL_VERSION} ]
+     then
+        ESP_FULL_VERSION=${tag}
+     fi
   done
-  ESP_FULL_VERSION="${TAGS_BY_LENGTH[-1]}"
 fi
 echo "Building image for ESP version: ${ESP_FULL_VERSION}"
 


### PR DESCRIPTION
Indexing bash arrays by negative index is a new feature not supported in older shells. Instead, just run a loop to find the longest string.

Fixes #245

Signed-off-by: Teju Nareddy <nareddyt@google.com>