### PR TITLE
b/167586109: Add name prefix for backend/jwtProvider cluster

### DIFF
--- a/examples/auth/envoy_config.json
+++ b/examples/auth/envoy_config.json
@@ -37,7 +37,7 @@
             }
           ]
         },
-        "name": "examples-auth.endpoints.cloudesf-testing.cloud.goog_local",
+        "name": "backend-cluster-examples-auth.endpoints.cloudesf-testing.cloud.goog_local",
         "type": "LOGICAL_DNS"
       },
       {
@@ -342,7 +342,7 @@
                               "prefix": "/"
                             },
                             "route": {
-                              "cluster": "examples-auth.endpoints.cloudesf-testing.cloud.goog_local",
+                              "cluster": "backend-cluster-examples-auth.endpoints.cloudesf-testing.cloud.goog_local",
                               "timeout": "15s"
                             }
                           }

--- a/examples/auth/envoy_config.json
+++ b/examples/auth/envoy_config.json
@@ -125,7 +125,7 @@
             }
           ]
         },
-        "name": "www.googleapis.com:443",
+        "name": "jwt-provider-cluster-www.googleapis.com:443",
         "transportSocket": {
           "name": "envoy.transport_sockets.tls",
           "typedConfig": {
@@ -242,7 +242,7 @@
                             "remoteJwks": {
                               "cacheDuration": "300s",
                               "httpUri": {
-                                "cluster": "www.googleapis.com:443",
+                                "cluster": "jwt-provider-cluster-www.googleapis.com:443",
                                 "timeout": "30s",
                                 "uri": "https://www.googleapis.com/service_accounts/v1/jwk/123456789-compute@developer.gserviceaccount.com"
                               }
@@ -271,7 +271,7 @@
                             "remoteJwks": {
                               "cacheDuration": "300s",
                               "httpUri": {
-                                "cluster": "www.googleapis.com:443",
+                                "cluster": "jwt-provider-cluster-www.googleapis.com:443",
                                 "timeout": "30s",
                                 "uri": "https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com"
                               }
@@ -300,7 +300,7 @@
                             "remoteJwks": {
                               "cacheDuration": "300s",
                               "httpUri": {
-                                "cluster": "www.googleapis.com:443",
+                                "cluster": "jwt-provider-cluster-www.googleapis.com:443",
                                 "timeout": "30s",
                                 "uri": "https://www.googleapis.com/oauth2/v3/certs"
                               }

--- a/examples/dynamic_routing/envoy_config.json
+++ b/examples/dynamic_routing/envoy_config.json
@@ -37,7 +37,7 @@
             }
           ]
         },
-        "name": "examples-dynamic-routing-wd6ufmzfya-uc.a.run.app_local",
+        "name": "backend-cluster-examples-dynamic-routing-wd6ufmzfya-uc.a.run.app_local",
         "type": "LOGICAL_DNS"
       },
       {
@@ -125,7 +125,7 @@
             }
           ]
         },
-        "name": "http-bookstore-abc123456-uc.a.run.app:443",
+        "name": "backend-cluster-http-bookstore-abc123456-uc.a.run.app:443",
         "transportSocket": {
           "name": "envoy.transport_sockets.tls",
           "typedConfig": {
@@ -166,7 +166,7 @@
             }
           ]
         },
-        "name": "http-bookstore-edf123456-uc.a.run.app:443",
+        "name": "backend-cluster-http-bookstore-edf123456-uc.a.run.app:443",
         "transportSocket": {
           "name": "envoy.transport_sockets.tls",
           "typedConfig": {
@@ -325,7 +325,7 @@
                               "path": "/shelves"
                             },
                             "route": {
-                              "cluster": "http-bookstore-edf123456-uc.a.run.app:443",
+                              "cluster": "backend-cluster-http-bookstore-edf123456-uc.a.run.app:443",
                               "hostRewriteLiteral": "http-bookstore-edf123456-uc.a.run.app",
                               "timeout": "23s"
                             }
@@ -344,7 +344,7 @@
                               "path": "/shelves"
                             },
                             "route": {
-                              "cluster": "http-bookstore-abc123456-uc.a.run.app:443",
+                              "cluster": "backend-cluster-http-bookstore-abc123456-uc.a.run.app:443",
                               "hostRewriteLiteral": "http-bookstore-abc123456-uc.a.run.app",
                               "timeout": "7s"
                             }

--- a/examples/grpc_dynamic_routing/envoy_config.json
+++ b/examples/grpc_dynamic_routing/envoy_config.json
@@ -38,7 +38,7 @@
             }
           ]
         },
-        "name": "examples-grpc-dynamic-routing-wd6ufmzfya-uc.a.run.app_local",
+        "name": "backend-cluster-examples-grpc-dynamic-routing-wd6ufmzfya-uc.a.run.app_local",
         "type": "LOGICAL_DNS"
       },
       {
@@ -126,7 +126,7 @@
             }
           ]
         },
-        "name": "grpc-echo-oxouww7xzq-uc.a.run.app:443",
+        "name": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
         "transportSocket": {
           "name": "envoy.transport_sockets.tls",
           "typedConfig": {
@@ -1139,7 +1139,7 @@
                               "path": "/test.grpc.Test/Cork"
                             },
                             "route": {
-                              "cluster": "grpc-echo-oxouww7xzq-uc.a.run.app:443",
+                              "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
                               "timeout": "0s"
                             }
@@ -1158,7 +1158,7 @@
                               "path": "/echo"
                             },
                             "route": {
-                              "cluster": "grpc-echo-oxouww7xzq-uc.a.run.app:443",
+                              "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
                               "timeout": "300s"
                             }
@@ -1177,7 +1177,7 @@
                               "path": "/test.grpc.Test/Echo"
                             },
                             "route": {
-                              "cluster": "grpc-echo-oxouww7xzq-uc.a.run.app:443",
+                              "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
                               "timeout": "300s"
                             }
@@ -1196,7 +1196,7 @@
                               "path": "/echoreport"
                             },
                             "route": {
-                              "cluster": "grpc-echo-oxouww7xzq-uc.a.run.app:443",
+                              "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
                               "timeout": "300s"
                             }
@@ -1215,7 +1215,7 @@
                               "path": "/test.grpc.Test/EchoReport"
                             },
                             "route": {
-                              "cluster": "grpc-echo-oxouww7xzq-uc.a.run.app:443",
+                              "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
                               "timeout": "300s"
                             }
@@ -1234,7 +1234,7 @@
                               "path": "/echostream"
                             },
                             "route": {
-                              "cluster": "grpc-echo-oxouww7xzq-uc.a.run.app:443",
+                              "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
                               "timeout": "0s"
                             }
@@ -1253,7 +1253,7 @@
                               "path": "/test.grpc.Test/EchoStream"
                             },
                             "route": {
-                              "cluster": "grpc-echo-oxouww7xzq-uc.a.run.app:443",
+                              "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
                               "timeout": "0s"
                             }

--- a/examples/grpc_dynamic_routing/envoy_config.json
+++ b/examples/grpc_dynamic_routing/envoy_config.json
@@ -168,7 +168,7 @@
             }
           ]
         },
-        "name": "www.googleapis.com:443",
+        "name": "jwt-provider-cluster-www.googleapis.com:443",
         "transportSocket": {
           "name": "envoy.transport_sockets.tls",
           "typedConfig": {
@@ -464,7 +464,7 @@
                             "remoteJwks": {
                               "cacheDuration": "300s",
                               "httpUri": {
-                                "cluster": "www.googleapis.com:443",
+                                "cluster": "jwt-provider-cluster-www.googleapis.com:443",
                                 "timeout": "30s",
                                 "uri": "https://www.googleapis.com/service_accounts/v1/jwk/e2e-client-jwk@cloudesf-testing.iam.gserviceaccount.com"
                               }

--- a/examples/service_control/envoy_config.json
+++ b/examples/service_control/envoy_config.json
@@ -37,7 +37,7 @@
             }
           ]
         },
-        "name": "examples-service-control.endpoints.cloudesf-testing.cloud.goog_local",
+        "name": "backend-cluster-examples-service-control.endpoints.cloudesf-testing.cloud.goog_local",
         "type": "LOGICAL_DNS"
       },
       {
@@ -782,7 +782,7 @@
                               "prefix": "/"
                             },
                             "route": {
-                              "cluster": "examples-service-control.endpoints.cloudesf-testing.cloud.goog_local",
+                              "cluster": "backend-cluster-examples-service-control.endpoints.cloudesf-testing.cloud.goog_local",
                               "timeout": "15s"
                             }
                           }

--- a/examples/testdata/path_matcher/envoy_config.json
+++ b/examples/testdata/path_matcher/envoy_config.json
@@ -37,7 +37,7 @@
             }
           ]
         },
-        "name": "examples-path-matcher.endpoints.cloudesf-testing.cloud.goog_local",
+        "name": "backend-cluster-examples-path-matcher.endpoints.cloudesf-testing.cloud.goog_local",
         "type": "LOGICAL_DNS"
       },
       {
@@ -124,7 +124,7 @@
             }
           ]
         },
-        "name": "http-bookstore-edf123456-uc.a.run.app:443",
+        "name": "backend-cluster-http-bookstore-edf123456-uc.a.run.app:443",
         "transportSocket": {
           "name": "envoy.transport_sockets.tls",
           "typedConfig": {
@@ -312,7 +312,7 @@
                               }
                             },
                             "route": {
-                              "cluster": "http-bookstore-edf123456-uc.a.run.app:443",
+                              "cluster": "backend-cluster-http-bookstore-edf123456-uc.a.run.app:443",
                               "hostRewriteLiteral": "http-bookstore-edf123456-uc.a.run.app",
                               "timeout": "15s"
                             }
@@ -334,7 +334,7 @@
                               }
                             },
                             "route": {
-                              "cluster": "http-bookstore-edf123456-uc.a.run.app:443",
+                              "cluster": "backend-cluster-http-bookstore-edf123456-uc.a.run.app:443",
                               "hostRewriteLiteral": "http-bookstore-edf123456-uc.a.run.app",
                               "timeout": "15s"
                             }

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/miekg/dns v1.1.29
 	golang.org/x/net v0.0.0-20190923162816-aa69164e4478
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
-	golang.org/x/tools v0.0.0-20191216052735-49a3e744a425
+	golang.org/x/tools v0.0.0-20191216052735-49a3e744a425 // indirect
 	google.golang.org/api v0.7.0
 	google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d
 	google.golang.org/grpc v1.27.0

--- a/src/go/bootstrap/static/bootstrap_test.go
+++ b/src/go/bootstrap/static/bootstrap_test.go
@@ -34,7 +34,7 @@ var (
 	FakeConfigID = "2019-12-16r0"
 )
 
-func zTestServiceToBootstrapConfig(t *testing.T) {
+func TestServiceToBootstrapConfig(t *testing.T) {
 	testData := []struct {
 		desc              string
 		opt_mod           func(opt *options.ConfigGeneratorOptions)

--- a/src/go/bootstrap/static/bootstrap_test.go
+++ b/src/go/bootstrap/static/bootstrap_test.go
@@ -34,7 +34,7 @@ var (
 	FakeConfigID = "2019-12-16r0"
 )
 
-func TestServiceToBootstrapConfig(t *testing.T) {
+func zTestServiceToBootstrapConfig(t *testing.T) {
 	testData := []struct {
 		desc              string
 		opt_mod           func(opt *options.ConfigGeneratorOptions)

--- a/src/go/configgenerator/cluster_generator.go
+++ b/src/go/configgenerator/cluster_generator.go
@@ -203,10 +203,12 @@ func makeJwtProviderClusters(serviceInfo *sc.ServiceInfo) ([]*clusterpb.Cluster,
 
 	for _, provider := range authn.GetProviders() {
 		jwksUri := provider.GetJwksUri()
-		clusterName, err := util.ExtraAddressFromURI(jwksUri)
+		addr, err := util.ExtraAddressFromURI(jwksUri)
 		if err != nil {
 			return nil, err
 		}
+
+		clusterName := util.JwtProviderClusterName(addr)
 		if ok, _ := generatedClusters[clusterName]; ok {
 			continue
 		}

--- a/src/go/configgenerator/cluster_generator_test.go
+++ b/src/go/configgenerator/cluster_generator_test.go
@@ -194,7 +194,7 @@ func TestMakeBackendRoutingCluster(t *testing.T) {
 			BackendAddress: "http://127.0.0.1:80",
 			wantedClusters: []*clusterpb.Cluster{
 				{
-					Name:                 "mybackend.com:443",
+					Name:                 "backend-cluster-mybackend.com:443",
 					ConnectTimeout:       ptypes.DurationProto(20 * time.Second),
 					ClusterDiscoveryType: &clusterpb.Cluster_Type{clusterpb.Cluster_LOGICAL_DNS},
 					LoadAssignment:       util.CreateLoadAssignment("mybackend.com", 443),
@@ -242,7 +242,7 @@ func TestMakeBackendRoutingCluster(t *testing.T) {
 			BackendAddress: "http://127.0.0.1:80",
 			wantedClusters: []*clusterpb.Cluster{
 				{
-					Name:                 "mybackend.com:80",
+					Name:                 "backend-cluster-mybackend.com:80",
 					ConnectTimeout:       ptypes.DurationProto(20 * time.Second),
 					ClusterDiscoveryType: &clusterpb.Cluster_Type{clusterpb.Cluster_LOGICAL_DNS},
 					LoadAssignment:       util.CreateLoadAssignment("mybackend.com", 80),
@@ -292,13 +292,13 @@ func TestMakeBackendRoutingCluster(t *testing.T) {
 			BackendAddress: "http://127.0.0.1:80",
 			wantedClusters: []*clusterpb.Cluster{
 				{
-					Name:                 "mybackend_http.com:80",
+					Name:                 "backend-cluster-mybackend_http.com:80",
 					ConnectTimeout:       ptypes.DurationProto(20 * time.Second),
 					ClusterDiscoveryType: &clusterpb.Cluster_Type{clusterpb.Cluster_LOGICAL_DNS},
 					LoadAssignment:       util.CreateLoadAssignment("mybackend_http.com", 80),
 				},
 				{
-					Name:                 "mybackend_https.com:443",
+					Name:                 "backend-cluster-mybackend_https.com:443",
 					ConnectTimeout:       ptypes.DurationProto(20 * time.Second),
 					ClusterDiscoveryType: &clusterpb.Cluster_Type{clusterpb.Cluster_LOGICAL_DNS},
 					LoadAssignment:       util.CreateLoadAssignment("mybackend_https.com", 443),
@@ -349,7 +349,7 @@ func TestMakeBackendRoutingCluster(t *testing.T) {
 			BackendAddress: "http://127.0.0.1:80",
 			wantedClusters: []*clusterpb.Cluster{
 				{
-					Name:                 "mybackend.com:443",
+					Name:                 "backend-cluster-mybackend.com:443",
 					ConnectTimeout:       ptypes.DurationProto(20 * time.Second),
 					ClusterDiscoveryType: &clusterpb.Cluster_Type{clusterpb.Cluster_LOGICAL_DNS},
 					LoadAssignment:       util.CreateLoadAssignment("mybackend.com", 443),
@@ -394,7 +394,7 @@ func TestMakeBackendRoutingCluster(t *testing.T) {
 			BackendAddress: "http://127.0.0.1:80",
 			wantedClusters: []*clusterpb.Cluster{
 				{
-					Name:                 "mybackend.com:80",
+					Name:                 "backend-cluster-mybackend.com:80",
 					ConnectTimeout:       ptypes.DurationProto(20 * time.Second),
 					ClusterDiscoveryType: &clusterpb.Cluster_Type{clusterpb.Cluster_LOGICAL_DNS},
 					LoadAssignment:       util.CreateLoadAssignment("mybackend.com", 80),
@@ -445,14 +445,14 @@ func TestMakeBackendRoutingCluster(t *testing.T) {
 			BackendAddress: "http://127.0.0.1:80",
 			wantedClusters: []*clusterpb.Cluster{
 				{
-					Name:                 "mybackend_http.com:80",
+					Name:                 "backend-cluster-mybackend_http.com:80",
 					ConnectTimeout:       ptypes.DurationProto(20 * time.Second),
 					ClusterDiscoveryType: &clusterpb.Cluster_Type{clusterpb.Cluster_LOGICAL_DNS},
 					LoadAssignment:       util.CreateLoadAssignment("mybackend_http.com", 80),
 					Http2ProtocolOptions: &corepb.Http2ProtocolOptions{},
 				},
 				{
-					Name:                 "mybackend_https.com:443",
+					Name:                 "backend-cluster-mybackend_https.com:443",
 					ConnectTimeout:       ptypes.DurationProto(20 * time.Second),
 					ClusterDiscoveryType: &clusterpb.Cluster_Type{clusterpb.Cluster_LOGICAL_DNS},
 					LoadAssignment:       util.CreateLoadAssignment("mybackend_https.com", 443),
@@ -502,7 +502,7 @@ func TestMakeBackendRoutingCluster(t *testing.T) {
 			BackendAddress: "http://127.0.0.1:80",
 			wantedClusters: []*clusterpb.Cluster{
 				{
-					Name:                 "mybackend.run.app:443",
+					Name:                 "backend-cluster-mybackend.run.app:443",
 					ConnectTimeout:       ptypes.DurationProto(20 * time.Second),
 					DnsLookupFamily:      clusterpb.Cluster_V4_ONLY,
 					ClusterDiscoveryType: &clusterpb.Cluster_Type{Type: clusterpb.Cluster_LOGICAL_DNS},
@@ -574,7 +574,7 @@ func TestMakeBackendRoutingCluster(t *testing.T) {
 		}
 
 		if tc.wantedClusters != nil && !cmp.Equal(clusters, tc.wantedClusters, cmp.Comparer(proto.Equal)) {
-			t.Errorf("Test Desc(%d): %s, makeBackendRoutingClusters got: %v, want: %v", i, tc.desc, clusters, tc.wantedClusters)
+			t.Errorf("Test Desc(%d): %s, makeBackendRoutingClusters\ngot: %v,\nwant: %v", i, tc.desc, clusters, tc.wantedClusters)
 		}
 	}
 }
@@ -603,7 +603,7 @@ func TestMakeJwtProviderClusters(t *testing.T) {
 			},
 			wantedClusters: []*clusterpb.Cluster{
 				{
-					Name:                 "metadata.com:443",
+					Name:                 "jwt-provider-cluster-metadata.com:443",
 					ConnectTimeout:       ptypes.DurationProto(20 * time.Second),
 					ClusterDiscoveryType: &clusterpb.Cluster_Type{clusterpb.Cluster_LOGICAL_DNS},
 					DnsLookupFamily:      clusterpb.Cluster_V4_ONLY,
@@ -611,7 +611,7 @@ func TestMakeJwtProviderClusters(t *testing.T) {
 					TransportSocket:      createTransportSocket("metadata.com"),
 				},
 				{
-					Name:                 "metadata.com:80",
+					Name:                 "jwt-provider-cluster-metadata.com:80",
 					ConnectTimeout:       ptypes.DurationProto(20 * time.Second),
 					ClusterDiscoveryType: &clusterpb.Cluster_Type{clusterpb.Cluster_LOGICAL_DNS},
 					DnsLookupFamily:      clusterpb.Cluster_V4_ONLY,
@@ -645,7 +645,7 @@ func TestMakeJwtProviderClusters(t *testing.T) {
 			},
 			wantedClusters: []*clusterpb.Cluster{
 				{
-					Name:                 "metadata.com:443",
+					Name:                 "jwt-provider-cluster-metadata.com:443",
 					ConnectTimeout:       ptypes.DurationProto(20 * time.Second),
 					ClusterDiscoveryType: &clusterpb.Cluster_Type{clusterpb.Cluster_LOGICAL_DNS},
 					DnsLookupFamily:      clusterpb.Cluster_V4_ONLY,

--- a/src/go/configgenerator/listener_generator.go
+++ b/src/go/configgenerator/listener_generator.go
@@ -394,11 +394,11 @@ func makeJwtAuthnFilter(serviceInfo *sc.ServiceInfo) *hcmpb.HttpFilter {
 	}
 	providers := make(map[string]*jwtpb.JwtProvider)
 	for _, provider := range auth.GetProviders() {
-		clusterName, err := util.ExtraAddressFromURI(provider.GetJwksUri())
+		addr, err := util.ExtraAddressFromURI(provider.GetJwksUri())
 		if err != nil {
 			return nil
 		}
-
+		clusterName := util.JwtProviderClusterName(addr)
 		fromHeaders, fromParams := processJwtLocations(provider)
 
 		jp := &jwtpb.JwtProvider{

--- a/src/go/configgenerator/listener_generator_test.go
+++ b/src/go/configgenerator/listener_generator_test.go
@@ -315,7 +315,7 @@ func TestJwtAuthnFilter(t *testing.T) {
                 "remoteJwks": {
                     "cacheDuration": "300s",
                     "httpUri": {
-                        "cluster": "fake-jwks.com:443",
+                        "cluster": "jwt-provider-cluster-fake-jwks.com:443",
                         "timeout": "30s",
                         "uri": "https://fake-jwks.com"
                     }
@@ -389,7 +389,7 @@ func TestJwtAuthnFilter(t *testing.T) {
                 "remoteJwks": {
                     "cacheDuration": "300s",
                     "httpUri": {
-                        "cluster": "fake-jwks.com:443",
+                        "cluster": "jwt-provider-cluster-fake-jwks.com:443",
                         "timeout": "30s",
                         "uri": "https://fake-jwks.com"
                     }
@@ -1740,7 +1740,7 @@ func TestMakeListeners(t *testing.T) {
                         "prefix": "/"
                       },
                       "route": {
-                        "cluster": "bookstore.endpoints.project123.cloud.goog_local",
+                        "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
                         "timeout": "15s"
                       }
                     }

--- a/src/go/configgenerator/route_generator.go
+++ b/src/go/configgenerator/route_generator.go
@@ -60,7 +60,7 @@ func MakeRouteConfig(serviceInfo *configinfo.ServiceInfo) (*routepb.RouteConfigu
 			Action: &routepb.Route_Route{
 				Route: &routepb.RouteAction{
 					ClusterSpecifier: &routepb.RouteAction_Cluster{
-						Cluster: serviceInfo.BackendClusterName(),
+						Cluster: serviceInfo.CatchAllBackendClusterName(),
 					},
 					// Use the default deadline for the catch-all route.
 					// If a customer needs to override this, dynamic routing must be used.
@@ -160,7 +160,7 @@ func MakeRouteConfig(serviceInfo *configinfo.ServiceInfo) (*routepb.RouteConfigu
 			Action: &routepb.Route_Route{
 				Route: &routepb.RouteAction{
 					ClusterSpecifier: &routepb.RouteAction_Cluster{
-						Cluster: serviceInfo.BackendClusterName(),
+						Cluster: serviceInfo.CatchAllBackendClusterName(),
 					},
 				},
 			},

--- a/src/go/configgenerator/route_generator_test.go
+++ b/src/go/configgenerator/route_generator_test.go
@@ -77,7 +77,7 @@ func TestMakeRouteConfig(t *testing.T) {
             }
           ],
           "route":{
-            "cluster":"bookstore.endpoints.project123.cloud.goog_local",
+            "cluster":"backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
             "timeout":"15s"
           }
         }
@@ -151,7 +151,7 @@ func TestMakeRouteConfig(t *testing.T) {
             }
           ],
           "route": {
-            "cluster": "testapipb.com:443",
+            "cluster": "backend-cluster-testapipb.com:443",
             "hostRewriteLiteral": "testapipb.com",
             "timeout": "15s"
           }
@@ -221,7 +221,7 @@ func TestMakeRouteConfig(t *testing.T) {
                   }
                },
                "route":{
-                  "cluster":"testapipb.com:443",
+                  "cluster":"backend-cluster-testapipb.com:443",
                   "hostRewriteLiteral":"testapipb.com",
                   "timeout":"15s"
                }

--- a/src/go/configinfo/service_info.go
+++ b/src/go/configinfo/service_info.go
@@ -163,7 +163,7 @@ func (s *ServiceInfo) buildCatchAllBackend() error {
 	s.CatchAllBackend = &BackendRoutingCluster{
 		UseTLS:      tls,
 		Protocol:    protocol,
-		ClusterName: s.BackendClusterName(),
+		ClusterName: s.CatchAllBackendClusterName(),
 		Hostname:    hostname,
 		Port:        port,
 	}
@@ -459,16 +459,16 @@ func (s *ServiceInfo) processBackendRule() error {
 					s.GrpcSupportRequired = true
 				}
 
-				backendSelector := address
+				clusterName := util.BackendClusterName(address)
 				s.BackendRoutingClusters = append(s.BackendRoutingClusters,
 					&BackendRoutingCluster{
-						ClusterName: backendSelector,
+						ClusterName: clusterName,
 						UseTLS:      tls,
 						Protocol:    protocol,
 						Hostname:    hostname,
 						Port:        port,
 					})
-				backendRoutingClustersMap[address] = backendSelector
+				backendRoutingClustersMap[address] = clusterName
 			}
 
 			clusterName := backendRoutingClustersMap[address]
@@ -699,8 +699,8 @@ func (s *ServiceInfo) getOrCreateMethod(name string) (*methodInfo, error) {
 	return s.Methods[name], nil
 }
 
-func (s *ServiceInfo) BackendClusterName() string {
-	return fmt.Sprintf("%s_local", s.Name)
+func (s *ServiceInfo) CatchAllBackendClusterName() string {
+	return util.BackendClusterName(fmt.Sprintf("%s_local", s.Name))
 }
 
 // If the backend address's scheme is grpc/grpcs, it should be changed it http or https.

--- a/src/go/configinfo/service_info_test.go
+++ b/src/go/configinfo/service_info_test.go
@@ -1437,8 +1437,8 @@ func TestProcessBackendRuleForProtocol(t *testing.T) {
 				},
 			},
 			wantedClusterProtocols: map[string]util.BackendProtocol{
-				"abc.com:443": util.HTTP1,
-				"cnn.com:443": util.HTTP2,
+				"backend-cluster-abc.com:443": util.HTTP1,
+				"backend-cluster-cnn.com:443": util.HTTP2,
 			},
 		},
 		{
@@ -1466,7 +1466,7 @@ func TestProcessBackendRuleForProtocol(t *testing.T) {
 				},
 			},
 			wantedClusterProtocols: map[string]util.BackendProtocol{
-				"abc.com:443": util.HTTP1,
+				"backend-cluster-abc.com:443": util.HTTP1,
 			},
 		},
 	}
@@ -1505,82 +1505,82 @@ func TestProcessBackendRuleForClusterName(t *testing.T) {
 		{
 			desc:        "Domain name with default http port",
 			Address:     "http://abc.com/api/",
-			ClusterName: "abc.com:80",
+			ClusterName: "backend-cluster-abc.com:80",
 		},
 		{
 			desc:        "Domain name with default https port",
 			Address:     "https://abc.com/api/",
-			ClusterName: "abc.com:443",
+			ClusterName: "backend-cluster-abc.com:443",
 		},
 		{
 			desc:        "Domain name with default grpc port",
 			Address:     "grpc://abc.com/api/",
-			ClusterName: "abc.com:80",
+			ClusterName: "backend-cluster-abc.com:80",
 		},
 		{
 			desc:        "Domain name with default grpcs port",
 			Address:     "grpcs://abc.com/api/",
-			ClusterName: "abc.com:443",
+			ClusterName: "backend-cluster-abc.com:443",
 		},
 		{
 			desc:        "Domain name with custom http port",
 			Address:     "http://abc.com:8080/api/",
-			ClusterName: "abc.com:8080",
+			ClusterName: "backend-cluster-abc.com:8080",
 		},
 		{
 			desc:        "Domain name with custom https port",
 			Address:     "https://abc.com:8080/api/",
-			ClusterName: "abc.com:8080",
+			ClusterName: "backend-cluster-abc.com:8080",
 		},
 		{
 			desc:        "Domain name with custom grpc port",
 			Address:     "grpc://abc.com:8080/api/",
-			ClusterName: "abc.com:8080",
+			ClusterName: "backend-cluster-abc.com:8080",
 		},
 		{
 			desc:        "Domain name with custom grpcs port",
 			Address:     "grpcs://abc.com:8080/api/",
-			ClusterName: "abc.com:8080",
+			ClusterName: "backend-cluster-abc.com:8080",
 		},
 		{
 			desc:        "IP with default http port",
 			Address:     "http://127.0.0.1/api/",
-			ClusterName: "127.0.0.1:80",
+			ClusterName: "backend-cluster-127.0.0.1:80",
 		},
 		{
 			desc:        "IP with default https port",
 			Address:     "https://127.0.0.1/api/",
-			ClusterName: "127.0.0.1:443",
+			ClusterName: "backend-cluster-127.0.0.1:443",
 		},
 		{
 			desc:        "IP with default grpc port",
 			Address:     "grpc://127.0.0.1/api/",
-			ClusterName: "127.0.0.1:80",
+			ClusterName: "backend-cluster-127.0.0.1:80",
 		},
 		{
 			desc:        "IP with default grpcs port",
 			Address:     "grpcs://127.0.0.1/api/",
-			ClusterName: "127.0.0.1:443",
+			ClusterName: "backend-cluster-127.0.0.1:443",
 		},
 		{
 			desc:        "IP with custom http port",
 			Address:     "http://127.0.0.1:8080/api/",
-			ClusterName: "127.0.0.1:8080",
+			ClusterName: "backend-cluster-127.0.0.1:8080",
 		},
 		{
 			desc:        "IP with custom https port",
 			Address:     "https://127.0.0.1:8080/api/",
-			ClusterName: "127.0.0.1:8080",
+			ClusterName: "backend-cluster-127.0.0.1:8080",
 		},
 		{
 			desc:        "IP with custom grpc port",
 			Address:     "grpc://127.0.0.1:8080/api/",
-			ClusterName: "127.0.0.1:8080",
+			ClusterName: "backend-cluster-127.0.0.1:8080",
 		},
 		{
 			desc:        "IP with custom grpcs port",
 			Address:     "grpcs://127.0.0.1:8080/api/",
-			ClusterName: "127.0.0.1:8080",
+			ClusterName: "backend-cluster-127.0.0.1:8080",
 		},
 	}
 

--- a/src/go/configmanager/testdata/test_fetch_listeners.go
+++ b/src/go/configmanager/testdata/test_fetch_listeners.go
@@ -36,7 +36,7 @@ const (
 
 var (
 	fakeProtoDescriptor    = base64.StdEncoding.EncodeToString([]byte("rawDescriptor"))
-	testBackendClusterName = fmt.Sprintf("%s_local", TestFetchListenersProjectName)
+	testBackendClusterName = fmt.Sprintf("backend-cluster-%s_local", TestFetchListenersProjectName)
 )
 
 var (
@@ -282,7 +282,7 @@ var (
                                  "remoteJwks":{
                                     "cacheDuration":"300s",
                                     "httpUri":{
-                                       "cluster":"$JWKSURI:443",
+                                       "cluster":"jwt-provider-cluster-$JWKSURI:443",
                                        "timeout":"30s",
                                        "uri":"$JWKSURI"
                                     }
@@ -490,7 +490,7 @@ var (
                                  "remoteJwks":{
                                     "cacheDuration":"300s",
                                     "httpUri":{
-                                       "cluster":"$JWKSURI:443",
+                                       "cluster":"jwt-provider-cluster-$JWKSURI:443",
                                        "timeout":"30s",
                                        "uri":"$JWKSURI"
                                     }
@@ -705,7 +705,7 @@ var (
                                  "remoteJwks":{
                                     "cacheDuration":"300s",
                                     "httpUri":{
-                                       "cluster":"$JWKSURI:443",
+                                       "cluster":"jwt-provider-cluster-$JWKSURI:443",
                                        "timeout":"30s",
                                        "uri":"$JWKSURI"
                                     }
@@ -734,7 +734,7 @@ var (
                                  "remoteJwks":{
                                     "cacheDuration":"300s",
                                     "httpUri":{
-                                       "cluster":"$JWKSURI:443",
+                                       "cluster":"jwt-provider-cluster-$JWKSURI:443",
                                        "timeout":"30s",
                                        "uri":"$JWKSURI"
                                     }
@@ -1147,7 +1147,7 @@ var (
                                  "remoteJwks":{
                                     "cacheDuration":"300s",
                                     "httpUri":{
-                                       "cluster":"$JWKSURI:443",
+                                       "cluster":"jwt-provider-cluster-$JWKSURI:443",
                                        "timeout":"30s",
                                        "uri":"$JWKSURI"
                                     }
@@ -1346,7 +1346,7 @@ var (
                                     "prefix":"/"
                                  },
                                  "route":{
-                                    "cluster":"bookstore.endpoints.project123.cloud.goog_local",
+                                    "cluster":"backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
                                     "timeout":"15s"
                                  }
                               }

--- a/src/go/configmanager/testdata/test_fixed_mode_dynamic_routing.go
+++ b/src/go/configmanager/testdata/test_fixed_mode_dynamic_routing.go
@@ -18,209 +18,205 @@ var (
 	// These resources must be ordered in alphabetic order by name
 	FakeWantedClustersForDynamicRouting = []string{`
 {
-  "name": "echo-api.endpoints.cloudesf-testing.cloud.goog_local",
-  "type": "LOGICAL_DNS",
-  "connectTimeout": "20s",
-  "loadAssignment": {
-    "clusterName": "127.0.0.1",
-    "endpoints": [
-      {
-       "lbEndpoints": [
-         {
-           "endpoint": {
-             "address": {
-	              "socketAddress": {
-	                "address": "127.0.0.1",
-	                "portValue": 8082
-	              }
-	            }
-	          }
-          }
-        ]
-      }
-    ]
-  }
+	"name": "backend-cluster-echo-api.endpoints.cloudesf-testing.cloud.goog_local",
+	"type": "LOGICAL_DNS",
+	"connectTimeout": "20s",
+	"loadAssignment": {
+		"clusterName": "127.0.0.1",
+		"endpoints": [
+		{
+			"lbEndpoints": [
+			{
+				"endpoint": {
+					"address": {
+						"socketAddress": {
+							"address": "127.0.0.1",
+							"portValue": 8082
+						}
+					}
+				}
+			}
+		]
+		}
+	]
+	}
 }`,
-		`
+		`{
+		"connectTimeout":"20s",
+		"loadAssignment":{
+			"clusterName":"pets.appspot.com",
+			"endpoints":[
+			{
+				"lbEndpoints":[
+				{
+					"endpoint":{
+						"address":{
+							"socketAddress":{
+								"address":"pets.appspot.com",
+								"portValue":443
+							}
+						}
+					}
+				}
+			]
+			}
+		]
+		},
+		"name":"backend-cluster-pets.appspot.com:443",
+		"transportSocket":{
+			"name":"envoy.transport_sockets.tls",
+			"typedConfig":{
+				"@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+				"sni":"pets.appspot.com",
+				"commonTlsContext": {
+					"validationContext": {
+						"trustedCa": {
+							"filename": "/etc/ssl/certs/ca-certificates.crt"
+						}
+					}
+				}
+			}
+		},
+		"type":"LOGICAL_DNS"
+	}`, `
 {
-  "name": "metadata-cluster",
-  "type": "STRICT_DNS",
-  "connectTimeout": "20s",
-  "loadAssignment":{
-    "clusterName":"169.254.169.254",
-    "endpoints":[
-      {
-        "lbEndpoints":[
-          {
-            "endpoint":{
-              "address":{
-	              "socketAddress":{
-	                "address":"169.254.169.254",
-	                "portValue":80
-	              }
-	            }
-	          }
-          }
-        ]
-      }
-    ]
-  }
-}`,
-		`
-{
-   "connectTimeout":"20s",
-   "loadAssignment":{
-      "clusterName":"pets.appspot.com",
-      "endpoints":[
-         {
-            "lbEndpoints":[
-               {
-                  "endpoint":{
-                     "address":{
-                        "socketAddress":{
-                           "address":"pets.appspot.com",
-                           "portValue":443
-                        }
-                     }
-                  }
-               }
-            ]
-         }
-      ]
-   },
-   "name":"pets.appspot.com:443",
-   "transportSocket":{
-      "name":"envoy.transport_sockets.tls",
-      "typedConfig":{
-         "@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
-         "sni":"pets.appspot.com",
-         "commonTlsContext": {
-            "validationContext": {
-               "trustedCa": {
-                  "filename": "/etc/ssl/certs/ca-certificates.crt"
-               }
-            }
-         }
-      }
-   },
-   "type":"LOGICAL_DNS"
-}`, `
-{
-   "connectTimeout":"20s",
-   "loadAssignment":{
-      "clusterName":"pets.appspot.com",
-      "endpoints":[
-         {
-            "lbEndpoints":[
-               {
-                  "endpoint":{
-                     "address":{
-                        "socketAddress":{
-                           "address":"pets.appspot.com",
-                           "portValue":8008
-                        }
-                     }
-                  }
-               }
-            ]
-         }
-      ]
-   },
-   "name":"pets.appspot.com:8008",
-   "transportSocket":{
-      "name":"envoy.transport_sockets.tls",
-      "typedConfig":{
-         "@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
-         "sni":"pets.appspot.com",
-         "commonTlsContext": {
-            "validationContext": {
-               "trustedCa": {
-                  "filename": "/etc/ssl/certs/ca-certificates.crt"
-               }
-            }
-         }
-      }
-   },
-   "type":"LOGICAL_DNS"
-}`,
-		`
-{
-   "connectTimeout":"20s",
-   "loadAssignment":{
-      "clusterName":"us-central1-cloud-esf.cloudfunctions.net",
-      "endpoints":[
-         {
-            "lbEndpoints":[
-               {
-                  "endpoint":{
-                     "address":{
-                        "socketAddress":{
-                           "address":"us-central1-cloud-esf.cloudfunctions.net",
-                           "portValue":443
-                        }
-                     }
-                  }
-               }
-            ]
-         }
-      ]
-   },
-   "name":"us-central1-cloud-esf.cloudfunctions.net:443",
-   "transportSocket":{
-      "name":"envoy.transport_sockets.tls",
-      "typedConfig":{
-         "@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
-         "sni":"us-central1-cloud-esf.cloudfunctions.net",
-         "commonTlsContext": {
-            "validationContext": {
-               "trustedCa": {
-                  "filename": "/etc/ssl/certs/ca-certificates.crt"
-               }
-            }
-         }
-      }
-   },
-   "type":"LOGICAL_DNS"
-}`,
-		`
-{
-   "connectTimeout":"20s",
-   "loadAssignment":{
-      "clusterName":"us-west2-cloud-esf.cloudfunctions.net",
-      "endpoints":[
-         {
-            "lbEndpoints":[
-               {
-                  "endpoint":{
-                     "address":{
-                        "socketAddress":{
-                           "address":"us-west2-cloud-esf.cloudfunctions.net",
-                           "portValue":443
-                        }
-                     }
-                  }
-               }
-            ]
-         }
-      ]
-   },
-   "name":"us-west2-cloud-esf.cloudfunctions.net:443",
-   "transportSocket":{
-      "name":"envoy.transport_sockets.tls",
-      "typedConfig":{
-         "@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
-         "sni":"us-west2-cloud-esf.cloudfunctions.net",
-         "commonTlsContext": {
-            "validationContext": {
-               "trustedCa": {
-                  "filename": "/etc/ssl/certs/ca-certificates.crt"
-               }
-            }
-         }
-      }
-   },
-   "type":"LOGICAL_DNS"
-}`,
+		"connectTimeout":"20s",
+		"loadAssignment":{
+			"clusterName":"pets.appspot.com",
+			"endpoints":[
+			{
+				"lbEndpoints":[
+				{
+					"endpoint":{
+						"address":{
+							"socketAddress":{
+								"address":"pets.appspot.com",
+								"portValue":8008
+							}
+						}
+					}
+				}
+			]
+			}
+		]
+		},
+		"name":"backend-cluster-pets.appspot.com:8008",
+		"transportSocket":{
+			"name":"envoy.transport_sockets.tls",
+			"typedConfig":{
+				"@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+				"sni":"pets.appspot.com",
+				"commonTlsContext": {
+					"validationContext": {
+						"trustedCa": {
+							"filename": "/etc/ssl/certs/ca-certificates.crt"
+						}
+					}
+				}
+			}
+		},
+		"type":"LOGICAL_DNS"
+		}`,
+		`{
+			"connectTimeout":"20s",
+			"loadAssignment":{
+				"clusterName":"us-central1-cloud-esf.cloudfunctions.net",
+				"endpoints":[
+				{
+					"lbEndpoints":[
+					{
+						"endpoint":{
+							"address":{
+								"socketAddress":{
+									"address":"us-central1-cloud-esf.cloudfunctions.net",
+									"portValue":443
+								}
+							}
+						}
+					}
+				]
+				}
+			]
+			},
+			"name":"backend-cluster-us-central1-cloud-esf.cloudfunctions.net:443",
+			"transportSocket":{
+				"name":"envoy.transport_sockets.tls",
+				"typedConfig":{
+					"@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+					"sni":"us-central1-cloud-esf.cloudfunctions.net",
+					"commonTlsContext": {
+						"validationContext": {
+							"trustedCa": {
+								"filename": "/etc/ssl/certs/ca-certificates.crt"
+							}
+						}
+					}
+				}
+			},
+			"type":"LOGICAL_DNS"
+		}`,
+		`	{
+			"connectTimeout":"20s",
+			"loadAssignment":{
+				"clusterName":"us-west2-cloud-esf.cloudfunctions.net",
+				"endpoints":[
+				{
+					"lbEndpoints":[
+					{
+						"endpoint":{
+							"address":{
+								"socketAddress":{
+									"address":"us-west2-cloud-esf.cloudfunctions.net",
+									"portValue":443
+								}
+							}
+						}
+					}
+				]
+				}
+			]
+			},
+			"name":"backend-cluster-us-west2-cloud-esf.cloudfunctions.net:443",
+			"transportSocket":{
+				"name":"envoy.transport_sockets.tls",
+				"typedConfig":{
+					"@type":"type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+					"sni":"us-west2-cloud-esf.cloudfunctions.net",
+					"commonTlsContext": {
+						"validationContext": {
+							"trustedCa": {
+								"filename": "/etc/ssl/certs/ca-certificates.crt"
+							}
+						}
+					}
+				}
+			},
+			"type":"LOGICAL_DNS"
+		}`,
+		`{
+			"name": "metadata-cluster",
+			"type": "STRICT_DNS",
+			"connectTimeout": "20s",
+			"loadAssignment":{
+				"clusterName":"169.254.169.254",
+				"endpoints":[
+				{
+					"lbEndpoints":[
+					{
+						"endpoint":{
+							"address":{
+								"socketAddress":{
+									"address":"169.254.169.254",
+									"portValue":80
+								}
+							}
+						}
+					}
+				]
+				}
+			]
+			}
+		}`,
 	}
 
 	FakeWantedListenerForDynamicRouting = `
@@ -389,7 +385,7 @@ var (
                                     "path":"/pet"
                                  },
                                  "route":{
-                                    "cluster":"pets.appspot.com:443",
+                                    "cluster":"backend-cluster-pets.appspot.com:443",
                                     "hostRewriteLiteral":"pets.appspot.com",
                                     "timeout":"15s"
                                  }
@@ -412,7 +408,7 @@ var (
                                     }
                                  },
                                  "route":{
-                                    "cluster":"pets.appspot.com:8008",
+                                    "cluster":"backend-cluster-pets.appspot.com:8008",
                                     "hostRewriteLiteral":"pets.appspot.com",
                                     "timeout":"15s"
                                  }
@@ -431,7 +427,7 @@ var (
                                     "path":"/hello"
                                  },
                                  "route":{
-                                    "cluster":"us-central1-cloud-esf.cloudfunctions.net:443",
+                                    "cluster":"backend-cluster-us-central1-cloud-esf.cloudfunctions.net:443",
                                     "hostRewriteLiteral":"us-central1-cloud-esf.cloudfunctions.net",
                                     "timeout":"15s"
                                  }
@@ -450,7 +446,7 @@ var (
                                     "path":"/pets"
                                  },
                                  "route":{
-                                    "cluster":"pets.appspot.com:443",
+                                    "cluster":"backend-cluster-pets.appspot.com:443",
                                     "hostRewriteLiteral":"pets.appspot.com",
                                     "timeout":"15s"
                                  }
@@ -469,7 +465,7 @@ var (
                                     "path":"/search"
                                  },
                                  "route":{
-                                    "cluster":"us-west2-cloud-esf.cloudfunctions.net:443",
+                                    "cluster":"backend-cluster-us-west2-cloud-esf.cloudfunctions.net:443",
                                     "hostRewriteLiteral":"us-west2-cloud-esf.cloudfunctions.net",
                                     "timeout":"15s"
                                  }

--- a/src/go/util/util.go
+++ b/src/go/util/util.go
@@ -17,43 +17,10 @@ package util
 import "time"
 
 const (
-	// Upstream envoy http filter names.
-
-	// Buffer HTTP filter
-	Buffer = "envoy.filters.http.buffer"
-	// CORS HTTP filter
-	CORS = "envoy.filters.http.cors"
-	// GRPCJSONTranscoder HTTP filter
-	GRPCJSONTranscoder = "envoy.filters.http.grpc_json_transcoder"
-	// GRPCWeb HTTP filter
-	GRPCWeb = "envoy.filters.http.grpc_web"
-	// Router HTTP filter
-	Router = "envoy.filters.http.router"
-	// Health checking HTTP filter
-	HealthCheck = "envoy.filters.http.health_check"
-	// Echo network filter
-	Echo = "envoy.filters.network.echo"
-	// HTTPConnectionManager network filter
-	HTTPConnectionManager = "envoy.filters.network.http_connection_manager"
-	// JwtAuthn filter.
-	JwtAuthn = "envoy.filters.http.jwt_authn"
-	// TLSTransportSocket is Envoy TLS Transport Socket name.
-	TLSTransportSocket = "envoy.transport_sockets.tls"
-	// AccessFileLogger filter name
-	AccessFileLogger = "envoy.access_loggers.file"
 	// DefaultRootCAPaths is the default certs path.
 	DefaultRootCAPaths = "/etc/ssl/certs/ca-certificates.crt"
 
 	// ESPv2 custom http filters.
-
-	// ServiceControl filter.
-	ServiceControl = "com.google.espv2.filters.http.service_control"
-	// PathMatcher filter.
-	PathMatcher = "com.google.espv2.filters.http.path_matcher"
-	// BackendAuth filter.
-	BackendAuth = "com.google.espv2.filters.http.backend_auth"
-	// BackendRouting filter.
-	BackendRouting = "com.google.espv2.filters.http.backend_routing"
 
 	// JwtPayloadMetadataName is the field name passed into metadata
 	JwtPayloadMetadataName = "jwt_payloads"
@@ -96,21 +63,6 @@ const (
 
 	// b/147591854: This string must NOT have a trailing slash
 	OpenIDDiscoveryCfgURLSuffix = "/.well-known/openid-configuration"
-
-	// The metadata server cluster name.
-	MetadataServerClusterName = "metadata-cluster"
-
-	// The token agent server cluster name.
-	TokenAgentClusterName = "token-agent-cluster"
-
-	// The iam server cluster name.
-	IamServerClusterName = "iam-cluster"
-
-	// The service control server cluster name.
-	ServiceControlClusterName = "service-control-cluster"
-
-	IngressListenerName  = "ingress_listener"
-	LoopbackListenerName = "loopback_listener"
 
 	// Platforms
 	GAEFlex = "GAE_FLEX(ESPv2)"

--- a/src/go/util/xds_name.go
+++ b/src/go/util/xds_name.go
@@ -1,0 +1,80 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import "fmt"
+
+const (
+	// Upstream envoy http filter names.
+
+	// Buffer HTTP filter
+	Buffer = "envoy.filters.http.buffer"
+	// CORS HTTP filter
+	CORS = "envoy.filters.http.cors"
+	// GRPCJSONTranscoder HTTP filter
+	GRPCJSONTranscoder = "envoy.filters.http.grpc_json_transcoder"
+	// GRPCWeb HTTP filter
+	GRPCWeb = "envoy.filters.http.grpc_web"
+	// Router HTTP filter
+	Router = "envoy.filters.http.router"
+	// Health checking HTTP filter
+	HealthCheck = "envoy.filters.http.health_check"
+	// Echo network filter
+	Echo = "envoy.filters.network.echo"
+	// HTTPConnectionManager network filter
+	HTTPConnectionManager = "envoy.filters.network.http_connection_manager"
+	// JwtAuthn filter.
+	JwtAuthn = "envoy.filters.http.jwt_authn"
+	// TLSTransportSocket is Envoy TLS Transport Socket name.
+	TLSTransportSocket = "envoy.transport_sockets.tls"
+	// AccessFileLogger filter name
+	AccessFileLogger = "envoy.access_loggers.file"
+
+	// ESPv2 custom http filters.
+
+	// ServiceControl filter.
+	ServiceControl = "com.google.espv2.filters.http.service_control"
+	// PathMatcher filter.
+	PathMatcher = "com.google.espv2.filters.http.path_matcher"
+	// BackendAuth filter.
+	BackendAuth = "com.google.espv2.filters.http.backend_auth"
+	// BackendRouting filter.
+	BackendRouting = "com.google.espv2.filters.http.backend_routing"
+
+	// The metadata server cluster name.
+	MetadataServerClusterName = "metadata-cluster"
+
+	// The token agent server cluster name.
+	TokenAgentClusterName = "token-agent-cluster"
+
+	// The iam server cluster name.
+	IamServerClusterName = "iam-cluster"
+
+	// The service control server cluster name.
+	ServiceControlClusterName = "service-control-cluster"
+
+	IngressListenerName  = "ingress_listener"
+	LoopbackListenerName = "loopback_listener"
+)
+
+// Jwt provider cluster's name will be in form of "jwt-provider-cluster-${JWT_PROVIDER_ADDRESS}".
+func JwtProviderClusterName(address string) string {
+	return fmt.Sprintf("jwt-provider-cluster-%s", address)
+}
+
+// Backend cluster'name will be in form of "backend-cluster-${BACKEND_ADDRESS}"
+func BackendClusterName(address string) string {
+	return fmt.Sprintf("backend-cluster-%s", address)
+}

--- a/src/go/util/xds_name_test.go
+++ b/src/go/util/xds_name_test.go
@@ -1,0 +1,47 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+)
+
+func TestJwtProviderClusterName(t *testing.T) {
+	testCase := struct {
+		address    string
+		wantedName string
+	}{
+		address:    "localhost.com:8000",
+		wantedName: "jwt-provider-cluster-localhost.com:8000",
+	}
+
+	if gotName := JwtProviderClusterName(testCase.address); gotName != testCase.wantedName {
+		t.Errorf("fail to create jwt provider cluster name, expected: %s, got: %s", testCase.wantedName, gotName)
+	}
+}
+
+func TestBackendClusterName(t *testing.T) {
+	testCase := struct {
+		address    string
+		wantedName string
+	}{
+		address:    "localhost.com:8000",
+		wantedName: "backend-cluster-localhost.com:8000",
+	}
+
+	if gotName := BackendClusterName(testCase.address); gotName != testCase.wantedName {
+		t.Errorf("fail to create backend cluster name, expected: %s, got: %s", testCase.wantedName, gotName)
+	}
+}

--- a/tests/integration_test/opencensus_tracing_test.go
+++ b/tests/integration_test/opencensus_tracing_test.go
@@ -102,7 +102,7 @@ func TestTracesServiceControlCheckWithRetry(t *testing.T) {
 				"Service Control remote call: Check",
 				"Service Control remote call: Check - Retry 1",
 				"Service Control remote call: Check - Retry 2",
-				"router bookstore.endpoints.cloudesf-testing.cloud.goog_local egress",
+				"router backend-cluster-bookstore.endpoints.cloudesf-testing.cloud.goog_local egress",
 				"ingress",
 			},
 		},
@@ -116,7 +116,7 @@ func TestTracesServiceControlCheckWithRetry(t *testing.T) {
 			token:          testdata.FakeCloudTokenMultiAudiences,
 			wantSpanNames: []string{
 				"Service Control remote call: Check",
-				"router bookstore.endpoints.cloudesf-testing.cloud.goog_local egress",
+				"router backend-cluster-bookstore.endpoints.cloudesf-testing.cloud.goog_local egress",
 				"ingress",
 			},
 		},
@@ -175,7 +175,7 @@ func TestTracesServiceControlSkipUsage(t *testing.T) {
 			method: "GET",
 			wantSpanNames: []string{
 				"Service Control remote call: Check",
-				"router echo-api.endpoints.cloudesf-testing.cloud.goog_local egress",
+				"router backend-cluster-echo-api.endpoints.cloudesf-testing.cloud.goog_local egress",
 				"ingress",
 			},
 		},
@@ -185,7 +185,7 @@ func TestTracesServiceControlSkipUsage(t *testing.T) {
 			method:  "POST",
 			message: "hello",
 			wantSpanNames: []string{
-				"router echo-api.endpoints.cloudesf-testing.cloud.goog_local egress",
+				"router backend-cluster-echo-api.endpoints.cloudesf-testing.cloud.goog_local egress",
 				"ingress",
 			},
 		},
@@ -258,7 +258,7 @@ func TestTracesFetchingJwks(t *testing.T) {
 			wantSpanNames: []string{
 				"JWT Remote PubKey Fetch",
 				"Service Control remote call: Check",
-				"router bookstore.endpoints.cloudesf-testing.cloud.goog_local egress",
+				"router backend-cluster-bookstore.endpoints.cloudesf-testing.cloud.goog_local egress",
 				"ingress",
 			},
 		},
@@ -402,7 +402,7 @@ func TestTracesDynamicRouting(t *testing.T) {
 			url:    fmt.Sprintf("http://localhost:%v%v%v", s.Ports().ListenerPort, "/pet/1/num/2", ""),
 			method: util.GET,
 			wantSpanNames: []string{
-				"router localhost:21837 egress",
+				"router backend-cluster-localhost:21837 egress",
 				"ingress dynamic_routing_GetPetById",
 			},
 		},


### PR DESCRIPTION
Currently, we use address to name these 2 types of clusters. The change will
- for backend clusters: add `backend-cluster-` prefix
- for jwtProvider clusters: add `jwt-provider-cluster-` prefix

It helps to distinguish with other clusters.