### PR TITLE
b/165086608: Use dedicated SA Key for JWT e2e tests

### DIFF
--- a/examples/grpc_dynamic_routing/envoy_config.json
+++ b/examples/grpc_dynamic_routing/envoy_config.json
@@ -449,14 +449,14 @@
                             "fromParams": [
                               "access_token"
                             ],
-                            "issuer": "245521401045-compute@developer.gserviceaccount.com",
+                            "issuer": "e2e-client-jwk@cloudesf-testing.iam.gserviceaccount.com",
                             "payloadInMetadata": "jwt_payloads",
                             "remoteJwks": {
                               "cacheDuration": "300s",
                               "httpUri": {
                                 "cluster": "www.googleapis.com:443",
                                 "timeout": "30s",
-                                "uri": "https://www.googleapis.com/service_accounts/v1/jwk/245521401045-compute@developer.gserviceaccount.com"
+                                "uri": "https://www.googleapis.com/service_accounts/v1/jwk/e2e-client-jwk@cloudesf-testing.iam.gserviceaccount.com"
                               }
                             }
                           }

--- a/examples/grpc_dynamic_routing/grpc-test.yaml
+++ b/examples/grpc_dynamic_routing/grpc-test.yaml
@@ -25,8 +25,8 @@ authentication:
         - provider_id: test_jwk
   providers:
     - id: test_jwk
-      issuer: 245521401045-compute@developer.gserviceaccount.com
-      jwks_uri: https://www.googleapis.com/service_accounts/v1/jwk/245521401045-compute@developer.gserviceaccount.com
+      issuer: e2e-client-jwk@cloudesf-testing.iam.gserviceaccount.com
+      jwks_uri: https://www.googleapis.com/service_accounts/v1/jwk/e2e-client-jwk@cloudesf-testing.iam.gserviceaccount.com
 usage:
   rules:
     - selector: test.grpc.Test.Echo

--- a/examples/grpc_dynamic_routing/service_config_generated.json
+++ b/examples/grpc_dynamic_routing/service_config_generated.json
@@ -69,8 +69,8 @@
     "providers": [
       {
         "id": "test_jwk",
-        "issuer": "245521401045-compute@developer.gserviceaccount.com",
-        "jwksUri": "https://www.googleapis.com/service_accounts/v1/jwk/245521401045-compute@developer.gserviceaccount.com"
+        "issuer": "e2e-client-jwk@cloudesf-testing.iam.gserviceaccount.com",
+        "jwksUri": "https://www.googleapis.com/service_accounts/v1/jwk/e2e-client-jwk@cloudesf-testing.iam.gserviceaccount.com"
       }
     ],
     "rules": [

--- a/tests/e2e/scripts/gen-auth-token.sh
+++ b/tests/e2e/scripts/gen-auth-token.sh
@@ -48,7 +48,8 @@ while getopts a:c:s:? arg; do
 done
 
 # By default, use jwk key. Can be switched to x509 or symmetric key.
-SECRET_FILE="${SECRET_FILE:-$(get_test_client_key e2e-client-jwk.json ${ROOT}/tests/e2e/client/test-client-secret-jwk.json)}"
+KEY_PATH="$(mktemp /tmp/test-client-secret-jwk.XXXX)"
+SECRET_FILE="${SECRET_FILE:-$(get_test_client_key e2e-client-jwk.json ${KEY_PATH})}"
 
 go run ${ROOT}/tests/e2e/client/jwt_client.go \
   --service-account-file=${SECRET_FILE} \

--- a/tests/e2e/scripts/gen-auth-token.sh
+++ b/tests/e2e/scripts/gen-auth-token.sh
@@ -26,7 +26,7 @@ ROOT="$(cd "${SCRIPT_PATH}/../../.." && pwd)"
 # By default audience is service name,  use -a to change it to your service
 # name or other allowed audiences (check service swagger configuration).
 AUDIENCE="apiproxy.cloudendpointsapis.com"
-SERVICE_ACCOUNT="245521401045-compute@developer.gserviceaccount.com"
+SERVICE_ACCOUNT="e2e-client-jwk@cloudesf-testing.iam.gserviceaccount.com"
 
 function usage() {
   echo "usage: $0 [options ...]"
@@ -48,7 +48,7 @@ while getopts a:c:s:? arg; do
 done
 
 # By default, use jwk key. Can be switched to x509 or symmetric key.
-SECRET_FILE="${SECRET_FILE:-$(get_test_client_key e2e-client-service-account.json ${ROOT}/tests/e2e/client/test-client-secret-jwk.json)}"
+SECRET_FILE="${SECRET_FILE:-$(get_test_client_key e2e-client-jwk.json ${ROOT}/tests/e2e/client/test-client-secret-jwk.json)}"
 
 go run ${ROOT}/tests/e2e/client/jwt_client.go \
   --service-account-file=${SECRET_FILE} \

--- a/tests/e2e/scripts/gen-auth-token.sh
+++ b/tests/e2e/scripts/gen-auth-token.sh
@@ -48,7 +48,7 @@ while getopts a:c:s:? arg; do
 done
 
 # By default, use jwk key. Can be switched to x509 or symmetric key.
-KEY_PATH="$(mktemp /tmp/test-client-secret-jwk.XXXX)"
+KEY_PATH="$(mktemp /tmp/e2e-client-secret-jwk.XXXX)"
 SECRET_FILE="${SECRET_FILE:-$(get_test_client_key e2e-client-jwk.json ${KEY_PATH})}"
 
 go run ${ROOT}/tests/e2e/client/jwt_client.go \

--- a/tests/endpoints/bookstore/bookstore_swagger_template.json
+++ b/tests/endpoints/bookstore/bookstore_swagger_template.json
@@ -527,8 +527,8 @@
       "authorizationUrl": "",
       "flow": "implicit",
       "type": "oauth2",
-      "x-google-issuer": "245521401045-compute@developer.gserviceaccount.com",
-      "x-google-jwks_uri": "https://www.googleapis.com/service_accounts/v1/jwk/245521401045-compute@developer.gserviceaccount.com",
+      "x-google-issuer": "e2e-client-jwk@cloudesf-testing.iam.gserviceaccount.com",
+      "x-google-jwks_uri": "https://www.googleapis.com/service_accounts/v1/jwk/e2e-client-jwk@cloudesf-testing.iam.gserviceaccount.com",
       "x-google-audiences": "bookstore.endpoints.cloudesf-testing.cloud.goog",
       "x-google-jwt-locations": [
         {

--- a/tests/endpoints/grpc_echo/grpc-test-dynamic-routing.tmpl.yaml
+++ b/tests/endpoints/grpc_echo/grpc-test-dynamic-routing.tmpl.yaml
@@ -25,8 +25,8 @@ authentication:
         - provider_id: test_jwk
   providers:
     - id: test_jwk
-      issuer: 245521401045-compute@developer.gserviceaccount.com
-      jwks_uri: https://www.googleapis.com/service_accounts/v1/jwk/245521401045-compute@developer.gserviceaccount.com
+      issuer: e2e-client-jwk@cloudesf-testing.iam.gserviceaccount.com
+      jwks_uri: https://www.googleapis.com/service_accounts/v1/jwk/e2e-client-jwk@cloudesf-testing.iam.gserviceaccount.com
 usage:
   rules:
     - selector: test.grpc.Test.Echo

--- a/tests/endpoints/grpc_echo/grpc-test.yaml
+++ b/tests/endpoints/grpc_echo/grpc-test.yaml
@@ -25,8 +25,8 @@ authentication:
         - provider_id: test_jwk
   providers:
     - id: test_jwk
-      issuer: 245521401045-compute@developer.gserviceaccount.com
-      jwks_uri: https://www.googleapis.com/service_accounts/v1/jwk/245521401045-compute@developer.gserviceaccount.com
+      issuer: e2e-client-jwk@cloudesf-testing.iam.gserviceaccount.com
+      jwks_uri: https://www.googleapis.com/service_accounts/v1/jwk/e2e-client-jwk@cloudesf-testing.iam.gserviceaccount.com
 usage:
   rules:
     - selector: test.grpc.Test.Echo


### PR DESCRIPTION
- Reduce the chance of leaking the SA Key: e2e tests download the key into the `/tmp` folder instead of the repository. This will prevent accidentally committing the file.
- Reduce the risk of malicious use if a leak occurs: Current tests use the default compute developer account. This has broad roles. Instead, create a dedicated service account with no roles at all.