### PR TITLE
Add more port restrictions for usability

### DIFF
--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -590,8 +590,8 @@ environment variable or by passing "-k" flag to this script.
 
     parser.add_argument('--ssl_port', default=None, type=int, help='''
         This flag added for backward compatible for ESPv1 and will be deprecated.
-        Please use the flag --ssl_server_cert_path instead. When configured, ESPv2
-        accepts HTTP/1.x and HTTP/2 secure connections on this port,
+        Please use the flags --listener_port and --ssl_server_cert_path instead. 
+        When configured, ESPv2 accepts HTTP/1.x and HTTP/2 secure connections on this port,
         Requires the certificate and key files /etc/nginx/ssl/nginx.crt and
         /etc/nginx/ssl/nginx.key''')
 
@@ -674,14 +674,26 @@ def enforce_conflict_args(args):
          return "Flag --generate_self_signed_cert and --ssl_server_cert_path cannot be used simutaneously."
 
     port_flags = []
+    port_num = DEFAULT_LISTENER_PORT
     if args.http_port:
         port_flags.append("--http_port")
+        port_num = args.http_port
     if args.http2_port:
         port_flags.append("--http2_port")
+        port_num = args.http2_port
     if args.listener_port:
         port_flags.append("--listener_port")
+        port_num = args.listener_port
+    if args.ssl_port:
+        port_flags.append("--ssl_port")
+        port_num = args.ssl_port
+
     if len(port_flags) > 1:
-        return "Multiple port flags {} are not allowed, please just use --listener_port flag".format(",".join(port_flags))
+        return "Multiple port flags {} are not allowed, use only the --listener_port flag".format(",".join(port_flags))
+    elif port_num < 1024:
+        return "Port {} is a privileged port. " \
+               "For security purposes, the ESPv2 container cannot bind to it. " \
+               "Use any port above 1024 instead.".format(port_num)
 
     if args.ssl_protocols and (args.ssl_minimum_protocol or args.ssl_maximum_protocol):
         return "Flag --ssl_protocols is going to be deprecated, please use --ssl_minimum_protocol and --ssl_maximum_protocol."

--- a/tests/start_proxy/start_proxy_test.py
+++ b/tests/start_proxy/start_proxy_test.py
@@ -111,11 +111,11 @@ class TestStartProxy(unittest.TestCase):
               '/etc/endpoint/ssl', '--disable_tracing'
               ]),
             # legacy ssl_port specified
-            (['-R=managed','--ssl_port=443'],
+            (['-R=managed','--ssl_port=9000'],
              ['bin/configmanager', '--logtostderr', '--rollout_strategy', 'managed',
               '--backend_address', 'http://127.0.0.1:8082', '--v', '0',
               '--ssl_server_cert_path', '/etc/nginx/ssl',
-              '--listener_port', '443',
+              '--listener_port', '9000',
               ]),
             # ssl_client_cert_path specified
             (['-R=managed','--listener_port=8080',  '--disable_tracing',
@@ -388,9 +388,17 @@ class TestStartProxy(unittest.TestCase):
              '--service_json_path=/tmp/service.json'],
             ['--backend_dns_lookup_family=v4'],
             ['--non_gcp'],
-            ['--http_port=80', '--http2_port=80'],
-            ['--http_port=80', '--listener_port=80'],
-            ['--ssl_server_cert_path=/etc/endpoint/ssl', '--ssl_port=443'],
+            # Duplicate port flags.
+            ['--http_port=8000', '--http2_port=8000'],
+            ['--http_port=8000', '--listener_port=8000'],
+            ['--listener_port=8000', '--ssl_port=9000'],
+            # Privileged ports.
+            ['--listener_port=80'],
+            ['--http_port=80'],
+            ['--listener_port=80'],
+            ['--ssl_port=443'],
+            # SSL config.
+            ['--ssl_server_cert_path=/etc/endpoint/ssl', '--ssl_port=9000'],
             ['--ssl_server_cert_path=/etc/endpoint/ssl', '--generate_self_signed_cert'],
             ['--ssl_client_cert_path=/etc/endpoint/ssl', '--tls_mutual_auth'],
             ['--ssl_protocols=TLSv1.3',  '--ssl_minimum_protocol=TLSv1.1'],
@@ -404,7 +412,7 @@ class TestStartProxy(unittest.TestCase):
 
         for flags in testcases:
           with self.assertRaises(SystemExit) as cm:
-            gotArgs = gen_proxy_config(self.parser.parse_args(flags))
+            gen_proxy_config(self.parser.parse_args(flags))
           print(cm.exception)
           self.assertEqual(cm.exception.code, 1)
 

--- a/tests/start_proxy/start_proxy_test.py
+++ b/tests/start_proxy/start_proxy_test.py
@@ -395,7 +395,7 @@ class TestStartProxy(unittest.TestCase):
             # Privileged ports.
             ['--listener_port=80'],
             ['--http_port=80'],
-            ['--listener_port=80'],
+            ['--http2_port=80'],
             ['--ssl_port=443'],
             # SSL config.
             ['--ssl_server_cert_path=/etc/endpoint/ssl', '--ssl_port=9000'],


### PR DESCRIPTION
Based on my tests of deploying ESPv2 with SSL.

- `--ssl_port` and `--listener_port` cannot be used together.
- Specified port must be non-privileged.

Signed-off-by: Teju Nareddy <nareddyt@google.com>