### PR TITLE
Add 1m sleep time for GAP backend ready

### DIFF
--- a/scripts/all-utilities.sh
+++ b/scripts/all-utilities.sh
@@ -406,6 +406,14 @@ function try_setup_bazel_remote_cache() {
   sed -i -e "s@CACHE_PROJECT_ID@${gcp_project_id}@g" ${root_dir}/.bazelrc
 }
 
+function sleep_wrapper() {
+  local length=$1
+  local msg=$2
+  echo "$(date): ${msg}"
+  sleep ${length}
+  echo "$(date): End sleep"
+}
+
 function envoy_binary_gcs_path() {
   echo -n "gs://apiproxy-testing-envoy-binaries/$(get_sha)"
 }

--- a/tests/e2e/scripts/cloud-run/deploy.sh
+++ b/tests/e2e/scripts/cloud-run/deploy.sh
@@ -121,9 +121,7 @@ function deployBackend() {
 
     sed "s/SERVICE_NAME/${BACKEND_SERVICE_NAME}/g" app_template.yaml > app.yaml
     gcloud app deploy --quiet
-    echo "Sleep 1m for App Engine backend setup"
-    sleep 1m
-    echo "End sleep"
+    sleep_wrapper "1m" "Sleep 1m for App Engine backend setup"
 
 
     # For how requests are routed in App Engine, refer to
@@ -193,7 +191,7 @@ function setup() {
       --network=default \
       --zone=${CLUSTER_ZONE} \
       --scopes cloud-platform
-    sleep 1m
+    sleep_wrapper "1m" "Sleep 1m for Anthos cluster setup"
     gcloud config set run/cluster ${CLUSTER_NAME}
     gcloud config set run/cluster_location ${CLUSTER_ZONE}
   else
@@ -357,8 +355,7 @@ function test() {
   echo "Testing"
 
   # Wait a few minutes for service to be enabled and the permissions to propagate
-  echo "Waiting for the endpoints service to be enabled"
-  sleep 5m
+  sleep_wrapper "1m" "Sleep 5m for the endpoints service to be enabled"
 
   if [[ ${PROXY_PLATFORM} == "anthos-cloud-run" ]];
   then
@@ -395,8 +392,7 @@ function test() {
 }
 
 function tearDown() {
-  echo "Waiting for Stackdriver Logging to collect logs"
-  sleep 1m
+  sleep_wrapper "1m" "Sleep 1m for Stackdriver Logging to collect logs"
 
   echo "Teardown env"
 

--- a/tests/e2e/scripts/cloud-run/deploy.sh
+++ b/tests/e2e/scripts/cloud-run/deploy.sh
@@ -134,6 +134,7 @@ function deployBackend() {
       exit 1
       ;;
   esac
+  sleep 1m
 }
 
 function deployProxy() {

--- a/tests/e2e/scripts/cloud-run/deploy.sh
+++ b/tests/e2e/scripts/cloud-run/deploy.sh
@@ -121,7 +121,10 @@ function deployBackend() {
 
     sed "s/SERVICE_NAME/${BACKEND_SERVICE_NAME}/g" app_template.yaml > app.yaml
     gcloud app deploy --quiet
+    echo "Sleep 1m for App Engine backend setup"
     sleep 1m
+    echo "End sleep"
+
 
     # For how requests are routed in App Engine, refer to
     # https://cloud.google.com/appengine/docs/standard/python/how-requests-are-routed#example_urls

--- a/tests/e2e/scripts/cloud-run/deploy.sh
+++ b/tests/e2e/scripts/cloud-run/deploy.sh
@@ -121,6 +121,7 @@ function deployBackend() {
 
     sed "s/SERVICE_NAME/${BACKEND_SERVICE_NAME}/g" app_template.yaml > app.yaml
     gcloud app deploy --quiet
+    sleep 1m
 
     # For how requests are routed in App Engine, refer to
     # https://cloud.google.com/appengine/docs/standard/python/how-requests-are-routed#example_urls
@@ -134,7 +135,6 @@ function deployBackend() {
       exit 1
       ;;
   esac
-  sleep 1m
 }
 
 function deployProxy() {


### PR DESCRIPTION
e2e test for app engine backend is flaky because app angine backend need more time to setup like [this](https://prow.k8s.io/view/gcs/oss-prow/logs/ESPv2-continuous-cloud-run-e2e-app-engine-http-bookstore/1296960732272791555). Add 1m sleep time for it.