### PR TITLE
b/167455579: For Cloud Run, report location with region instead of zone

### DIFF
--- a/api/envoy/v8/http/service_control/config.proto
+++ b/api/envoy/v8/http/service_control/config.proto
@@ -91,7 +91,9 @@ message Service {
 message GcpAttributes {
   // GCP Project ID
   string project_id = 1;
-  // The zone where the GCP proxy is running (e.g. us-west-1)
+  // The location where the GCP proxy is running (e.g. us-west1-a, us-central1).
+  // Note: The naming is not correct, it doesn't always hold a zone.
+  // Cloud Run platform is regional, so this location will be a region instead.
   string zone = 2;
   // Platform where the GCP Proxy is running: GAE_FLEX, GKE, GCE, or UNKNOWN
   string platform = 3;

--- a/src/api_proxy/service_control/request_builder_test.cc
+++ b/src/api_proxy/service_control/request_builder_test.cc
@@ -333,8 +333,8 @@ TEST_F(RequestBuilderTest, FillReportWithUntrustedApiKeyTest) {
 
     std::string text = ReportRequestToString(&request);
 
-    // It doesn't make sense to create different files just for one minor change.
-    // Template the file and replace the string as needed.
+    // It doesn't make sense to create different files just for one minor
+    // change. Template the file and replace the string as needed.
     std::string template_expected_text =
         ReadTestBaseline("report_request_failed_bad_api_key.golden");
     std::string expected_text = absl::StrReplaceAll(

--- a/src/go/metadata/metadata_fetcher.go
+++ b/src/go/metadata/metadata_fetcher.go
@@ -185,7 +185,7 @@ func (mf *MetadataFetcher) FetchProjectId() (string, error) {
 }
 
 func (mf *MetadataFetcher) fetchLocation() (string, error) {
-	// Fetch try to fetch the region. Cloud run will support this path, while other
+	// Try to fetch the region. Cloud run will support this path, while other
 	// platforms will return 404.
 	region, err := mf.fetchMetadata(util.RegionPath)
 	if err == nil {

--- a/src/go/metadata/metadata_fetcher.go
+++ b/src/go/metadata/metadata_fetcher.go
@@ -187,25 +187,23 @@ func (mf *MetadataFetcher) FetchProjectId() (string, error) {
 func (mf *MetadataFetcher) fetchLocation() (string, error) {
 	// Try to fetch the region. Cloud run will support this path, while other
 	// platforms will return 404.
-	region, err := mf.fetchMetadata(util.RegionPath)
-	if err == nil {
-		return region, nil
-	}
-
-	// Otherwise we're not on Cloud Run, fetch the zone directly.
-	zonePath, err := mf.fetchMetadata(util.ZonePath)
+	locationPath, err := mf.fetchMetadata(util.RegionPath)
 	if err != nil {
-		return "", err
+		// Otherwise we're not on Cloud Run, fetch the zone directly.
+		locationPath, err = mf.fetchMetadata(util.ZonePath)
+		if err != nil {
+			return "", err
+		}
 	}
 
-	// Zone format: projects/PROJECT_ID/ZONE
+	// Location format: projects/PROJECT_ID/<zone|region>/LOCATION
 	// Get the substring after the last '/'.
-	index := strings.LastIndex(zonePath, "/")
-	if index == -1 || index+1 >= len(zonePath) {
-		glog.Warningf("Invalid zone format is fetched: %s", zonePath)
-		return "", fmt.Errorf("Invalid zone format: %s", zonePath)
+	index := strings.LastIndex(locationPath, "/")
+	if index == -1 || index+1 >= len(locationPath) {
+		glog.Warningf("Invalid location format is fetched: %s", locationPath)
+		return "", fmt.Errorf("Invalid location format: %s", locationPath)
 	}
-	return zonePath[index+1:], nil
+	return locationPath[index+1:], nil
 }
 
 func (mf *MetadataFetcher) fetchPlatform() string {

--- a/src/go/metadata/metadata_fetcher_test.go
+++ b/src/go/metadata/metadata_fetcher_test.go
@@ -33,6 +33,7 @@ const (
 	fakeConfigID         = "canary-config"
 	fakeZonePath         = "projects/4242424242/zones/us-west-1b"
 	fakeZone             = "us-west-1b"
+	fakeRegion           = "us-central1"
 	fakeProjectID        = "gcpproxy"
 )
 
@@ -281,6 +282,17 @@ func TestFetchGCPAttributes(t *testing.T) {
 			desc:                  "No MetadataServer",
 			mockedResp:            nil,
 			expectedGCPAttributes: nil,
+		},
+		{
+			desc: "When region path is support, zone is ignored",
+			mockedResp: map[string]string{
+				util.ZonePath:   fakeZonePath,
+				util.RegionPath: fakeRegion,
+			},
+			expectedGCPAttributes: &scpb.GcpAttributes{
+				Zone:     fakeRegion,
+				Platform: util.GCE,
+			},
 		},
 	}
 

--- a/src/go/metadata/metadata_fetcher_test.go
+++ b/src/go/metadata/metadata_fetcher_test.go
@@ -284,7 +284,7 @@ func TestFetchGCPAttributes(t *testing.T) {
 			expectedGCPAttributes: nil,
 		},
 		{
-			desc: "When region path is support, zone is ignored",
+			desc: "When region path is supported, zone is ignored",
 			mockedResp: map[string]string{
 				util.ZonePath:   fakeZonePath,
 				util.RegionPath: fakeRegion,

--- a/src/go/metadata/metadata_fetcher_test.go
+++ b/src/go/metadata/metadata_fetcher_test.go
@@ -33,6 +33,7 @@ const (
 	fakeConfigID         = "canary-config"
 	fakeZonePath         = "projects/4242424242/zones/us-west-1b"
 	fakeZone             = "us-west-1b"
+	fakeRegionPath       = "projects/4242424242/regions/us-central1"
 	fakeRegion           = "us-central1"
 	fakeProjectID        = "gcpproxy"
 )
@@ -287,7 +288,7 @@ func TestFetchGCPAttributes(t *testing.T) {
 			desc: "When region path is supported, zone is ignored",
 			mockedResp: map[string]string{
 				util.ZonePath:   fakeZonePath,
-				util.RegionPath: fakeRegion,
+				util.RegionPath: fakeRegionPath,
 			},
 			expectedGCPAttributes: &scpb.GcpAttributes{
 				Zone:     fakeRegion,

--- a/src/go/util/util.go
+++ b/src/go/util/util.go
@@ -84,7 +84,12 @@ const (
 	AccessTokenPath   = "/computeMetadata/v1/instance/service-accounts/default/token"
 	IdentityTokenPath = "/computeMetadata/v1/instance/service-accounts/default/identity"
 	ProjectIDPath     = "/computeMetadata/v1/project/project-id"
-	ZonePath          = "/computeMetadata/v1/instance/zone"
+
+	// Cloud Run platform is regional, use the region path.
+	RegionPath = "/computeMetadata/v1/instance/region"
+
+	// GKE/GCE platforms are zonal. Regional path does not exist in IMDS.
+	ZonePath = "/computeMetadata/v1/instance/zone"
 
 	// The path of getting access token from token agent server
 	TokenAgentAccessTokenPath = "/local/access_token"

--- a/tests/integration_test/report_gcp_attributes_test.go
+++ b/tests/integration_test/report_gcp_attributes_test.go
@@ -140,7 +140,7 @@ func TestReportGCPAttributes(t *testing.T) {
 		{
 			desc: "Cloud Run uses regional location, zone is ignored",
 			mockMetadataOverride: map[string]string{
-				util.RegionPath: "test-region",
+				util.RegionPath: "projects/123/regions/test-region",
 			},
 			platformOverride: "Cloud Run(ESPv2)",
 			wantLocation:     "test-region",

--- a/tests/integration_test/report_gcp_attributes_test.go
+++ b/tests/integration_test/report_gcp_attributes_test.go
@@ -137,6 +137,15 @@ func TestReportGCPAttributes(t *testing.T) {
 			wantLocation:         "test-zone",
 			wantPlatform:         "Cloud Run",
 		},
+		{
+			desc: "Cloud Run uses regional location, zone is ignored",
+			mockMetadataOverride: map[string]string{
+				util.RegionPath: "test-region",
+			},
+			platformOverride: "Cloud Run(ESPv2)",
+			wantLocation:     "test-region",
+			wantPlatform:     "Cloud Run(ESPv2)",
+		},
 	}
 
 	configID := "test-config-id"


### PR DESCRIPTION
Otherwise Google Service Control will treat this as a `global` service, which is incorrect. [Example](https://screenshot.googleplex.com/8Hq4k8apSZkWe9W)

Testing done:
- Unit + integration tests with mock IMDS
- Manually confirmed Cloud Run deployments correctly display the regional location now. [Example](https://screenshot.googleplex.com/7t6UHFibtZez9NE)
- Manually confirmed Anthos deployments maintain zonal location. [Example](https://screenshot.googleplex.com/9ECzhTH77LrqNEE)
- Manually confirmed GKE deployments maintain zonal location. [Example](https://screenshot.googleplex.com/AFV3JPhV8np4UZu)

Signed-off-by: Teju Nareddy <nareddyt@google.com>