### PR TITLE
Remove port replacement from GCS Runner

### DIFF
--- a/src/go/gcsrunner/fetch_config.go
+++ b/src/go/gcsrunner/fetch_config.go
@@ -36,8 +36,6 @@ import (
 type FetchConfigOptions struct {
 	BucketName                    string
 	ConfigFileName                string
-	WantPort                      uint32
-	LoopbackPort                  uint32
 	WriteFilePath                 string
 	FetchGCSObjectInitialInterval time.Duration
 	FetchGCSObjectTimeout         time.Duration

--- a/src/go/gcsrunner/main/runner.go
+++ b/src/go/gcsrunner/main/runner.go
@@ -24,13 +24,6 @@
 // `gsutil cp "gs://${BUCKET}/${CONFIG_FILE_NAME}" envoy.json`
 //
 // without needing `gsutil` in the image.
-//
-// Additionally, an optional `PORT` variable may be provided to override
-// where Envoy listens to traffic. This will be used only if the original config
-// specifies the port `8080`.
-//
-// Optionally, `LOOPBACK_PORT` may be used to configure Envoy configurations which
-// have an extra listener with the name "loopback_listener" to listen on this port.
 package main
 
 import (
@@ -61,17 +54,6 @@ var (
 
 func main() {
 	flag.Parse()
-	port, err := envNum("PORT", 8080)
-	if err != nil {
-		glog.Fatalf("Failed to get PORT number: %v", err)
-	}
-	loopbackPort, err := envNum("LOOPBACK_PORT", 8090)
-	if err != nil {
-		glog.Fatalf("Failed to get LOOPBACK_PORT number: %v", err)
-	}
-	if port == loopbackPort {
-		glog.Fatalf("PORT and LOOPBACK_PORT cannot be the same, got: (%d == %d)", port, loopbackPort)
-	}
 	bucketName := os.Getenv("BUCKET")
 	if bucketName == "" {
 		glog.Fatal("Must specify the BUCKET environment variable.")
@@ -103,8 +85,6 @@ func main() {
 	if err := gcsrunner.FetchConfigFromGCS(gcsrunner.FetchConfigOptions{
 		BucketName:                    bucketName,
 		ConfigFileName:                configFileName,
-		WantPort:                      port,
-		LoopbackPort:                  loopbackPort,
 		FetchGCSObjectInitialInterval: fetchGCSObjectInitialInterval,
 		FetchGCSObjectTimeout:         fetchGCSObjectTimeout,
 		WriteFilePath:                 envoyConfigPath,

--- a/src/go/gcsrunner/transform_config_test.go
+++ b/src/go/gcsrunner/transform_config_test.go
@@ -15,7 +15,6 @@
 package gcsrunner
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
@@ -23,8 +22,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	scpb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/v7/http/service_control"
-	corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 )
 
 func TestAddGCPAttributes(t *testing.T) {
@@ -87,161 +84,42 @@ func TestAddGCPAttributes(t *testing.T) {
 	}
 }
 
-func TestReplaceListenerPort(t *testing.T) {
-	testCases := []struct {
-		name                   string
-		listener, wantListener *listenerpb.Listener
-		wantPort               uint32
-		wantError              bool
-	}{
-		{
-			name:     "successful replace",
-			wantPort: 5678,
-			listener: &listenerpb.Listener{
-				Name: util.IngressListenerName,
-				Address: &corepb.Address{
-					Address: &corepb.Address_SocketAddress{
-						SocketAddress: &corepb.SocketAddress{
-							PortSpecifier: &corepb.SocketAddress_PortValue{
-								PortValue: 1234,
-							},
-						},
-					},
-				},
-			},
-			wantListener: &listenerpb.Listener{
-				Name: util.IngressListenerName,
-				Address: &corepb.Address{
-					Address: &corepb.Address_SocketAddress{
-						SocketAddress: &corepb.SocketAddress{
-							PortSpecifier: &corepb.SocketAddress_PortValue{
-								PortValue: 5678,
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "unset WantPort does not replace port",
-			listener: &listenerpb.Listener{
-				Name: util.IngressListenerName,
-				Address: &corepb.Address{
-					Address: &corepb.Address_SocketAddress{
-						SocketAddress: &corepb.SocketAddress{
-							PortSpecifier: &corepb.SocketAddress_PortValue{
-								PortValue: 1234,
-							},
-						},
-					},
-				},
-			},
-			wantListener: &listenerpb.Listener{
-				Name: util.IngressListenerName,
-				Address: &corepb.Address{
-					Address: &corepb.Address_SocketAddress{
-						SocketAddress: &corepb.SocketAddress{
-							PortSpecifier: &corepb.SocketAddress_PortValue{
-								PortValue: 1234,
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name:      "Invalid config should return an error",
-			wantPort:  5678,
-			wantError: true,
-			listener: &listenerpb.Listener{
-				Name: util.IngressListenerName,
-				Address: &corepb.Address{
-					Address: &corepb.Address_Pipe{
-						Pipe: &corepb.Pipe{},
-					},
-				},
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		err := replaceListenerPort(tc.listener, tc.wantPort)
-		if (err != nil) != tc.wantError {
-			t.Errorf("%s: replaceListenerPort(%v,%v) returned error %v, want err!=nil to be %v", tc.name, tc.listener, tc.wantPort, err, tc.wantError)
-		}
-
-		if err == nil {
-			if diff := cmp.Diff(tc.wantListener, tc.listener, cmp.Comparer(proto.Equal)); diff != "" {
-				t.Errorf("%s: replaceListenerPort returned unexpected result: (-want/+got): %s", tc.name, diff)
-			}
-		}
-	}
-}
-
 func TestTransformConfigBytes(t *testing.T) {
-	opts := FetchConfigOptions{
-		WantPort:     1234,
-		LoopbackPort: 5678,
-	}
-
 	testCases := []struct {
-		name            string
-		config          []byte
-		requireLoopback bool
+		name      string
+		config    []byte
+		wantError bool
 	}{
 		{
-			name:            "Valid config",
-			config:          validConfigInput,
-			requireLoopback: true,
+			name:   "Valid config",
+			config: validConfigInput,
 		},
 		{
-			name:            "Valid config with old name (http_listener)",
-			config:          validConfigInputHTTPListener,
-			requireLoopback: true,
-		},
-		{
-			name:            "Valid config with old name (https_listener)",
-			config:          validConfigInputHTTPSListener,
-			requireLoopback: true,
-		},
-		{
-			name:   "Valid config without Loopback",
-			config: validConfigInputWithoutLoopback,
+			name:      "Invalid config missing ingress_listener",
+			config:    invalidConfigInput,
+			wantError: true,
 		},
 	}
 
 	for _, tc := range testCases {
-		doListenerCalledOnIngress := false
-		doListenerCalledOnLoopback := false
 		doServiceControlCalled := false
-		doListenerTransform = func(_ *listenerpb.Listener, port uint32) error {
-			switch port {
-			case opts.WantPort:
-				doListenerCalledOnIngress = true
-				return nil
-			case opts.LoopbackPort:
-				doListenerCalledOnLoopback = true
-				return nil
-			default:
-				return fmt.Errorf("wrong parameters: doListenerTransform(%d), want %d or %d", port, opts.WantPort, opts.LoopbackPort)
-			}
-		}
 		doServiceControlTransform = func(_ *scpb.FilterConfig, _ FetchConfigOptions) error {
 			doServiceControlCalled = true
 			return nil
 		}
+		opts := FetchConfigOptions{}
 		_, err := transformConfigBytes(tc.config, opts)
-		if err != nil {
-			t.Fatalf("transformConfigBytes() returned %v, want nil", err)
-		}
-		if !doListenerCalledOnIngress {
-			t.Errorf("doListenerTransform was not called for ingress_listener")
-		}
-		if !doListenerCalledOnLoopback && tc.requireLoopback {
-			t.Errorf("doListenerTransform was not called for loopback_listener")
-		}
-		if !doServiceControlCalled {
-			t.Errorf("doServiceControlTransform was not called")
+		if tc.wantError {
+			if err == nil {
+				t.Fatal("transformConfigBytes() returned nil, want an error", err)
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("transformConfigBytes() returned %v, want nil", err)
+			}
+			if !doServiceControlCalled {
+				t.Errorf("doServiceControlTransform was not called")
+			}
 		}
 	}
 }
@@ -289,117 +167,9 @@ var validConfigInput = []byte(`{
   }
 }`)
 
-var validConfigInputWithoutLoopback = []byte(`{
+var invalidConfigInput = []byte(`{
 "static_resources": {
     "listeners": [
-      {
-      "name": "ingress_listener",
-        "address": {
-          "socket_address": {
-            "port_value": 1111
-          }
-        },
-        "filter_chains": [
-          {
-            "filters": [
-              {
-                "name": "envoy.filters.network.http_connection_manager",
-                "typed_config": {
-                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                  "http_filters": [
-                    {
-                      "name": "com.google.espv2.filters.http.service_control",
-                      "typed_config": {
-                        "@type": "type.googleapis.com/espv2.api.envoy.v7.http.service_control.FilterConfig"
-                      }
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  }
-}`)
-
-// This config has a listener name which old configs will be using.
-var validConfigInputHTTPListener = []byte(`{
-"static_resources": {
-    "listeners": [
-      {
-      "name": "http_listener",
-        "address": {
-          "socket_address": {
-            "port_value": 1111
-          }
-        },
-        "filter_chains": [
-          {
-            "filters": [
-              {
-                "name": "envoy.filters.network.http_connection_manager",
-                "typed_config": {
-                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                  "http_filters": [
-                    {
-                      "name": "com.google.espv2.filters.http.service_control",
-                      "typed_config": {
-                        "@type": "type.googleapis.com/espv2.api.envoy.v7.http.service_control.FilterConfig"
-                      }
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "name": "loopback_listener",
-        "address": {
-          "socket_address": {
-            "port_value": 2222
-          }
-        }
-      }
-    ]
-  }
-}`)
-
-// This config has a listener name which old configs will be using.
-var validConfigInputHTTPSListener = []byte(`{
-"static_resources": {
-    "listeners": [
-      {
-      "name": "https_listener",
-        "address": {
-          "socket_address": {
-            "port_value": 1111
-          }
-        },
-        "filter_chains": [
-          {
-            "filters": [
-              {
-                "name": "envoy.filters.network.http_connection_manager",
-                "typed_config": {
-                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                  "http_filters": [
-                    {
-                      "name": "com.google.espv2.filters.http.service_control",
-                      "typed_config": {
-                        "@type": "type.googleapis.com/espv2.api.envoy.v7.http.service_control.FilterConfig"
-                      }
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        ]
-      },
       {
         "name": "loopback_listener",
         "address": {


### PR DESCRIPTION
This is the job of the management and control planes, so by the time the runtime plane starts up, the port replacement is not only redundant but a vector for bugs.

This was originally used because Cloud Run did not guarantee the correct port was in use and recommended that containers read from the PORT variable. By switching off of Cloud Run, we can gaurantee the ports we want will be available.

TESTED=Ran E2E on our end using the image built in this PR.