### PR TITLE
Remove grpc_stats filter

### DIFF
--- a/examples/grpc_dynamic_routing/envoy_config.json
+++ b/examples/grpc_dynamic_routing/envoy_config.json
@@ -1062,14 +1062,6 @@
                       }
                     },
                     {
-                      "name": "envoy.filters.http.grpc_stats",
-                      "typedConfig": {
-                        "@type": "type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
-                        "emitFilterState": true,
-                        "statsForAllMethods": false
-                      }
-                    },
-                    {
                       "name": "com.google.espv2.filters.http.backend_auth",
                       "typedConfig": {
                         "@type": "type.googleapis.com/espv2.api.envoy.v8.http.backend_auth.FilterConfig",

--- a/src/go/configmanager/testdata/test_fetch_listeners.go
+++ b/src/go/configmanager/testdata/test_fetch_listeners.go
@@ -121,14 +121,6 @@ var (
                         }
                      },
                      {
-                        "name":"envoy.filters.http.grpc_stats",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
-                           "emitFilterState":true,
-                           "statsForAllMethods":false
-                        }
-                     },
-                     {
                         "name":"envoy.filters.http.router",
                         "typedConfig":{
                            "@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
@@ -298,14 +290,6 @@ var (
                      },
                      {
                         "name":"envoy.filters.http.grpc_web"
-                     },
-                     {
-                        "name":"envoy.filters.http.grpc_stats",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
-                           "emitFilterState":true,
-                           "statsForAllMethods":false
-                        }
                      },
                      {
                         "name":"envoy.filters.http.router",
@@ -511,14 +495,6 @@ var (
                      },
                      {
                         "name":"envoy.filters.http.grpc_web"
-                     },
-                     {
-                        "name":"envoy.filters.http.grpc_stats",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
-                           "emitFilterState":true,
-                           "statsForAllMethods":false
-                        }
                      },
                      {
                         "name":"envoy.filters.http.router",
@@ -762,14 +738,6 @@ var (
                         "name":"envoy.filters.http.grpc_web"
                      },
                      {
-                        "name":"envoy.filters.http.grpc_stats",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
-                           "emitFilterState":true,
-                           "statsForAllMethods":false
-                        }
-                     },
-                     {
                         "name":"envoy.filters.http.router",
                         "typedConfig":{
                            "@type":"type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
@@ -984,14 +952,6 @@ var (
                      },
                      {
                         "name":"envoy.filters.http.grpc_web"
-                     },
-                     {
-                        "name":"envoy.filters.http.grpc_stats",
-                        "typedConfig":{
-                           "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
-                           "emitFilterState":true,
-                           "statsForAllMethods":false
-                        }
                      },
                      {
                         "name":"envoy.filters.http.router",

--- a/src/go/util/util.go
+++ b/src/go/util/util.go
@@ -37,8 +37,6 @@ const (
 	HTTPConnectionManager = "envoy.filters.network.http_connection_manager"
 	// JwtAuthn filter.
 	JwtAuthn = "envoy.filters.http.jwt_authn"
-	// GrpcStats filter name
-	GrpcStatsFilterName = "envoy.filters.http.grpc_stats"
 	// TLSTransportSocket is Envoy TLS Transport Socket name.
 	TLSTransportSocket = "envoy.transport_sockets.tls"
 	// AccessFileLogger filter name


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

As part of removing unused metrics,   streaming related metrics have been removed in Google.
grpc_message_count  are streaming metrics that to be removed.
grpc_stats fitler is only used to calculate message_count, will not be needed any more. 

This PR just removes the grpc_stats filter. 
