### PR TITLE
Improve API Regression test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ integration-test-run-parallel:
 
 integration-test: build  build-envoy build-grpc-interop build-grpc-echo integration-test-run-sequential
 
-integration-test-without-envoy-build: build build-grpc-interop build-grpc-echo integration-test-run-sequential
+integration-test-without-envoy-build: depend.update build build-grpc-interop build-grpc-echo integration-test-run-sequential
 
 integration-debug: build build-envoy-debug build-grpc-interop build-grpc-echo
 	@echo "--> running integration tests and showing debug logs"

--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ integration-test-run-parallel:
 
 integration-test: build  build-envoy build-grpc-interop build-grpc-echo integration-test-run-sequential
 
-integration-test-without-envoy-build: depend.update build build-grpc-interop build-grpc-echo integration-test-run-sequential
+integration-test-without-envoy-build: build build-grpc-interop build-grpc-echo integration-test-run-sequential
 
 integration-debug: build build-envoy-debug build-grpc-interop build-grpc-echo
 	@echo "--> running integration tests and showing debug logs"

--- a/prow/gcpproxy-api-regression.sh
+++ b/prow/gcpproxy-api-regression.sh
@@ -37,6 +37,8 @@ exit 1; }
 . ${ROOT}/tests/e2e/scripts/prow-utilities.sh || { echo 'Cannot load Bash utilities';
 exit 1; }
 
+# Get the SHA of the head of master
+SHA=$(git ls-remote https://github.com/GoogleCloudPlatform/esp-v2.git HEAD | cut -f 1)
 
 wait_apiproxy_image
 
@@ -50,16 +52,9 @@ chmod +x ${ROOT}/bin/envoy
 VERSION=$(cat ${ROOT}/VERSION)
 
 # Checkout to the head of master
-SHA=$(git ls-remote https://github.com/GoogleCloudPlatform/esp-v2.git HEAD | cut -f 1)
 git checkout ${SHA}
 
 # keep the current version
 echo ${VERSION} > ${ROOT}/VERSION
 
-# Since the Makefile is on the submitted commit, the following cmds can only be
-# replaced with `make integration-test-without-envoy-build` after this pr submitted
-make depend.update
-make build
-make build-grpc-interop
-make build-grpc-echo
-make integration-test-run-sequential
+integration-test-without-envoy-build:

--- a/prow/gcpproxy-api-regression.sh
+++ b/prow/gcpproxy-api-regression.sh
@@ -57,4 +57,4 @@ git checkout ${SHA}
 # keep the current version
 echo ${VERSION} > ${ROOT}/VERSION
 
-make integration-test-without-envoy-build:
+make integration-test-without-envoy-build

--- a/prow/gcpproxy-api-regression.sh
+++ b/prow/gcpproxy-api-regression.sh
@@ -57,4 +57,5 @@ git checkout ${SHA}
 # keep the current version
 echo ${VERSION} > ${ROOT}/VERSION
 
+make depend.install
 make integration-test-without-envoy-build

--- a/prow/gcpproxy-api-regression.sh
+++ b/prow/gcpproxy-api-regression.sh
@@ -57,4 +57,4 @@ git checkout ${SHA}
 # keep the current version
 echo ${VERSION} > ${ROOT}/VERSION
 
-integration-test-without-envoy-build:
+make integration-test-without-envoy-build:


### PR DESCRIPTION
- Move getting SHA from beginning otherwise the head of master can be updated when it is waiting envoy binary, [ex](https://oss-prow.knative.dev/view/gs/oss-prow/pr-logs/pull/GoogleCloudPlatform_esp-v2/302/ESPv2-API-regression-test/1299488063969300480)
- Use Makefile target