### PR TITLE
Fix broken anthos e2e test

### DIFF
--- a/tests/e2e/client/apiproxy_bookstore_key_restriction_test.py
+++ b/tests/e2e/client/apiproxy_bookstore_key_restriction_test.py
@@ -38,7 +38,7 @@ class ApiProxyBookstoreTest(ApiProxyClientTest):
     """
 
     def __init__(self):
-        ApiProxyClientTest.__init__(self, FLAGS.host, '',
+        ApiProxyClientTest.__init__(self, FLAGS.host, FLAGS.host_header,
                                FLAGS.allow_unverified_cert,
                                FLAGS.verbose)
 
@@ -96,6 +96,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--verbose', type=bool, help='Turn on/off verbosity.')
     parser.add_argument('--host', help='Deployed application host name.')
+    parser.add_argument('--host_header', help='Deployed application host name.')
     parser.add_argument('--allow_unverified_cert', type=bool,
             default=False, help='used for testing self-signed ssl cert.')
     parser.add_argument('--key_restriction_tests',

--- a/tests/e2e/scripts/linux-test-kb-long-run.sh
+++ b/tests/e2e/scripts/linux-test-kb-long-run.sh
@@ -99,7 +99,7 @@ while true; do
       --api_key=${API_KEY}  \
       --auth_token=${JWT_TOKEN}  \
       --allow_unverified_cert=true \
-    --host_header="${HOST_HEADER}" || ((BOOKSTORE_FAILURES++)))
+      --host_header="${HOST_HEADER}" || ((BOOKSTORE_FAILURES++)))
 
   echo "Starting bookstore API Key restriction test at $(date)."
   (set -x;
@@ -107,7 +107,8 @@ while true; do
       --host="${SCHEME}://${HOST}:${PORT}"   \
       --allow_unverified_cert=true  \
       --key_restriction_tests=${ROOT}/tests/e2e/testdata/bookstore/key_restriction_test.json.template  \
-      --key_restriction_keys_file=${API_RESTRICTION_KEYS_FILE})
+      --key_restriction_keys_file=${API_RESTRICTION_KEYS_FILE} \
+      --host_header="${HOST_HEADER}")
 
   #TODO(taoxuy): b/148950591 enable stress test for cloud run on anthos
   if [[ -z ${HOST_HEADER} ]]; then

--- a/tests/e2e/testdata/bookstore/key_restriction_test.json.template
+++ b/tests/e2e/testdata/bookstore/key_restriction_test.json.template
@@ -1,6 +1,6 @@
 {
   "ip": [{
-      "description": "192.16.31.84 will be the remote IP address.",
+      "description": "Success, 192.16.31.84 will be the remote IP address, passes restriction.",
       "path": "/restricted",
       "api_key": "${api_key_ip}",
       "key_restriction": {
@@ -11,7 +11,7 @@
       },
       "status_code": 200
     }, {
-      "description": "172.17.131.252 will be the remote IP address.",
+      "description": "Fail, 172.17.131.252 will be the remote IP address, restricted.",
       "path": "/restricted",
       "api_key": "${api_key_ip}",
       "key_restriction": {
@@ -22,7 +22,7 @@
       },
       "status_code": 403
     }, {
-      "description": "172.17.131.252 will be the remote IP address.",
+      "description": "Fail, 172.17.131.252 will be the remote IP address, restricted.",
       "path": "/restricted",
       "api_key": "${api_key_ip}",
       "key_restriction": {
@@ -33,7 +33,7 @@
       },
       "status_code": 403
     }, {
-      "description": "192.16.31.88 will be the remote IP address.",
+      "description": "Fail, XFF header is too short, causing ESPv2 to use the direct downstream connection IP.",
       "path": "/restricted",
       "api_key": "${api_key_ip}",
       "key_restriction": {
@@ -44,7 +44,7 @@
       },
       "status_code": 403
     }, {
-      "description": "No XFF header. The IP address of the last proxy mismatch",
+      "description": "Fail, no XFF header, causing ESPv2 to use the direct downstream connection IP.",
       "path": "/restricted",
       "api_key": "${api_key_ip}",
       "key_restriction": {


### PR DESCRIPTION
PR #318 added an extra test that fails on Anthos because it's missing the `Host` header. Just add it in, simple fix.

Signed-off-by: Teju Nareddy <nareddyt@google.com>