### PR TITLE
Update e2e deployment yaml files for latest stable k8s

### DIFF
--- a/tests/e2e/testdata/bookstore_grpc/gke/bookstore.yaml
+++ b/tests/e2e/testdata/bookstore_grpc/gke/bookstore.yaml
@@ -26,12 +26,15 @@ spec:
   type: LoadBalancer
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: app
   template:
     metadata:
       labels:

--- a/tests/e2e/testdata/grpc_echo/gke/grpc-echo.yaml.template
+++ b/tests/e2e/testdata/grpc_echo/gke/grpc-echo.yaml.template
@@ -31,12 +31,15 @@ spec:
     app: app
   type: LoadBalancer
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: app
   template:
     metadata:
       labels:

--- a/tests/e2e/testdata/grpc_interop/gke/grpc-interop.yaml.template
+++ b/tests/e2e/testdata/grpc_interop/gke/grpc-interop.yaml.template
@@ -31,12 +31,15 @@ spec:
     app: app
   type: LoadBalancer
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: app
   template:
     metadata:
       labels:


### PR DESCRIPTION
`extensions/v1beta1` is not supported anymore.

Same changes as https://github.com/GoogleCloudPlatform/endpoints-samples/pull/59.
Needed because we updated our e2e gke version in https://github.com/GoogleCloudPlatform/oss-test-infra/pull/483.

Unblocks submitting other open PRs.

Signed-off-by: Teju Nareddy <nareddyt@google.com>