### PR TITLE
b/161200191,b/162231154: Add api_method in service control filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 bazel-*/
-bazel-esp-v2/
 bazel-*
 vendor/
 bin/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bazel-*/
+bazel-esp-v2/
 bazel-*
 vendor/
 bin/

--- a/src/envoy/http/service_control/handler_impl.cc
+++ b/src/envoy/http/service_control/handler_impl.cc
@@ -110,6 +110,9 @@ ServiceControlHandlerImpl::~ServiceControlHandlerImpl() {}
 void ServiceControlHandlerImpl::fillFilterState(FilterState& filter_state) {
   utils::setStringFilterState(filter_state, utils::kFilterStateApiKey,
                               api_key_);
+
+  utils::setStringFilterState(filter_state, utils::kFilterStateApiMethod,
+                              require_ctx_->config().operation_name());
 }
 
 void ServiceControlHandlerImpl::onDestroy() {

--- a/src/envoy/http/service_control/handler_impl_test.cc
+++ b/src/envoy/http/service_control/handler_impl_test.cc
@@ -671,6 +671,9 @@ TEST_F(HandlerTest, FillFilterState) {
   EXPECT_EQ(utils::getStringFilterState(*mock_stream_info_.filter_state_,
                                         utils::kFilterStateApiKey),
             "foobar");
+  EXPECT_EQ(utils::getStringFilterState(*mock_stream_info_.filter_state_,
+                                        utils::kFilterStateApiMethod),
+            "get_header_key");
 }
 
 TEST_F(HandlerTest, HandlerFailQuotaSync) {

--- a/src/envoy/utils/filter_state_utils.h
+++ b/src/envoy/utils/filter_state_utils.h
@@ -30,6 +30,8 @@ constexpr char kFilterStateQueryParams[] =
 // Data name in `FilterState` set by Service Control filter:
 constexpr char kFilterStateApiKey[] =
     "com.google.espv2.filters.http.service_control.api_key";
+constexpr char kFilterStateApiMethod[] =
+    "com.google.espv2.filters.http.service_control.api_method";
 
 // Sets a read only string value in the filter state.
 void setStringFilterState(Envoy::StreamInfo::FilterState& filter_state,

--- a/tests/integration_test/access_log_test.go
+++ b/tests/integration_test/access_log_test.go
@@ -63,7 +63,7 @@ func TestAccessLog(t *testing.T) {
 	accessLogFormat := "\"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\"" +
 		"%RESPONSE_CODE% %RESPONSE_FLAGS% %BYTES_RECEIVED% %BYTES_SENT%" +
 		"\"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" " +
-		"%FILTER_STATE(com.google.espv2.filters.http.path_matcher.operation):70% " +
+		"%FILTER_STATE(com.google.espv2.filters.http.service_control.api_method):70% " +
 		"%FILTER_STATE(com.google.espv2.filters.http.service_control.api_key):30%" +
 		"\n"
 


### PR DESCRIPTION

Consider path matcher filter may be moved out of ESPv2 and using `xxx.path_matcher.operation` is not a long-standing solution for api-gateway to query the api-method log, so move this dependency on service control filter.