### PR TITLE
Support GCP deployment with service account key

### DIFF
--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -650,10 +650,6 @@ def enforce_conflict_args(args):
         if args.version:
             return "Flag --version cannot be used together with --service_json_path."
 
-    # set non_gcp to True if service account key is provided.
-    if args.service_account_key:
-        args.non_gcp = True
-
     if args.non_gcp:
         if args.service_account_key is None and GOOGLE_CREDS_KEY not in os.environ:
             return "If --non_gcp is specified, --service_account_key has to be specified, or GOOGLE_APPLICATION_CREDENTIALS has to set in os.environ."

--- a/src/go/configmanager/config_manager.go
+++ b/src/go/configmanager/config_manager.go
@@ -124,9 +124,10 @@ func NewConfigManager(mf *metadata.MetadataFetcher, opts options.ConfigGenerator
 		return nil, fmt.Errorf(`failed to set rollout strategy. It must be either "managed" or "fixed"`)
 	}
 
-	// when --non_gcp  is set, instance metadata server(imds) is not defined so
+	// when --non_gcp  is set, instance metadata server(imds) is not defined. So
 	// accessToken is unavailable from imds and --service_account_key must be
 	// set to generate accessToken.
+	// The inverse is not true. We can still use IMDS on GCP when service account key is specified.
 	if mf == nil && opts.ServiceAccountKey == "" {
 		return nil, fmt.Errorf("If --non_gcp is specified, --service_account_key has to be specified.")
 	}

--- a/tests/e2e/scripts/gke/deploy.sh
+++ b/tests/e2e/scripts/gke/deploy.sh
@@ -69,7 +69,7 @@ if [ ${BACKEND} == "bookstore" ]; then
 
   # Support service account credentials for non-gcp deployment.
   SA_CRED_PATH="$(mktemp  /tmp/servie_account_cred.XXXX)"
-  [[ -n ${USING_SA_CRED} ]] && ARGS="$ARGS, \"--service_account_key=/etc/creds/$(basename "${SA_CRED_PATH}")\""
+  [[ -n ${USING_SA_CRED} ]] && ARGS="$ARGS, \"--non_gcp\", \"--service_account_key=/etc/creds/$(basename "${SA_CRED_PATH}")\""
 
   # Support TLS termination in ESPv2.
   ARGS="$ARGS, \"--ssl_server_cert_path=/etc/esp/ssl\""

--- a/tests/env/components/mock_metadata.go
+++ b/tests/env/components/mock_metadata.go
@@ -116,3 +116,12 @@ func (m *MockMetadataServer) GetReqCnt(reqURI string) int {
 	m.mtx.RUnlock()
 	return reqCnt
 }
+
+func (m *MockMetadataServer) GetTotalReqCnt() int {
+	m.mtx.RLock()
+	totalCount := 0
+	for _, pathCount := range m.reqCache {
+		totalCount += pathCount
+	}
+	return totalCount
+}

--- a/tests/env/components/ports.go
+++ b/tests/env/components/ports.go
@@ -78,6 +78,7 @@ const (
 	TestIamImdsDataPath
 	TestInvalidOpenIDConnectDiscovery
 	TestJwtLocations
+	TestMetadataRequestsPerPlatform
 	TestManagedServiceConfig
 	TestMethodOverrideBackendMethod
 	TestMethodOverrideBackendBody

--- a/tests/integration_test/non_gcp_test.go
+++ b/tests/integration_test/non_gcp_test.go
@@ -1,0 +1,126 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
+	"github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/echo/client"
+	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
+	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
+	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
+	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
+)
+
+func TestMetadataRequestsPerPlatform(t *testing.T) {
+	t.Parallel()
+
+	customSa, err := utils.NewServiceAccountForTest()
+	if err != nil {
+		t.Fatalf("Test failed: %v", err)
+	}
+	defer customSa.MockTokenServer.Close()
+
+	testData := []struct {
+		desc                     string
+		path                     string
+		method                   string
+		key                      string
+		confArgs                 []string
+		wantRequestsToMetaServer map[string]int
+	}{
+		{
+			desc:     "For GCP deployment, IMDS provides access token and location.",
+			path:     "/echo",
+			method:   "POST",
+			key:      "api-key",
+			confArgs: utils.CommonArgs(),
+			wantRequestsToMetaServer: map[string]int{
+				util.AccessTokenPath: 2,
+				util.ProjectIDPath:   1,
+				util.ZonePath:        1,
+			},
+		},
+		{
+			desc:   "For GCP deployment with service account, IMDS only provides location (not access token).",
+			path:   "/echo",
+			method: "POST",
+			key:    "api-key",
+			confArgs: append([]string{
+				"--service_account_key=" + customSa.FileName,
+			}, utils.CommonArgs()...),
+			wantRequestsToMetaServer: map[string]int{
+				util.AccessTokenPath: 0,
+				util.ProjectIDPath:   1,
+				util.ZonePath:        1,
+			},
+		},
+		{
+			desc:   "For non-GCP deployment, IMDS is never called.",
+			path:   "/echo",
+			method: "POST",
+			key:    "api-key",
+			confArgs: append([]string{
+				"--non_gcp",
+				"--service_account_key=" + customSa.FileName,
+			}, utils.CommonArgs()...),
+			wantRequestsToMetaServer: map[string]int{
+				util.AccessTokenPath: 0,
+				util.ProjectIDPath:   0,
+				util.ZonePath:        0,
+			},
+		},
+	}
+	for _, tc := range testData {
+
+		// Place in closure to allow deferring in loop.
+		func() {
+			s := env.NewTestEnv(comp.TestMetadataRequestsPerPlatform, platform.EchoSidecar)
+			defer s.TearDown(t)
+			if err := s.Setup(tc.confArgs); err != nil {
+				t.Fatalf("fail to setup test env, %v", err)
+			}
+
+			url := fmt.Sprintf("http://localhost:%v%v?key=%v", s.Ports().ListenerPort, tc.path, tc.key)
+			_, err := client.DoWithHeaders(url, tc.method, "message", nil)
+			if err != nil {
+				t.Fatalf("Test (%s): failed, %v", tc.desc, err)
+			}
+
+			expectNoRequests := true
+			for path, wantCount := range tc.wantRequestsToMetaServer {
+				if gotCnt := s.MockMetadataServer.GetReqCnt(path); gotCnt != wantCount {
+					t.Errorf("Test (%v): failed, path(%v) on MetadataServer, got requests: %v, want requests: %v", tc.desc, path, gotCnt, wantCount)
+				}
+
+				if wantCount != 0 {
+					expectNoRequests = false
+				}
+			}
+
+			if expectNoRequests {
+				// For the case where we expect no requests to IMDS, validate across all paths.
+				// Don't do this for all tests, it gets too messy.
+				gotTotalReq := s.MockMetadataServer.GetTotalReqCnt()
+				if gotTotalReq != 0 {
+					t.Errorf("Test (%v) failed: IMDS received %v total requests, want 0", tc.desc, gotTotalReq)
+				}
+			}
+		}()
+
+	}
+}

--- a/tests/integration_test/service_control_check_fail_test.go
+++ b/tests/integration_test/service_control_check_fail_test.go
@@ -173,7 +173,7 @@ func TestServiceControlCheckError(t *testing.T) {
 					},
 				},
 			},
-			// Note: first request is from Config Manager, second is from ESPv2
+			// Note: first request is from Config Manager, second is from Envoy.
 			wantRequestsToMetaServer: &expectedRequestCount{util.AccessTokenPath, 2},
 			wantRequestsToProvider:   &expectedRequestCount{provider, 1},
 			wantError:                `400 Bad Request, {"code":400,"message":"INVALID_ARGUMENT:Client project not valid. Please pass a valid project."}`,

--- a/tests/start_proxy/start_proxy_test.py
+++ b/tests/start_proxy/start_proxy_test.py
@@ -306,7 +306,7 @@ class TestStartProxy(unittest.TestCase):
             # Tracing disabled on non-gcp
             (['--service=test_bookstore.gloud.run',
               '--backend=http://127.0.0.1',
-              '--service_account_key', '/tmp/service_accout_key',],
+              '--service_account_key', '/tmp/service_accout_key', '--non_gcp'],
              ['bin/configmanager', '--logtostderr', '--rollout_strategy', 'fixed',
               '--backend_address', 'http://127.0.0.1', '--v', '0',
               '--service', 'test_bookstore.gloud.run',
@@ -316,7 +316,7 @@ class TestStartProxy(unittest.TestCase):
             # Tracing enabled when manually specifying project id on non-gcp.
             (['--service=test_bookstore.gloud.run',
               '--backend=http://127.0.0.1',
-              '--service_account_key', '/tmp/service_accout_key',
+              '--service_account_key', '/tmp/service_accout_key', '--non_gcp',
               '--tracing_project_id=test_project_1234'],
              ['bin/configmanager', '--logtostderr', '--rollout_strategy', 'fixed',
               '--backend_address', 'http://127.0.0.1', '--v', '0',
@@ -367,6 +367,18 @@ class TestStartProxy(unittest.TestCase):
               '--v', '0',
               '--service', 'test_bookstore.gloud.run',
               '--disable_tracing'
+              ]),
+            # Service account key does not assume non-gcp
+            # and does not disable tracing.
+            (['--service=test_bookstore.gloud.run',
+              '--backend=http://127.0.0.1',
+              '--service_account_key', '/tmp/service_account_key'],
+             ['bin/configmanager', '--logtostderr',
+              '--rollout_strategy', 'fixed',
+              '--backend_address', 'http://127.0.0.1',
+              '--v', '0',
+              '--service', 'test_bookstore.gloud.run',
+              '--service_account_key', '/tmp/service_account_key',
               ]),
         ]
 

--- a/tests/utils/service_account.go
+++ b/tests/utils/service_account.go
@@ -1,0 +1,50 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
+	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/testdata"
+)
+
+type ServiceAccountForTest struct {
+	MockTokenServer *util.MockServer
+	FileName        string
+}
+
+func NewServiceAccountForTest() (*ServiceAccountForTest, error) {
+	// Setup token server which will be queried by config manager.
+	fakeToken := `{"access_token": "this-is-sa_gen_token", "expires_in":3599, "token_type":"Bearer"}`
+	mockTokenServer := util.InitMockServer(fakeToken)
+
+	// Update fake token with server URI.
+	fakeKey := strings.Replace(testdata.FakeServiceAccountKeyData, "FAKE-TOKEN-URI", mockTokenServer.GetURL(), 1)
+	serviceAccountFile, err := ioutil.TempFile(os.TempDir(), "sa-cred-")
+	if err != nil {
+		return nil, fmt.Errorf("fail to create a temp service account file")
+	}
+
+	// Write token and return file name.
+	_ = ioutil.WriteFile(serviceAccountFile.Name(), []byte(fakeKey), 0644)
+	return &ServiceAccountForTest{
+		MockTokenServer: mockTokenServer,
+		FileName:        serviceAccountFile.Name(),
+	}, nil
+}

--- a/tests/utils/service_account.go
+++ b/tests/utils/service_account.go
@@ -34,14 +34,14 @@ func NewServiceAccountForTest() (*ServiceAccountForTest, error) {
 	fakeToken := `{"access_token": "this-is-sa_gen_token", "expires_in":3599, "token_type":"Bearer"}`
 	mockTokenServer := util.InitMockServer(fakeToken)
 
-	// Update fake token with server URI.
+	// Update service account file template with server URI.
 	fakeKey := strings.Replace(testdata.FakeServiceAccountKeyData, "FAKE-TOKEN-URI", mockTokenServer.GetURL(), 1)
 	serviceAccountFile, err := ioutil.TempFile(os.TempDir(), "sa-cred-")
 	if err != nil {
 		return nil, fmt.Errorf("fail to create a temp service account file")
 	}
 
-	// Write token and return file name.
+	// Write actual service account file and return file name.
 	_ = ioutil.WriteFile(serviceAccountFile.Name(), []byte(fakeKey), 0644)
 	return &ServiceAccountForTest{
 		MockTokenServer: mockTokenServer,


### PR DESCRIPTION
Specifying service account key should still allow a GCP deployment. User must specify `--non_gcp` to force a non-GCP deployment.

Testing:
- Added integration test to verify IMDS calls.
- Follow-up PR will add integration tests to verify report on non-gcp deployments. Requires #307 as well.

Ref: #304 - this will fix issue 1) described in the comments

Signed-off-by: Teju Nareddy <nareddyt@google.com>