### PR TITLE
Deduplicate semantically equivalent paths generated by `allowCors`

### DIFF
--- a/src/go/configgenerator/route_generator.go
+++ b/src/go/configgenerator/route_generator.go
@@ -16,7 +16,6 @@ package configgenerator
 
 import (
 	"fmt"
-	"regexp"
 	"time"
 
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/configinfo"
@@ -239,11 +238,16 @@ func makeHttpRouteMatcher(httpRule *commonpb.Pattern) *routepb.RouteMatch {
 		return nil
 	}
 	var routeMatcher routepb.RouteMatch
-	re := regexp.MustCompile(`{[^{}]+}`)
 
-	// Replace path templates inside "{}" by regex "[^\/]+", which means
-	// any character except `/`, also adds `$` to match to the end of the string.
-	if re.MatchString(httpRule.UriTemplate) {
+	regex, err := util.GetRegexForUriWithPathParams(httpRule.UriTemplate)
+	if err != nil {
+		// Match with HttpHeader method. Some methods may have same path.
+		routeMatcher = routepb.RouteMatch{
+			PathSpecifier: &routepb.RouteMatch_Path{
+				Path: httpRule.UriTemplate,
+			},
+		}
+	} else {
 		routeMatcher = routepb.RouteMatch{
 			PathSpecifier: &routepb.RouteMatch_SafeRegex{
 				SafeRegex: &matcher.RegexMatcher{
@@ -254,18 +258,12 @@ func makeHttpRouteMatcher(httpRule *commonpb.Pattern) *routepb.RouteMatch {
 							},
 						},
 					},
-					Regex: re.ReplaceAllString(httpRule.UriTemplate, `[^\/]+`) + `$`,
+					Regex: regex,
 				},
 			},
 		}
-	} else {
-		// Match with HttpHeader method. Some methods may have same path.
-		routeMatcher = routepb.RouteMatch{
-			PathSpecifier: &routepb.RouteMatch_Path{
-				Path: httpRule.UriTemplate,
-			},
-		}
 	}
+
 	routeMatcher.Headers = []*routepb.HeaderMatcher{
 		{
 			Name: ":method",

--- a/src/go/configgenerator/route_generator.go
+++ b/src/go/configgenerator/route_generator.go
@@ -239,8 +239,8 @@ func makeHttpRouteMatcher(httpRule *commonpb.Pattern) *routepb.RouteMatch {
 	}
 	var routeMatcher routepb.RouteMatch
 
-	regex, err := util.GetRegexForUriWithPathParams(httpRule.UriTemplate)
-	if err != nil {
+	regex := util.WildcardMatcherForPath(httpRule.UriTemplate)
+	if regex == "" {
 		// Match with HttpHeader method. Some methods may have same path.
 		routeMatcher = routepb.RouteMatch{
 			PathSpecifier: &routepb.RouteMatch_Path{

--- a/src/go/configinfo/service_info.go
+++ b/src/go/configinfo/service_info.go
@@ -287,7 +287,7 @@ func (s *ServiceInfo) processEndpoints() {
 	}
 }
 
-func addHttpRule(method *methodInfo, r *annotationspb.HttpRule, httpPathWithOptionsSet map[string]bool) error {
+func addHttpRule(method *methodInfo, r *annotationspb.HttpRule, httpMatcherWithOptionsSet map[string]bool) error {
 
 	var httpRule *commonpb.Pattern
 	switch r.GetPattern().(type) {
@@ -321,7 +321,11 @@ func addHttpRule(method *methodInfo, r *annotationspb.HttpRule, httpPathWithOpti
 			UriTemplate: r.GetCustom().GetPath(),
 			HttpMethod:  r.GetCustom().GetKind(),
 		}
-		httpPathWithOptionsSet[r.GetCustom().GetPath()] = true
+		matcher, err := util.GetRegexForUriWithPathParams(r.GetCustom().GetPath())
+		if err != nil {
+			matcher = r.GetCustom().GetPath()
+		}
+		httpMatcherWithOptionsSet[matcher] = true
 	default:
 		return fmt.Errorf("unsupported http method %T", r.GetPattern())
 	}
@@ -332,14 +336,14 @@ func addHttpRule(method *methodInfo, r *annotationspb.HttpRule, httpPathWithOpti
 
 func (s *ServiceInfo) processHttpRule() error {
 	// An temporary map to record generated OPTION methods, to avoid duplication.
-	httpPathWithOptionsSet := make(map[string]bool)
+	httpMatcherWithOptionsSet := make(map[string]bool)
 
 	for _, rule := range s.ServiceConfig().GetHttp().GetRules() {
 		method, err := s.getOrCreateMethod(rule.GetSelector())
 		if err != nil {
 			return err
 		}
-		if err := addHttpRule(method, rule, httpPathWithOptionsSet); err != nil {
+		if err := addHttpRule(method, rule, httpMatcherWithOptionsSet); err != nil {
 			return err
 		}
 
@@ -348,7 +352,7 @@ func (s *ServiceInfo) processHttpRule() error {
 		// when interpret the httprules from the descriptor. Therefore, no need to
 		// check for nested additional_bindings.
 		for _, additionalRule := range rule.AdditionalBindings {
-			if err := addHttpRule(method, additionalRule, httpPathWithOptionsSet); err != nil {
+			if err := addHttpRule(method, additionalRule, httpMatcherWithOptionsSet); err != nil {
 				return err
 			}
 		}
@@ -361,9 +365,13 @@ func (s *ServiceInfo) processHttpRule() error {
 			method := s.Methods[r.GetSelector()]
 			for _, httpRule := range method.HttpRule {
 				if httpRule.HttpMethod != "OPTIONS" {
-					if _, exist := httpPathWithOptionsSet[httpRule.UriTemplate]; !exist {
+					matcher, err := util.GetRegexForUriWithPathParams(httpRule.UriTemplate)
+					if err != nil {
+						matcher = httpRule.UriTemplate
+					}
+					if _, exist := httpMatcherWithOptionsSet[matcher]; !exist {
 						s.addOptionMethod(method.ApiName, httpRule.UriTemplate, method.BackendInfo)
-						httpPathWithOptionsSet[httpRule.UriTemplate] = true
+						httpMatcherWithOptionsSet[matcher] = true
 					}
 
 				}

--- a/src/go/configinfo/service_info_test.go
+++ b/src/go/configinfo/service_info_test.go
@@ -921,6 +921,27 @@ func TestMethods(t *testing.T) {
 								Post: "/auth/info/googlejwt",
 							},
 						},
+						{
+							// This will also have a CORS method generated for it.
+							Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.GetBook",
+							Pattern: &annotationspb.HttpRule_Get{
+								Get: "/shelves/{shelf_id}/books/{book.id}",
+							},
+						},
+						{
+							// No CORS method generated due to an equivalent path.
+							Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.UpdateBook",
+							Pattern: &annotationspb.HttpRule_Patch{
+								Patch: "/shelves/{shelf_id}/books/{book.id}",
+							},
+						},
+						{
+							// No CORS method generated due to a **semantically** equivalent path.
+							Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.DeleteBook",
+							Pattern: &annotationspb.HttpRule_Delete{
+								Delete: "/shelves/{shelf_id_different_param}/books/{book.id}",
+							},
+						},
 					},
 				},
 			},
@@ -944,6 +965,47 @@ func TestMethods(t *testing.T) {
 						{
 							UriTemplate: "/echo",
 							HttpMethod:  util.POST,
+						},
+					},
+				},
+				"1.echo_api_endpoints_cloudesf_testing_cloud_goog.GetBook": &methodInfo{
+					ShortName: "GetBook",
+					ApiName:   "1.echo_api_endpoints_cloudesf_testing_cloud_goog",
+					HttpRule: []*commonpb.Pattern{
+						{
+							UriTemplate: "/shelves/{shelf_id}/books/{book.id}",
+							HttpMethod:  util.GET,
+						},
+					},
+				},
+				"1.echo_api_endpoints_cloudesf_testing_cloud_goog.CORS_shelves_shelf_id_books_book.id": &methodInfo{
+					ShortName: "CORS_shelves_shelf_id_books_book.id",
+					ApiName:   "1.echo_api_endpoints_cloudesf_testing_cloud_goog",
+					HttpRule: []*commonpb.Pattern{
+						{
+							UriTemplate: "/shelves/{shelf_id}/books/{book.id}",
+							HttpMethod:  util.OPTIONS,
+						},
+					},
+					IsGenerated: true,
+				},
+				"1.echo_api_endpoints_cloudesf_testing_cloud_goog.UpdateBook": &methodInfo{
+					ShortName: "UpdateBook",
+					ApiName:   "1.echo_api_endpoints_cloudesf_testing_cloud_goog",
+					HttpRule: []*commonpb.Pattern{
+						{
+							UriTemplate: "/shelves/{shelf_id}/books/{book.id}",
+							HttpMethod:  util.PATCH,
+						},
+					},
+				},
+				"1.echo_api_endpoints_cloudesf_testing_cloud_goog.DeleteBook": &methodInfo{
+					ShortName: "DeleteBook",
+					ApiName:   "1.echo_api_endpoints_cloudesf_testing_cloud_goog",
+					HttpRule: []*commonpb.Pattern{
+						{
+							UriTemplate: "/shelves/{shelf_id_different_param}/books/{book.id}",
+							HttpMethod:  util.DELETE,
 						},
 					},
 				},

--- a/src/go/util/url_util.go
+++ b/src/go/util/url_util.go
@@ -164,15 +164,15 @@ func ExtraAddressFromURI(jwksUri string) (string, error) {
 }
 
 // Returns a regex that will match requests to the uri with path parameters.
-// If there are no path params, returns error.
-func GetRegexForUriWithPathParams(uri string) (string, error) {
+// If there are no path params, returns empty string.
+func WildcardMatcherForPath(uri string) string {
 	if !pathParamMatcherRegexp.MatchString(uri) {
-		return "", fmt.Errorf("uri (%v) has no path parameters", uri)
+		return ""
 	}
 
 	// Replace path templates inside "{}" by regex "[^\/]+", which means
 	// any character except `/`, also adds `$` to match to the end of the string.
-	return pathParamMatcherRegexp.ReplaceAllString(uri, `[^\/]+`) + `$`, nil
+	return pathParamMatcherRegexp.ReplaceAllString(uri, `[^\/]+`) + `$`
 }
 
 var (

--- a/src/go/util/url_util.go
+++ b/src/go/util/url_util.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -34,6 +35,10 @@ const (
 
 	// Default port for DNS.
 	DNSDefaultPort = "53"
+)
+
+var (
+	pathParamMatcherRegexp = regexp.MustCompile(`{[^{}]+}`)
 )
 
 // ParseURI parses uri into scheme, hostname, port, path with err(if exist).
@@ -156,6 +161,18 @@ func ExtraAddressFromURI(jwksUri string) (string, error) {
 		return "", fmt.Errorf("Fail to parse uri %s with error %v", jwksUri, err)
 	}
 	return fmt.Sprintf("%s:%v", hostname, port), nil
+}
+
+// Returns a regex that will match requests to the uri with path parameters.
+// If there are no path params, returns error.
+func GetRegexForUriWithPathParams(uri string) (string, error) {
+	if !pathParamMatcherRegexp.MatchString(uri) {
+		return "", fmt.Errorf("uri (%v) has no path parameters", uri)
+	}
+
+	// Replace path templates inside "{}" by regex "[^\/]+", which means
+	// any character except `/`, also adds `$` to match to the end of the string.
+	return pathParamMatcherRegexp.ReplaceAllString(uri, `[^\/]+`) + `$`, nil
 }
 
 var (

--- a/src/go/util/url_util_test.go
+++ b/src/go/util/url_util_test.go
@@ -433,3 +433,30 @@ func TestFetchConfigRelatedUrl(t *testing.T) {
 	}
 
 }
+
+func TestWildcardMatcherForPath(t *testing.T) {
+	testData := []struct {
+		desc        string
+		uri         string
+		wantMatcher string
+	}{
+		{
+			desc:        "No path params",
+			uri:         "/shelves",
+			wantMatcher: "",
+		},
+		{
+			desc:        "Multiple path params",
+			uri:         "/shelves/{shelf_id}/books/{book.id}",
+			wantMatcher: `/shelves/[^\/]+/books/[^\/]+$`,
+		},
+	}
+
+	for _, tc := range testData {
+		got := WildcardMatcherForPath(tc.uri)
+
+		if tc.wantMatcher != got {
+			t.Errorf("Test (%v): \n got %v \nwant %v", tc.desc, got, tc.wantMatcher)
+		}
+	}
+}

--- a/src/go/util/url_util_test.go
+++ b/src/go/util/url_util_test.go
@@ -450,6 +450,11 @@ func TestWildcardMatcherForPath(t *testing.T) {
 			uri:         "/shelves/{shelf_id}/books/{book.id}",
 			wantMatcher: `/shelves/[^\/]+/books/[^\/]+$`,
 		},
+		{
+			desc:        "Path param with wildcard",
+			uri:         "/test/{x=*}/test/{y=**}",
+			wantMatcher: `/test/[^\/]+/test/[^\/]+$`,
+		},
 	}
 
 	for _, tc := range testData {

--- a/tests/env/components/ports.go
+++ b/tests/env/components/ports.go
@@ -124,6 +124,7 @@ const (
 	TestServiceControlTLSWithValidCert
 	TestServiceManagementWithInvalidCert
 	TestServiceManagementWithValidCert
+	TestStartupDuplicatedPathsWithAllowCors
 	TestSimpleCorsWithBasicPreset
 	TestSimpleCorsWithRegexPreset
 	TestStatistics


### PR DESCRIPTION
**Background:** When `AllowCors` is enabled, ESPv2 will generate `HttpRules` that allow `OPTIONS` requests for each path to pass through to the backend. We currently have some logic to deduplicate equivalent paths across multiple `Methods`.

**Problem**: The paths can have path parameters. If two paths have different parameter names, then our current deduplication logic will treat them as distinct paths. When we push this config to Path Matcher, it fails because Path Matcher understands the path parameter names do not matter in route matching.

See #254 for a customer running into this problem. While it's unlikely to happen, their use case makes sense to me.

**Fix**: We already have some _hacky_ regex that will construct a URL where any path parameters match. Re-use this for our path deduplication. Now our deduplication logic can handle semantically equivalent paths, just like Path Matcher.

**There is one drawback**: When we generate `Methods` for `OPTIONS` requests, we generate the operation name in a specific format:
```
Configured Path:   /shelves/{shelf_id}/books/{book.id}
Operation Name:   CORS_shelves_shelf_id_books_book.id
```

But now that we support looser path deduplication, the operation name is not accurate anymore. It could be a request for a similar path, but with different variable bindings (example: `/shelves/{shelf_id}/books/{b_id}`. This results extra REPORTs for the first path, and no REPORTs for any semantically equivalent paths.

It should be fine though, this is a minor bug and most users probably do not care about which `OPTIONS` requests are going to their backends.

**Testing**: 
- Unit tests to verify paths are correctly deduplicated now.
- Integration test. Without the fix, it results in a continuous loop with the following error message:
```
[2020-07-31 11:59:22.910][3185866][warning][config] [external/envoy/source/common/config/grpc_subscription_impl.cc:100] gRPC config for type.googleapis.com/envoy.config.listener.v3.Listener rejected: Error adding/updating listener(s) ingress_listener: Proto constraint validation failed (Duplicated pattern or invalid pattern): uri_template: "/bookstore/shelves/{shelf_with_different_path_parameter}" http_method: "OPTIONS"
```

Signed-off-by: Teju Nareddy <nareddyt@google.com>