### PR TITLE
Add test for report of gcp attributes on non-GCP

### DIFF
--- a/src/go/tokengenerator/token_generator.go
+++ b/src/go/tokengenerator/token_generator.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
+	"github.com/golang/glog"
 	"github.com/gorilla/mux"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -110,6 +111,7 @@ func MakeTokenAgentHandler(serviceAccountKey string) http.Handler {
 		token, expire, err := GenerateAccessTokenFromFile(serviceAccountKey)
 
 		if err != nil {
+			glog.Errorf("local access token agent had error: %v", err)
 			http.Error(w, err.Error(), 500)
 			return
 		}

--- a/tests/env/components/ports.go
+++ b/tests/env/components/ports.go
@@ -87,6 +87,7 @@ const (
 	TestPreflightCorsWithBasicPreset
 	TestPreflightRequestWithAllowCors
 	TestReportGCPAttributes
+	TestReportGCPAttributesPerPlatform
 	TestServiceControlAccessTokenFromIam
 	TestServiceControlAccessTokenFromTokenAgent
 	TestServiceControlAllHTTPMethod


### PR DESCRIPTION
Follow-up on PRs #307 and #308 to add a regression test for GCP attributes on non-GCP deployments.

Testing done: Verified non-gcp e2e tests show metrics.

![image](https://user-images.githubusercontent.com/11142171/91912307-d44ce680-ec80-11ea-9049-e1b7ed643959.png)

Fixes #304.
Signed-off-by: Teju Nareddy <nareddyt@google.com>