### PR TITLE
b/156286299: GCS Runner: Enable statsd with --service-cluster and --service-node flags

### DIFF
--- a/src/go/gcsrunner/start_envoy.go
+++ b/src/go/gcsrunner/start_envoy.go
@@ -42,6 +42,8 @@ type StartEnvoyOptions struct {
 func StartEnvoyAndWait(signalChan chan os.Signal, opts StartEnvoyOptions) error {
 	cmd := execCommand(
 		opts.BinaryPath,
+		"--service-cluster", "front-envoy",
+		"--service-node", "front-envoy",
 		"--disable-hot-restart",
 		"--config-path", opts.ConfigPath,
 		"--log-level", opts.LogLevel,


### PR DESCRIPTION
I'm not entirely sure why these flags are required for StatsdSink, but they are. Without these flags, StatsdSink silently never starts up.