### PR TITLE
Validate sc filter config has SC uri

### DIFF
--- a/api/envoy/v8/http/service_control/config.proto
+++ b/api/envoy/v8/http/service_control/config.proto
@@ -124,7 +124,8 @@ message FilterConfig {
   ServiceControlCallingConfig sc_calling_config = 7;
 
   // The Http uri to call service control
-  espv2.api.envoy.v8.http.common.HttpUri service_control_uri = 8;
+  espv2.api.envoy.v8.http.common.HttpUri service_control_uri = 8
+      [(validate.rules).message.required = true];
 
   // The prefix added to generated headers
   string generated_header_prefix = 9 [(validate.rules).string = {

--- a/tests/fuzz/corpus/service_control_filter/crash-missing-sc-uri.prototxt
+++ b/tests/fuzz/corpus/service_control_filter/crash-missing-sc-uri.prototxt
@@ -1,0 +1,68 @@
+config {
+  services {
+    service_name: "\000\000p\177\177\177\177W"
+    service_config_id: "te\323\257.fuzz.Protoy"
+    producer_project_id: "dest.fuzz.ProtoBody"
+  }
+  requirements {
+    service_name: "\000\000p\177\177\177\177W"
+    operation_name: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo"
+    api_version: "$"
+    metric_costs {
+      name: "}eric_sfirsttric_sfirst"
+      cost: 5
+    }
+  }
+  gcp_attributes {
+    project_id: "\177\177\177"
+  }
+  imds_token {
+    uri: "."
+    cluster: "."
+    timeout {
+      seconds: 5
+    }
+  }
+  generated_header_prefix: "jwt_payl#ads"
+}
+downstream_request {
+}
+upstream_response {
+  trailers {
+  }
+}
+stream_info {
+  upstream_metadata {
+  }
+}
+sidestream_response {
+  headers {
+    headers {
+      key: ":method"
+      value: "test-config-id"
+    }
+    headers {
+      key: ":method"
+      value: "0]"
+    }
+    headers {
+      key: "+"
+      value: "/echo?key=test-api-key"
+    }
+    headers {
+      key: ":status"
+      value: "200"
+    }
+  }
+  http_body {
+    data: "{ \"access_token\": \"fuzz-access-token\", \"expires_in\": 60000 }"
+  }
+}
+sidestream_response {
+  headers {
+    headers {
+      key: "\016"
+      value: "200"
+    }
+  }
+}


### PR DESCRIPTION
Background:
- PR #251 changes SC calling logic
- SC URI is always passed via config manager and no longer hardcoded in the filter.

With that change, we should reject configs with missing uris. Otherwise a crash occurs when we try to parse and use the empty URI.

Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=25328
Signed-off-by: Teju Nareddy <nareddyt@google.com>