### PR TITLE
b/162452414: Fix tracing sample rate

### DIFF
--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -930,8 +930,6 @@ def gen_proxy_config(args):
     if args.enable_debug:
         proxy_conf.append("--suppress_envoy_headers=false")
 
-
-
     return proxy_conf
 
 def gen_envoy_args(args):

--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -58,26 +58,6 @@ def gen_bootstrap_conf(args):
     cmd = [BOOTSTRAP_CMD, "--logtostderr"]
 
     cmd.extend(["--admin_port", str(args.status_port)])
-    if args.disable_tracing:
-        cmd.append("--disable_tracing")
-    else:
-        if args.tracing_project_id:
-            cmd.extend(["--tracing_project_id", args.tracing_project_id])
-        if args.tracing_incoming_context:
-            cmd.extend(
-                ["--tracing_incoming_context", args.tracing_incoming_context])
-        if args.tracing_outgoing_context:
-            cmd.extend(
-                ["--tracing_outgoing_context", args.tracing_outgoing_context])
-        if args.cloud_trace_url_override:
-            cmd.extend(["--tracing_stackdriver_address",
-                        args.cloud_trace_url_override])
-
-        if args.disable_cloud_trace_auto_sampling:
-            cmd.extend(["--tracing_sample_rate", "0"])
-        elif args.tracing_sample_rate:
-            cmd.extend(["--tracing_sample_rate", str(args.tracing_sample_rate)])
-
     if args.http_request_timeout_s:
         cmd.extend(
             ["--http_request_timeout_s",
@@ -442,7 +422,6 @@ environment variable or by passing "-k" flag to this script.
         help="The Google project id for Stack driver tracing")
     parser.add_argument(
         '--tracing_sample_rate',
-        default=0.001,
         help='''
         Tracing sampling rate from 0.0 to 1.0.
         By default, 1 out of 1000 requests are sampled.
@@ -867,6 +846,24 @@ def gen_proxy_config(args):
 
     if args.disable_tracing:
         proxy_conf.append("--disable_tracing")
+    else:
+        if args.tracing_project_id:
+            proxy_conf.extend(["--tracing_project_id", args.tracing_project_id])
+        if args.tracing_incoming_context:
+            proxy_conf.extend(
+                ["--tracing_incoming_context", args.tracing_incoming_context])
+        if args.tracing_outgoing_context:
+            proxy_conf.extend(
+                ["--tracing_outgoing_context", args.tracing_outgoing_context])
+        if args.cloud_trace_url_override:
+            proxy_conf.extend(["--tracing_stackdriver_address",
+                        args.cloud_trace_url_override])
+
+        if args.disable_cloud_trace_auto_sampling:
+            proxy_conf.extend(["--tracing_sample_rate", "0"])
+        elif args.tracing_sample_rate:
+            proxy_conf.extend(["--tracing_sample_rate",
+                               str(args.tracing_sample_rate)])
 
     if args.transcoding_always_print_primitive_fields:
         proxy_conf.append("--transcoding_always_print_primitive_fields")
@@ -932,6 +929,8 @@ def gen_proxy_config(args):
 
     if args.enable_debug:
         proxy_conf.append("--suppress_envoy_headers=false")
+
+
 
     return proxy_conf
 

--- a/src/go/bootstrap/ads/bootstrap.go
+++ b/src/go/bootstrap/ads/bootstrap.go
@@ -17,7 +17,6 @@ package ads
 import (
 	"fmt"
 
-	"github.com/GoogleCloudPlatform/esp-v2/src/go/bootstrap"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/options"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	"github.com/golang/protobuf/ptypes"
@@ -90,12 +89,6 @@ func CreateBootstrapConfig(opts options.AdsBootstrapperOptions) (string, error) 
 				},
 			},
 		},
-	}
-
-	if !opts.DisableTracing {
-		if bt.Tracing, err = bootstrap.CreateTracing(opts.CommonOptions); err != nil {
-			return "", fmt.Errorf("failed to create tracing config, error: %v", err)
-		}
 	}
 
 	jsonStr, err := util.ProtoToJson(bt)

--- a/src/go/bootstrap/ads/bootstrap_test.go
+++ b/src/go/bootstrap/ads/bootstrap_test.go
@@ -91,31 +91,13 @@ func TestCreateBootstrapConfig(t *testing.T) {
         "type": "STRICT_DNS"
       }
     ]
-  },
-  "tracing": {
-    "http": {
-      "name": "envoy.tracers.opencensus",
-      "typedConfig": {
-        "@type": "type.googleapis.com/envoy.config.trace.v3.OpenCensusConfig",
-        "stackdriverExporterEnabled": true,
-        "stackdriverProjectId": "test_project",
-        "traceConfig": {
-          "maxNumberOfAnnotations": "32",
-          "maxNumberOfAttributes": "32",
-          "maxNumberOfLinks": "128",
-          "maxNumberOfMessageEvents": "128",
-          "probabilitySampler": {
-            "samplingProbability": 0.001
-          }
-        }
-      }
-    }
   }
 }`,
 		},
 		{
 			desc: "bootstrap with options",
 			args: map[string]string{
+				// TODO(nareddyt): Remove flag from bootstrap binary in follow-up PR
 				"disable_tracing": "true",
 				"admin_port":      "8001",
 				"node":            "test-node",

--- a/src/go/bootstrap/static/bootstrap.go
+++ b/src/go/bootstrap/static/bootstrap.go
@@ -49,12 +49,6 @@ func ServiceToBootstrapConfig(serviceConfig *confpb.Service, id string, opts opt
 		return nil, err
 	}
 
-	if !opts.DisableTracing {
-		if bt.Tracing, err = bootstrap.CreateTracing(opts.CommonOptions); err != nil {
-			return nil, fmt.Errorf("failed to create tracing config, error: %v", err)
-		}
-	}
-
 	bt.StaticResources = &bootstrappb.Bootstrap_StaticResources{
 		Listeners: listeners,
 		Clusters:  clusters,

--- a/src/go/configmanager/config_manager_test.go
+++ b/src/go/configmanager/config_manager_test.go
@@ -110,6 +110,7 @@ func TestFetchListeners(t *testing.T) {
 		opts := options.DefaultConfigGeneratorOptions()
 		opts.BackendAddress = tc.BackendAddress
 		opts.DisableTracing = !tc.enableTracing
+		opts.TracingProjectId = "fake-project-id"
 		opts.SuppressEnvoyHeaders = !tc.enableDebug
 
 		setFlags(testdata.TestFetchListenersProjectName, testdata.TestFetchListenersConfigID, util.FixedRolloutStrategy, "100ms", "")
@@ -384,6 +385,7 @@ func TestServiceConfigAutoUpdate(t *testing.T) {
 
 	opts := options.DefaultConfigGeneratorOptions()
 	opts.BackendAddress = tc.BackendAddress
+	opts.DisableTracing = true
 
 	setFlags(testProjectName, testConfigID, util.ManagedRolloutStrategy, "100ms", "")
 

--- a/src/go/configmanager/testdata/test_fetch_listeners.go
+++ b/src/go/configmanager/testdata/test_fetch_listeners.go
@@ -1373,12 +1373,32 @@ var (
                         }
                      ]
                   },
+                  "tracing":{
+                     "clientSampling":{},
+                     "overallSampling":{
+                        "value":0.1
+                     },
+                     "provider":{
+                        "name":"envoy.tracers.opencensus",
+                        "typedConfig":{
+                           "@type":"type.googleapis.com/envoy.config.trace.v3.OpenCensusConfig",
+                           "stackdriverExporterEnabled":true,
+                           "stackdriverProjectId":"fake-project-id",
+                           "traceConfig":{
+                              "maxNumberOfAnnotations":"32",
+                              "maxNumberOfAttributes":"32",
+                              "maxNumberOfLinks":"128",
+                              "maxNumberOfMessageEvents":"128"
+                           }
+                        }
+                     },
+                     "randomSampling":{
+                        "value":0.1
+                     }
+                  },
                   "upgradeConfigs": [{"upgradeType": "websocket"}],
                   "statPrefix":"ingress_http",
                   "commonHttpProtocolOptions":{"headersWithUnderscoresAction":"REJECT_REQUEST"},
-                  "tracing":{
-
-                  },
                   "useRemoteAddress":false,
                   %s,
                   "xffNumTrustedHops":2

--- a/src/go/tracing/tracing_test.go
+++ b/src/go/tracing/tracing_test.go
@@ -284,6 +284,46 @@ func TestHcmTracingSampleRate(t *testing.T) {
 			},
 		},
 		{
+			desc:              "Sample rate of 1 works",
+			tracingSampleRate: 1,
+			wantResult: &hcmpb.HttpConnectionManager_Tracing{
+				ClientSampling: &typepb.Percent{
+					Value: 0,
+				},
+				RandomSampling: &typepb.Percent{
+					Value: 100,
+				},
+				OverallSampling: &typepb.Percent{
+					Value: 100,
+				},
+				Provider: &tracepb.Tracing_Http{
+					Name: "envoy.tracers.opencensus",
+					// Typed config is already tested, so strip it out.
+					ConfigType: nil,
+				},
+			},
+		},
+		{
+			desc:              "Sample rate of 0 works",
+			tracingSampleRate: 0,
+			wantResult: &hcmpb.HttpConnectionManager_Tracing{
+				ClientSampling: &typepb.Percent{
+					Value: 0,
+				},
+				RandomSampling: &typepb.Percent{
+					Value: 0,
+				},
+				OverallSampling: &typepb.Percent{
+					Value: 0,
+				},
+				Provider: &tracepb.Tracing_Http{
+					Name: "envoy.tracers.opencensus",
+					// Typed config is already tested, so strip it out.
+					ConfigType: nil,
+				},
+			},
+		},
+		{
 			desc:              "Sample rate rounded at 6 decimal points",
 			tracingSampleRate: 0.123456789,
 			wantResult: &hcmpb.HttpConnectionManager_Tracing{

--- a/src/go/tracing/tracing_test.go
+++ b/src/go/tracing/tracing_test.go
@@ -244,6 +244,26 @@ func TestHcmTracingSampleRate(t *testing.T) {
 		wantError         string
 	}{
 		{
+			desc:              "Default sampling rate works",
+			tracingSampleRate: options.DefaultCommonOptions().TracingSamplingRate,
+			wantResult: &hcmpb.HttpConnectionManager_Tracing{
+				ClientSampling: &typepb.Percent{
+					Value: 0,
+				},
+				RandomSampling: &typepb.Percent{
+					Value: 0.1,
+				},
+				OverallSampling: &typepb.Percent{
+					Value: 0.1,
+				},
+				Provider: &tracepb.Tracing_Http{
+					Name: "envoy.tracers.opencensus",
+					// Typed config is already tested, so strip it out.
+					ConfigType: nil,
+				},
+			},
+		},
+		{
 			desc:              "Custom sampling rate works",
 			tracingSampleRate: 0.275,
 			wantResult: &hcmpb.HttpConnectionManager_Tracing{

--- a/src/go/util/marshal.go
+++ b/src/go/util/marshal.go
@@ -27,6 +27,7 @@ import (
 	scpb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/v7/http/service_control"
 
 	statspb "github.com/envoyproxy/go-control-plane/envoy/config/metrics/v3"
+	tracepb "github.com/envoyproxy/go-control-plane/envoy/config/trace/v3"
 	accessfilepb "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/file/v3"
 	accessgrpcpb "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/grpc/v3"
 	transcoderpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/grpc_json_transcoder/v3"
@@ -110,6 +111,8 @@ var Resolver = FuncResolver(func(url string) (proto.Message, error) {
 		return new(statspb.StatsSink), nil
 	case "type.googleapis.com/envoy.config.metrics.v3.StatsdSink":
 		return new(statspb.StatsdSink), nil
+	case "type.googleapis.com/envoy.config.trace.v3.OpenCensusConfig":
+		return new(tracepb.OpenCensusConfig), nil
 	default:
 		return nil, fmt.Errorf("unexpected protobuf.Any with url: %s", url)
 	}

--- a/tests/e2e/scripts/cloud-run/deploy.sh
+++ b/tests/e2e/scripts/cloud-run/deploy.sh
@@ -325,7 +325,7 @@ function setup() {
     -i "${APIPROXY_IMAGE}"
 
   # Redeploy ESPv2 to update the service config
-  proxy_args="^++^--tracing_sample_rate=0.00001++--tracing_outgoing_context=x-cloud-trace-context"
+  proxy_args="^++^--tracing_sample_rate=0.00005++--tracing_outgoing_context=x-cloud-trace-context"
 
   if [[ ${PROXY_PLATFORM} == "cloud-run" ]];
   then

--- a/tests/e2e/scripts/cloud-run/deploy.sh
+++ b/tests/e2e/scripts/cloud-run/deploy.sh
@@ -325,7 +325,7 @@ function setup() {
     -i "${APIPROXY_IMAGE}"
 
   # Redeploy ESPv2 to update the service config
-  proxy_args="^++^--tracing_sample_rate=0.00005++--tracing_outgoing_context=x-cloud-trace-context"
+  proxy_args="^++^--tracing_sample_rate=0.01++--tracing_outgoing_context=x-cloud-trace-context"
 
   if [[ ${PROXY_PLATFORM} == "cloud-run" ]];
   then

--- a/tests/e2e/scripts/gke/deploy.sh
+++ b/tests/e2e/scripts/gke/deploy.sh
@@ -41,7 +41,8 @@ PROJECT_ID="cloudesf-testing"
 # Parses parameters into config file.
 ARGS="$ARGS \"--service=${APIPROXY_SERVICE}\","
 ARGS="$ARGS \"--rollout_strategy=${ROLLOUT_STRATEGY}\","
-ARGS="$ARGS \"--tracing_sample_rate=0.00001\","
+ARGS="$ARGS \"--tracing_sample_rate=0.00005\","
+ARGS="$ARGS \"--tracing_outgoing_context=x-cloud-trace-context\","
 ARGS="$ARGS \"--admin_port=8001\""
 case "${BACKEND}" in
   'bookstore')

--- a/tests/e2e/scripts/gke/deploy.sh
+++ b/tests/e2e/scripts/gke/deploy.sh
@@ -41,7 +41,7 @@ PROJECT_ID="cloudesf-testing"
 # Parses parameters into config file.
 ARGS="$ARGS \"--service=${APIPROXY_SERVICE}\","
 ARGS="$ARGS \"--rollout_strategy=${ROLLOUT_STRATEGY}\","
-ARGS="$ARGS \"--tracing_sample_rate=0.00005\","
+ARGS="$ARGS \"--tracing_sample_rate=0.01\","
 ARGS="$ARGS \"--tracing_outgoing_context=x-cloud-trace-context\","
 ARGS="$ARGS \"--admin_port=8001\""
 case "${BACKEND}" in

--- a/tests/env/components/envoy.go
+++ b/tests/env/components/envoy.go
@@ -31,17 +31,9 @@ type Envoy struct {
 }
 
 // createEnvoyConf create envoy config.
-func createEnvoyConf(configPath string, bootstrapArgs []string, shouldEnableTrace bool, ports *Ports) error {
+func createEnvoyConf(configPath string, bootstrapArgs []string, ports *Ports) error {
 
 	glog.Infof("Outputting envoy bootstrap config to: %v", configPath)
-
-	if shouldEnableTrace {
-		bootstrapArgs = append(bootstrapArgs, "--tracing_sample_rate=1.0")
-		// This address must be in gRPC format: https://github.com/grpc/grpc/blob/master/doc/naming.md
-		bootstrapArgs = append(bootstrapArgs, fmt.Sprintf("--tracing_stackdriver_address=%v:%v:%v", platform.GetIpProtocol(), platform.GetLoopbackAddress(), ports.FakeStackdriverPort))
-	} else {
-		bootstrapArgs = append(bootstrapArgs, "--disable_tracing")
-	}
 
 	bootstrapArgs = append(bootstrapArgs, fmt.Sprintf("--discovery_port=%v", ports.DiscoveryPort))
 	bootstrapArgs = append(bootstrapArgs, fmt.Sprintf("--admin_port=%v", ports.AdminPort))
@@ -57,9 +49,9 @@ func createEnvoyConf(configPath string, bootstrapArgs []string, shouldEnableTrac
 }
 
 // NewEnvoy creates a new Envoy struct and starts envoy.
-func NewEnvoy(args []string, bootstrapArgs []string, confPath string, shouldEnableTrace bool, ports *Ports, testId uint16) (*Envoy, error) {
+func NewEnvoy(args []string, bootstrapArgs []string, confPath string, ports *Ports, testId uint16) (*Envoy, error) {
 
-	if err := createEnvoyConf(confPath, bootstrapArgs, shouldEnableTrace, ports); err != nil {
+	if err := createEnvoyConf(confPath, bootstrapArgs, ports); err != nil {
 		return nil, err
 	}
 

--- a/tests/env/components/fake_stackdriver_server.go
+++ b/tests/env/components/fake_stackdriver_server.go
@@ -46,7 +46,7 @@ func (s *FakeTraceServer) BatchWriteSpans(ctx context.Context, req *cloudtracepb
 }
 
 func (s *FakeTraceServer) CreateSpan(ctx context.Context, span *cloudtracepb.Span) (*cloudtracepb.Span, error) {
-	glog.Info("Fake stackdriver server created span with name: %v", span.DisplayName.Value)
+	glog.Infof("Fake stackdriver server created span with name: %v", span.DisplayName.Value)
 	return span, nil
 }
 

--- a/tests/env/components/fake_stackdriver_server.go
+++ b/tests/env/components/fake_stackdriver_server.go
@@ -38,8 +38,8 @@ type FakeTraceServer struct {
 }
 
 func (s *FakeTraceServer) BatchWriteSpans(ctx context.Context, req *cloudtracepb.BatchWriteSpansRequest) (*emptypb.Empty, error) {
-	for _, span := range req.Spans {
-		glog.Infof("Fake stackdriver server received span with name: %v", span.DisplayName.Value)
+	for i, span := range req.Spans {
+		glog.Infof("Fake stackdriver server received span %v with name: %v", i, span.DisplayName.Value)
 		s.RcvSpan <- span
 	}
 	return &emptypb.Empty{}, nil
@@ -60,7 +60,7 @@ func NewFakeStackdriver() *FakeTraceServer {
 
 	grpcServer := grpc.NewServer()
 	fsds := &FakeTraceServer{
-		RcvSpan: make(chan *cloudtracepb.Span, 10),
+		RcvSpan: make(chan *cloudtracepb.Span, 20),
 		server:  grpcServer,
 	}
 	cloudtracegrpc.RegisterTraceServiceServer(grpcServer, fsds)

--- a/tests/env/components/fake_stackdriver_server.go
+++ b/tests/env/components/fake_stackdriver_server.go
@@ -39,12 +39,14 @@ type FakeTraceServer struct {
 
 func (s *FakeTraceServer) BatchWriteSpans(ctx context.Context, req *cloudtracepb.BatchWriteSpansRequest) (*emptypb.Empty, error) {
 	for _, span := range req.Spans {
+		glog.Infof("Fake stackdriver server received span with name: %v", span.DisplayName.Value)
 		s.RcvSpan <- span
 	}
 	return &emptypb.Empty{}, nil
 }
 
 func (s *FakeTraceServer) CreateSpan(ctx context.Context, span *cloudtracepb.Span) (*cloudtracepb.Span, error) {
+	glog.Info("Fake stackdriver server created span with name: %v", span.DisplayName.Value)
 	return span, nil
 }
 

--- a/tests/env/components/fake_stackdriver_server.go
+++ b/tests/env/components/fake_stackdriver_server.go
@@ -114,5 +114,6 @@ func (s *FakeTraceServer) RetrieveSpanCount() (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	glog.Infof("got %v spans", len(names))
 	return len(names), nil
 }

--- a/tests/env/components/ports.go
+++ b/tests/env/components/ports.go
@@ -98,7 +98,6 @@ const (
 	TestServiceControlCheckRetry
 	TestServiceControlCheckServerFail
 	TestServiceControlCheckTimeout
-	TestServiceControlCheckTracesWithRetry
 	TestServiceControlCheckWrongServerName
 	TestServiceControlCredentialId
 	TestServiceControlFailedRequestReport
@@ -120,7 +119,6 @@ const (
 	TestServiceControlRequestWithAllowCors
 	TestServiceControlRequestWithoutAllowCors
 	TestServiceControlSkipUsage
-	TestServiceControlSkipUsageTraces
 	TestServiceControlTLSWithValidCert
 	TestServiceManagementWithInvalidCert
 	TestServiceManagementWithValidCert
@@ -128,6 +126,10 @@ const (
 	TestSimpleCorsWithRegexPreset
 	TestStatistics
 	TestStatisticsServiceControlCallStatus
+	TestTracesFetchingJwks
+	TestTracesServiceControlCheckWithRetry
+	TestTracesServiceControlSkipUsage
+	TestTracingSampleRate
 	TestTranscodingBindings
 	TestTranscodingIgnoreQueryParameters
 	TestTranscodingPrintOptions

--- a/tests/env/env.go
+++ b/tests/env/env.go
@@ -361,11 +361,10 @@ func (e *TestEnv) Setup(confArgs []string) error {
 	// Enable tracing if the stackdriver server was setup for this test
 	shouldEnableTrace := e.FakeStackdriverServer != nil
 	if shouldEnableTrace {
-		bootstrapperArgs = append(bootstrapperArgs, fmt.Sprintf("--tracing_sample_rate=%v", e.tracingSampleRate))
+		confArgs = append(confArgs, fmt.Sprintf("--tracing_sample_rate=%v", e.tracingSampleRate))
 		// This address must be in gRPC format: https://github.com/grpc/grpc/blob/master/doc/naming.md
-		bootstrapperArgs = append(bootstrapperArgs, fmt.Sprintf("--tracing_stackdriver_address=%v:%v:%v", platform.GetIpProtocol(), platform.GetLoopbackAddress(), e.ports.FakeStackdriverPort))
+		confArgs = append(confArgs, fmt.Sprintf("--tracing_stackdriver_address=%v:%v:%v", platform.GetIpProtocol(), platform.GetLoopbackAddress(), e.ports.FakeStackdriverPort))
 	} else {
-		bootstrapperArgs = append(bootstrapperArgs, "--disable_tracing")
 		confArgs = append(confArgs, "--disable_tracing")
 	}
 

--- a/tests/env/env.go
+++ b/tests/env/env.go
@@ -76,6 +76,7 @@ type TestEnv struct {
 	envoyDrainTimeInSec             int
 	ServiceControlServer            *components.MockServiceCtrl
 	FakeStackdriverServer           *components.FakeTraceServer
+	tracingSampleRate               float32
 	healthRegistry                  *components.HealthRegistry
 	FakeJwtService                  *components.FakeJwtService
 	skipHealthChecks                bool
@@ -266,9 +267,10 @@ func addDynamicRoutingBackendPort(serviceConfig *confpb.Service, port uint16) er
 	return nil
 }
 
-func (e *TestEnv) SetupFakeTraceServer() {
+func (e *TestEnv) SetupFakeTraceServer(sampleRate float32) {
 	// Start fake stackdriver server
 	e.FakeStackdriverServer = components.NewFakeStackdriver()
+	e.tracingSampleRate = sampleRate
 }
 
 func (e *TestEnv) DisableHttp2ForHttpsBackend() {
@@ -358,7 +360,12 @@ func (e *TestEnv) Setup(confArgs []string) error {
 
 	// Enable tracing if the stackdriver server was setup for this test
 	shouldEnableTrace := e.FakeStackdriverServer != nil
-	if !shouldEnableTrace {
+	if shouldEnableTrace {
+		bootstrapperArgs = append(bootstrapperArgs, fmt.Sprintf("--tracing_sample_rate=%v", e.tracingSampleRate))
+		// This address must be in gRPC format: https://github.com/grpc/grpc/blob/master/doc/naming.md
+		bootstrapperArgs = append(bootstrapperArgs, fmt.Sprintf("--tracing_stackdriver_address=%v:%v:%v", platform.GetIpProtocol(), platform.GetLoopbackAddress(), e.ports.FakeStackdriverPort))
+	} else {
+		bootstrapperArgs = append(bootstrapperArgs, "--disable_tracing")
 		confArgs = append(confArgs, "--disable_tracing")
 	}
 
@@ -400,7 +407,7 @@ func (e *TestEnv) Setup(confArgs []string) error {
 		envoyArgs = append(envoyArgs, "--drain-time-s", strconv.Itoa(e.envoyDrainTimeInSec))
 	}
 
-	e.envoy, err = components.NewEnvoy(envoyArgs, bootstrapperArgs, envoyConfPath, shouldEnableTrace, e.ports, e.testId)
+	e.envoy, err = components.NewEnvoy(envoyArgs, bootstrapperArgs, envoyConfPath, e.ports, e.testId)
 	if err != nil {
 		glog.Errorf("unable to create Envoy %v", err)
 		return err

--- a/tests/integration_test/opencensus_tracing_test.go
+++ b/tests/integration_test/opencensus_tracing_test.go
@@ -304,11 +304,11 @@ func TestTracingSampleRate(t *testing.T) {
 			numWantSpansMax:   1,
 		},
 		{
-			desc:              "A single request with sample rate 0.0 has 0 spans",
+			desc:              "20 requests with sample rate 0.0 has 0 spans",
 			clientProtocol:    "http",
 			httpMethod:        "GET",
 			tracingSampleRate: 0,
-			numRequests:       1,
+			numRequests:       20,
 			numWantSpansMin:   0,
 			numWantSpansMax:   0,
 		},

--- a/tests/integration_test/opencensus_tracing_test.go
+++ b/tests/integration_test/opencensus_tracing_test.go
@@ -313,14 +313,26 @@ func TestTracingSampleRate(t *testing.T) {
 			numWantSpansMax:   0,
 		},
 		{
-			// Binomial distribution tells us this has < 0.1% chance of failing.
-			desc:              "40 requests with sample rate 0.5 has [10, 30] spans",
+			// Don't make too many requests, as Envoy will batch writes with multiple minutes of delay.
+			// Binomial distribution tells us this test has < 0.3% chance of a false negative.
+			desc:              "20 requests with sample rate 0.5 has [4, 16] spans",
 			clientProtocol:    "http",
 			httpMethod:        "GET",
 			tracingSampleRate: 0.5,
-			numRequests:       40,
-			numWantSpansMin:   10,
-			numWantSpansMax:   30,
+			numRequests:       20,
+			numWantSpansMin:   4,
+			numWantSpansMax:   16,
+		},
+		{
+			// Don't make too many requests, as Envoy will batch writes with multiple minutes of delay.
+			// Binomial distribution tells us this test has < 0.3% chance of a false negative.
+			desc:              "20 requests with sample rate 0.9 has [14, 20] spans",
+			clientProtocol:    "http",
+			httpMethod:        "GET",
+			tracingSampleRate: 0.9,
+			numRequests:       20,
+			numWantSpansMin:   14,
+			numWantSpansMax:   20,
 		},
 	}
 

--- a/tests/integration_test/opencensus_tracing_test.go
+++ b/tests/integration_test/opencensus_tracing_test.go
@@ -315,24 +315,24 @@ func TestTracingSampleRate(t *testing.T) {
 		{
 			// Don't make too many requests, as Envoy will batch writes with multiple minutes of delay.
 			// Binomial distribution tells us this test has < 0.3% chance of a false negative.
-			desc:              "20 requests with sample rate 0.5 has [4, 16] spans",
+			desc:              "10 requests with sample rate 0.1 has [0, 4] spans",
 			clientProtocol:    "http",
 			httpMethod:        "GET",
-			tracingSampleRate: 0.5,
-			numRequests:       20,
-			numWantSpansMin:   4,
-			numWantSpansMax:   16,
+			tracingSampleRate: 0.1,
+			numRequests:       10,
+			numWantSpansMin:   0,
+			numWantSpansMax:   4,
 		},
 		{
 			// Don't make too many requests, as Envoy will batch writes with multiple minutes of delay.
 			// Binomial distribution tells us this test has < 0.3% chance of a false negative.
-			desc:              "20 requests with sample rate 0.9 has [14, 20] spans",
+			desc:              "5 requests with sample rate 0.9 has [2, 5] spans",
 			clientProtocol:    "http",
 			httpMethod:        "GET",
 			tracingSampleRate: 0.9,
-			numRequests:       20,
-			numWantSpansMin:   14,
-			numWantSpansMax:   20,
+			numRequests:       5,
+			numWantSpansMin:   2,
+			numWantSpansMax:   5,
 		},
 	}
 


### PR DESCRIPTION
All requests are being traced by default. Root caused in #248, tldr:
- Trace config should be set in HCM, not bootstrap config (deprecated since we've implemented this feature)
- Envoy's OpenCensus tracer extension does not use OpenCensus sampling config to determine sample rate. It uses Envoy's HCM Tracer config instead.

Added integration test for sampling rate to confirm the fix works.

Signed-off-by: Teju Nareddy <nareddyt@google.com>