### PR TITLE
Add logic to delete temporary directory in gcloud_build_image

### DIFF
--- a/docker/serverless/gcloud_build_image
+++ b/docker/serverless/gcloud_build_image
@@ -100,5 +100,8 @@ EOF
 
 NEW_IMAGE="gcr.io/${PROJECT}/endpoints-runtime-serverless:${ESP_FULL_VERSION}-${SERVICE}-${CONFIG_ID}"
 gcloud builds submit --tag "${NEW_IMAGE}" . --project="${PROJECT}"
+
+# Delete the temporary directory we created earlier.
+rm -r "${PWD}"
 )
 


### PR DESCRIPTION
When gcloud_build_image creates a temporary directory to store files for the build, that temporary directory is not deleted after the build has finished.
This PR adds directory deletion logic after the build.