### PR TITLE
Fix incorrect sleep time for serverless service activation

### DIFF
--- a/tests/e2e/scripts/cloud-run/deploy.sh
+++ b/tests/e2e/scripts/cloud-run/deploy.sh
@@ -355,7 +355,7 @@ function test() {
   echo "Testing"
 
   # Wait a few minutes for service to be enabled and the permissions to propagate
-  sleep_wrapper "1m" "Sleep 5m for the endpoints service to be enabled"
+  sleep_wrapper "5m" "Sleep 5m for the endpoints service to be enabled"
 
   if [[ ${PROXY_PLATFORM} == "anthos-cloud-run" ]];
   then


### PR DESCRIPTION
PR #301 accidentally reduced the sleep time here. Put it back to 5 minutes, otherwise our tests keep failing. https://screenshot.googleplex.com/Bci3dN4km7YJcKw

Signed-off-by: Teju Nareddy <nareddyt@google.com>