### PR TITLE
E2E test with ESPv2 TLS Termination

### DIFF
--- a/tests/e2e/client/apiproxy_bookstore_key_restriction_test.py
+++ b/tests/e2e/client/apiproxy_bookstore_key_restriction_test.py
@@ -38,7 +38,7 @@ class ApiProxyBookstoreTest(ApiProxyClientTest):
     """
 
     def __init__(self):
-        ApiProxyClientTest.__init__(self, FLAGS.host,
+        ApiProxyClientTest.__init__(self, FLAGS.host, '',
                                FLAGS.allow_unverified_cert,
                                FLAGS.verbose)
 

--- a/tests/e2e/client/utils.py
+++ b/tests/e2e/client/utils.py
@@ -64,24 +64,26 @@ def red(text):
 
 def http_connection(host, allow_unverified_cert):
     if host.startswith(HTTPS_PREFIX):
+        print('Create HTTPS connection')
         host = host[len(HTTPS_PREFIX):]
-        print 'Use https to connect: %s' % host
+
+        ssl_ctx = ssl.create_default_context()
         if allow_unverified_cert:
-            try:
-                return httplib.HTTPSConnection(
-                    host, timeout=10, context=ssl._create_unverified_context())
-            except AttributeError:
-                # Legacy versions of python do not check certificate.
-                return httplib.HTTPSConnection(
-                    host, timeout=10)
+            print('Certs NOT verified for this connection')
+            ssl_ctx.check_hostname = False
+            ssl_ctx.verify_mode = ssl.CERT_NONE
         else:
-            return httplib.HTTPSConnection(host)
+            print('Certs will be verified for this connection')
+            ssl_ctx.check_hostname = True
+            ssl_ctx.verify_mode = ssl.CERT_REQUIRED
+        return httplib.HTTPSConnection(host, timeout=10, context=ssl_ctx)
+
     else:
+        print('Create HTTP connection')
         if host.startswith(HTTP_PREFIX):
             host = host[len(HTTP_PREFIX):]
         else:
             host = host
-        print 'Use http to connect: %s' % host
         return httplib.HTTPConnection(host)
 
 

--- a/tests/e2e/testdata/bookstore/gke/http-bookstore.yaml.template
+++ b/tests/e2e/testdata/bookstore/gke/http-bookstore.yaml.template
@@ -18,11 +18,11 @@ metadata:
   name: app
 spec:
   ports:
-  # Port that accepts gRPC and JSON/HTTP2 requests over HTTP.
-  - port: 80
+  # Port that accepts gRPC and JSON/HTTP2 requests over HTTPS.
+  - port: 443
     targetPort: 8080
     protocol: TCP
-    name: http
+    name: https
   - port: 8001
     targetPort: 8001
     protocol: TCP
@@ -49,6 +49,9 @@ spec:
         - name: service-account-cred
           secret:
             secretName: service-account-cred
+        - name: esp-ssl
+          secret:
+            secretName: esp-ssl
       containers:
       - name: apiproxy
         image: APIPROXY_IMAGE
@@ -58,6 +61,9 @@ spec:
         volumeMounts:
           - mountPath: /etc/creds
             name: service-account-cred
+            readOnly: true
+          - mountPath: /etc/esp/ssl
+            name: esp-ssl
             readOnly: true
         imagePullPolicy: Always
       - name: bookstore


### PR DESCRIPTION
Modify the http-bookstore on GKE e2e test. 
- ESPv2 is deployed onto GKE with TLS termination and a self-signed cert.
- K8s service routes port 443 to non-privileged ESPv2 container port.
- All pre-existing e2e tests run as expected. Note they do NOT verify the validity of the self-signed cert (including hostname).

Signed-off-by: Teju Nareddy <nareddyt@google.com>