### PR TITLE
Refactor test framework for port rewrite

### DIFF
--- a/tests/env/components/config_manager.go
+++ b/tests/env/components/config_manager.go
@@ -28,7 +28,7 @@ type ConfigManagerServer struct {
 	grpcPort uint16
 }
 
-func NewConfigManagerServer(debugMode bool, ports *Ports, args []string) (*ConfigManagerServer, error) {
+func NewConfigManagerServer(debugMode bool, ports *platform.Ports, args []string) (*ConfigManagerServer, error) {
 
 	// Set config manager flags.
 	args = append(args, "--listener_address", platform.GetAnyAddress())

--- a/tests/env/components/envoy.go
+++ b/tests/env/components/envoy.go
@@ -31,7 +31,7 @@ type Envoy struct {
 }
 
 // createEnvoyConf create envoy config.
-func createEnvoyConf(configPath string, bootstrapArgs []string, ports *Ports) error {
+func createEnvoyConf(configPath string, bootstrapArgs []string, ports *platform.Ports) error {
 
 	glog.Infof("Outputting envoy bootstrap config to: %v", configPath)
 
@@ -49,7 +49,7 @@ func createEnvoyConf(configPath string, bootstrapArgs []string, ports *Ports) er
 }
 
 // NewEnvoy creates a new Envoy struct and starts envoy.
-func NewEnvoy(args []string, bootstrapArgs []string, confPath string, ports *Ports, testId uint16) (*Envoy, error) {
+func NewEnvoy(args []string, bootstrapArgs []string, confPath string, ports *platform.Ports, testId uint16) (*Envoy, error) {
 
 	if err := createEnvoyConf(confPath, bootstrapArgs, ports); err != nil {
 		return nil, err

--- a/tests/env/components/mock_jwt_provider.go
+++ b/tests/env/components/mock_jwt_provider.go
@@ -58,7 +58,7 @@ func NewFakeJwtService() *FakeJwtService {
 }
 
 // Setup non-OpenId providers.
-func (fjs *FakeJwtService) SetupJwt(requestedProviders map[string]bool, ports *Ports) error {
+func (fjs *FakeJwtService) SetupJwt(requestedProviders map[string]bool, ports *platform.Ports) error {
 
 	// Setup non-OpenID providers
 	for i, config := range testdata.ProviderConfigs {

--- a/tests/env/components/stats_verifier.go
+++ b/tests/env/components/stats_verifier.go
@@ -35,7 +35,7 @@ type StatsVerifier struct {
 	adminPort uint16
 }
 
-func NewStatsVerifier(ports *Ports) *StatsVerifier {
+func NewStatsVerifier(ports *platform.Ports) *StatsVerifier {
 	return &StatsVerifier{
 		adminPort: ports.AdminPort,
 	}

--- a/tests/env/platform/ports.go
+++ b/tests/env/platform/ports.go
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package components
+package platform
 
 import (
 	"fmt"
 	"net"
 	"time"
 
-	"github.com/GoogleCloudPlatform/esp-v2/tests/env/testdata"
 	"github.com/golang/glog"
 )
 
@@ -147,15 +146,21 @@ const (
 )
 
 const (
+	// Start port allocation range.
 	portBase uint16 = 20000
 
 	// Maximum number of ports used by non-jwt components.
 	portNum uint16 = 7
 )
 
+const (
+	WorkingBackendPort string = "-1"
+	InvalidBackendPort string = "6"
+)
+
 var (
 	// Maximum number of ports used by jwt fake servers.
-	jwtPortNum = uint16(len(testdata.ProviderConfigs))
+	jwtPortNum = uint16(20)
 
 	preAllocatedPorts = map[uint16]bool{
 		// Ports allocated to Jwt open-id servers

--- a/tests/env/testdata/fake_echo_service_config_for_dynamic_routing.go
+++ b/tests/env/testdata/fake_echo_service_config_for_dynamic_routing.go
@@ -15,6 +15,9 @@
 package testdata
 
 import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	annotationspb "google.golang.org/genproto/googleapis/api/annotations"
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
 	apipb "google.golang.org/genproto/protobuf/api"
@@ -415,13 +418,13 @@ var (
 			Rules: []*confpb.BackendRule{
 				{
 					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo",
-					Address:         "https://localhost:-1/echo",
+					Address:         fmt.Sprintf("https://localhost:%s/echo", platform.WorkingBackendPort),
 					PathTranslation: confpb.BackendRule_CONSTANT_ADDRESS,
 					// No authentication on this rule, essentially the same as `disable_auth`
 				},
 				{
 					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_GetPetById",
-					Address:         "https://localhost:-1/dynamicrouting/getpetbyid",
+					Address:         fmt.Sprintf("https://localhost:%s/dynamicrouting/getpetbyid", platform.WorkingBackendPort),
 					PathTranslation: confpb.BackendRule_CONSTANT_ADDRESS,
 					Authentication: &confpb.BackendRule_JwtAudience{
 						JwtAudience: "https://localhost/dynamicrouting/getpetbyid",
@@ -429,7 +432,7 @@ var (
 				},
 				{
 					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_SearchPet",
-					Address:         "https://localhost:-1/dynamicrouting/searchpet",
+					Address:         fmt.Sprintf("https://localhost:%s/dynamicrouting/searchpet", platform.WorkingBackendPort),
 					PathTranslation: confpb.BackendRule_APPEND_PATH_TO_ADDRESS,
 					Authentication: &confpb.BackendRule_JwtAudience{
 						JwtAudience: "https://localhost/dynamicrouting/searchpet",
@@ -437,7 +440,7 @@ var (
 				},
 				{
 					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_SearchDogsWithSlash",
-					Address:         "https://localhost:-1/dynamicrouting/searchdogs/",
+					Address:         fmt.Sprintf("https://localhost:%s/dynamicrouting/searchdogs/", platform.WorkingBackendPort),
 					PathTranslation: confpb.BackendRule_APPEND_PATH_TO_ADDRESS,
 					Authentication: &confpb.BackendRule_JwtAudience{
 						JwtAudience: "https://localhost/dynamicrouting/searchpet",
@@ -445,7 +448,7 @@ var (
 				},
 				{
 					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_AppendToRoot",
-					Address:         "https://localhost:-1",
+					Address:         fmt.Sprintf("https://localhost:%s", platform.WorkingBackendPort),
 					PathTranslation: confpb.BackendRule_APPEND_PATH_TO_ADDRESS,
 					Authentication: &confpb.BackendRule_JwtAudience{
 						JwtAudience: "https://localhost/searchroot",
@@ -453,7 +456,7 @@ var (
 				},
 				{
 					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_AppendToRootWithSlash",
-					Address:         "https://localhost:-1/",
+					Address:         fmt.Sprintf("https://localhost:%s/", platform.WorkingBackendPort),
 					PathTranslation: confpb.BackendRule_APPEND_PATH_TO_ADDRESS,
 					Authentication: &confpb.BackendRule_JwtAudience{
 						JwtAudience: "https://localhost/searchrootwithslash",
@@ -461,7 +464,7 @@ var (
 				},
 				{
 					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_ListPets",
-					Address:         "https://localhost:-1/dynamicrouting/listpet",
+					Address:         fmt.Sprintf("https://localhost:%s/dynamicrouting/listpet", platform.WorkingBackendPort),
 					PathTranslation: confpb.BackendRule_APPEND_PATH_TO_ADDRESS,
 					Authentication: &confpb.BackendRule_JwtAudience{
 						JwtAudience: "https://localhost/dynamicrouting/listpet",
@@ -469,7 +472,7 @@ var (
 				},
 				{
 					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_ListShelves",
-					Address:         "https://localhost:-1/dynamicrouting/shelves",
+					Address:         fmt.Sprintf("https://localhost:%s/dynamicrouting/shelves", platform.WorkingBackendPort),
 					PathTranslation: confpb.BackendRule_CONSTANT_ADDRESS,
 					Authentication: &confpb.BackendRule_JwtAudience{
 						JwtAudience: "https://localhost/dynamicrouting/shelves",
@@ -477,7 +480,7 @@ var (
 				},
 				{
 					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_EmptyPath",
-					Address:         "https://localhost:-1",
+					Address:         fmt.Sprintf("https://localhost:%s", platform.WorkingBackendPort),
 					PathTranslation: confpb.BackendRule_CONSTANT_ADDRESS,
 					Authentication: &confpb.BackendRule_JwtAudience{
 						JwtAudience: "https://localhost/dynamicrouting/emptypath",
@@ -485,7 +488,7 @@ var (
 				},
 				{
 					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_GetBookInfoWithSnakeCase",
-					Address:         "https://localhost:-1/dynamicrouting/bookinfo",
+					Address:         fmt.Sprintf("https://localhost:%s/dynamicrouting/bookinfo", platform.WorkingBackendPort),
 					PathTranslation: confpb.BackendRule_CONSTANT_ADDRESS,
 					Authentication: &confpb.BackendRule_JwtAudience{
 						JwtAudience: "https://localhost/dynamicrouting/bookinfo",
@@ -493,7 +496,7 @@ var (
 				},
 				{
 					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_GetBookIdWithSnakeCase",
-					Address:         "https://localhost:-1/dynamicrouting/bookid",
+					Address:         fmt.Sprintf("https://localhost:%s/dynamicrouting/bookid", platform.WorkingBackendPort),
 					PathTranslation: confpb.BackendRule_CONSTANT_ADDRESS,
 					Authentication: &confpb.BackendRule_JwtAudience{
 						JwtAudience: "https://localhost/dynamicrouting/bookid",
@@ -501,7 +504,7 @@ var (
 				},
 				{
 					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_SearchPetWithServiceControlVerification",
-					Address:         "https://localhost:-1/dynamicrouting/",
+					Address:         fmt.Sprintf("https://localhost:%s/dynamicrouting/", platform.WorkingBackendPort),
 					PathTranslation: confpb.BackendRule_APPEND_PATH_TO_ADDRESS,
 					Authentication: &confpb.BackendRule_JwtAudience{
 						JwtAudience: "https://localhost/dynamicrouting",
@@ -509,7 +512,7 @@ var (
 				},
 				{
 					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_GetPetByIdWithServiceControlVerification",
-					Address:         "https://localhost:-1/dynamicrouting/",
+					Address:         fmt.Sprintf("https://localhost:%s/dynamicrouting/", platform.WorkingBackendPort),
 					PathTranslation: confpb.BackendRule_CONSTANT_ADDRESS,
 					Authentication: &confpb.BackendRule_JwtAudience{
 						JwtAudience: "https://localhost/dynamicrouting",
@@ -517,7 +520,7 @@ var (
 				},
 				{
 					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_BearertokenConstantAddress",
-					Address:         "https://localhost:-1/bearertoken/constant",
+					Address:         fmt.Sprintf("https://localhost:%s/bearertoken/constant", platform.WorkingBackendPort),
 					PathTranslation: confpb.BackendRule_CONSTANT_ADDRESS,
 					Authentication: &confpb.BackendRule_JwtAudience{
 						JwtAudience: "https://localhost/bearertoken/constant",
@@ -525,7 +528,7 @@ var (
 				},
 				{
 					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_BearertokenAppendAddress",
-					Address:         "https://localhost:-1",
+					Address:         fmt.Sprintf("https://localhost:%s", platform.WorkingBackendPort),
 					PathTranslation: confpb.BackendRule_APPEND_PATH_TO_ADDRESS,
 					Authentication: &confpb.BackendRule_JwtAudience{
 						JwtAudience: "https://localhost/bearertoken/append",
@@ -533,24 +536,24 @@ var (
 				},
 				{
 					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_AuthenticationNotSet",
-					Address:         "https://localhost:-1/bearertoken/constant",
+					Address:         fmt.Sprintf("https://localhost:%s/bearertoken/constant", platform.WorkingBackendPort),
 					PathTranslation: confpb.BackendRule_CONSTANT_ADDRESS,
 				},
 				{
 					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_DisableAuthSetToTrue",
-					Address:         "https://localhost:-1/bearertoken/constant",
+					Address:         fmt.Sprintf("https://localhost:%s/bearertoken/constant", platform.WorkingBackendPort),
 					PathTranslation: confpb.BackendRule_CONSTANT_ADDRESS,
 					Authentication:  &confpb.BackendRule_DisableAuth{DisableAuth: true},
 				},
 				{
 					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_DisableAuthSetToFalse",
-					Address:         "https://localhost:-1/bearertoken/constant",
+					Address:         fmt.Sprintf("https://localhost:%s/bearertoken/constant", platform.WorkingBackendPort),
 					PathTranslation: confpb.BackendRule_CONSTANT_ADDRESS,
 					Authentication:  &confpb.BackendRule_DisableAuth{DisableAuth: false},
 				},
 				{
 					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_Simplegetcors",
-					Address:         "https://localhost:-1",
+					Address:         fmt.Sprintf("https://localhost:%s", platform.WorkingBackendPort),
 					PathTranslation: confpb.BackendRule_APPEND_PATH_TO_ADDRESS,
 					Authentication: &confpb.BackendRule_JwtAudience{
 						JwtAudience: "https://localhost/simplegetcors",
@@ -558,7 +561,7 @@ var (
 				},
 				{
 					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_Auth_info_firebase",
-					Address:         "https://localhost:-1",
+					Address:         fmt.Sprintf("https://localhost:%s", platform.WorkingBackendPort),
 					PathTranslation: confpb.BackendRule_APPEND_PATH_TO_ADDRESS,
 					Authentication: &confpb.BackendRule_JwtAudience{
 						JwtAudience: "https://localhost/auth/info/firebase",
@@ -566,7 +569,7 @@ var (
 				},
 				{
 					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_SleepDurationDefault",
-					Address:         "https://localhost:-1",
+					Address:         fmt.Sprintf("https://localhost:%s", platform.WorkingBackendPort),
 					PathTranslation: confpb.BackendRule_APPEND_PATH_TO_ADDRESS,
 					Authentication: &confpb.BackendRule_JwtAudience{
 						JwtAudience: "https://localhost/sleepDefault",
@@ -574,7 +577,7 @@ var (
 				},
 				{
 					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_SleepDurationShort",
-					Address:         "https://localhost:-1",
+					Address:         fmt.Sprintf("https://localhost:%s", platform.WorkingBackendPort),
 					PathTranslation: confpb.BackendRule_APPEND_PATH_TO_ADDRESS,
 					Authentication: &confpb.BackendRule_JwtAudience{
 						JwtAudience: "https://localhost/sleepShort",
@@ -583,7 +586,7 @@ var (
 				},
 				{
 					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_Re2ProgramSize",
-					Address:         "https://localhost:-1",
+					Address:         fmt.Sprintf("https://localhost:%s", platform.WorkingBackendPort),
 					PathTranslation: confpb.BackendRule_APPEND_PATH_TO_ADDRESS,
 					Authentication: &confpb.BackendRule_JwtAudience{
 						JwtAudience: "https://localhost/non-existant-url",
@@ -591,24 +594,24 @@ var (
 				},
 				{
 					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_Wildcards",
-					Address:         "https://localhost:-1/dynamicrouting/const_wildcard",
+					Address:         fmt.Sprintf("https://localhost:%s/dynamicrouting/const_wildcard", platform.WorkingBackendPort),
 					PathTranslation: confpb.BackendRule_CONSTANT_ADDRESS,
 				},
 				{
 					Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.operation_order_first_matched",
 					// Address is malformed on purpose. We can ensure envoy host rewrite fails.
-					Address:         "https://localhost:9/echo",
+					Address:         fmt.Sprintf("https://localhost:%s/echo", platform.InvalidBackendPort),
 					PathTranslation: confpb.BackendRule_CONSTANT_ADDRESS,
 				},
 				{
 					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.operation_order_second_catch_all",
-					Address:         "https://localhost:-1/echo",
+					Address:         fmt.Sprintf("https://localhost:%s/echo", platform.WorkingBackendPort),
 					PathTranslation: confpb.BackendRule_CONSTANT_ADDRESS,
 				},
 				{
 					Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.operation_order_third_unmatched",
 					// Address is malformed on purpose. We can ensure envoy host rewrite fails.
-					Address:         "https://localhost:9/echo",
+					Address:         fmt.Sprintf("https://localhost:%s/echo", platform.InvalidBackendPort),
 					PathTranslation: confpb.BackendRule_CONSTANT_ADDRESS,
 				},
 			},

--- a/tests/integration_test/access_log_test.go
+++ b/tests/integration_test/access_log_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/echo/client"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 )
 
@@ -96,7 +95,7 @@ func TestAccessLog(t *testing.T) {
 			args := []string{"--service_config_id=" + configID,
 				"--rollout_strategy=fixed", "--access_log=" + accessLogFilePath, "--access_log_format=" + accessLogFormat}
 
-			s := env.NewTestEnv(comp.TestAccessLog, platform.EchoSidecar)
+			s := env.NewTestEnv(platform.TestAccessLog, platform.EchoSidecar)
 
 			if err := s.Setup(args); err != nil {
 				t.Fatalf("fail to setup test env, %v", err)

--- a/tests/integration_test/auth_pkey_cache_test.go
+++ b/tests/integration_test/auth_pkey_cache_test.go
@@ -25,8 +25,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/testdata"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
-
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 )
 
 func TestAuthJwksCache(t *testing.T) {
@@ -71,7 +69,7 @@ func TestAuthJwksCache(t *testing.T) {
 		func() {
 			args := utils.CommonArgs()
 
-			s := env.NewTestEnv(comp.TestAuthJwksCache, platform.EchoSidecar)
+			s := env.NewTestEnv(platform.TestAuthJwksCache, platform.EchoSidecar)
 			if tc.jwksCacheDurationInS != 0 {
 				args = append(args, fmt.Sprintf("--jwks_cache_duration_in_s=%v", tc.jwksCacheDurationInS))
 			}

--- a/tests/integration_test/backend_auth_disable_auth_test.go
+++ b/tests/integration_test/backend_auth_disable_auth_test.go
@@ -23,14 +23,12 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
-
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 )
 
 func TestBackendAuthDisableAuth(t *testing.T) {
 	t.Parallel()
 
-	s := env.NewTestEnv(comp.TestBackendAuthDisableAuth, platform.EchoRemote)
+	s := env.NewTestEnv(platform.TestBackendAuthDisableAuth, platform.EchoRemote)
 	s.OverrideMockMetadata(
 		map[string]string{
 			util.IdentityTokenPath + "?format=standard&audience=https://localhost/bearertoken/constant": "ya29.JwtAudienceSet",

--- a/tests/integration_test/backend_auth_using_iam_test.go
+++ b/tests/integration_test/backend_auth_using_iam_test.go
@@ -26,14 +26,12 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
 	"github.com/golang/glog"
-
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 )
 
 func TestBackendAuthWithIamIdToken(t *testing.T) {
 	t.Parallel()
 
-	s := env.NewTestEnv(comp.TestBackendAuthWithIamIdToken, platform.EchoRemote)
+	s := env.NewTestEnv(platform.TestBackendAuthWithIamIdToken, platform.EchoRemote)
 	serviceAccount := "fakeServiceAccount@google.com"
 
 	s.SetBackendAuthIamServiceAccount(serviceAccount)
@@ -86,7 +84,7 @@ func TestBackendAuthWithIamIdToken(t *testing.T) {
 
 func TestBackendAuthWithIamIdTokenRetries(t *testing.T) {
 	t.Parallel()
-	s := env.NewTestEnv(comp.TestBackendAuthWithIamIdTokenRetries, platform.EchoRemote)
+	s := env.NewTestEnv(platform.TestBackendAuthWithIamIdTokenRetries, platform.EchoRemote)
 	serviceAccount := "fakeServiceAccount@google.com"
 	s.SetBackendAuthIamServiceAccount(serviceAccount)
 
@@ -195,7 +193,7 @@ func TestBackendAuthWithIamIdTokenTimeouts(t *testing.T) {
 
 		// Place in closure to allow deferring in loop.
 		func() {
-			s := env.NewTestEnv(comp.TestBackendAuthWithIamIdTokenTimeouts, platform.EchoRemote)
+			s := env.NewTestEnv(platform.TestBackendAuthWithIamIdTokenTimeouts, platform.EchoRemote)
 			serviceAccount := "fakeServiceAccount@google.com"
 			s.SetBackendAuthIamServiceAccount(serviceAccount)
 
@@ -246,7 +244,7 @@ func TestBackendAuthWithIamIdTokenTimeouts(t *testing.T) {
 func TestBackendAuthUsingIamIdTokenWithDelegates(t *testing.T) {
 	t.Parallel()
 
-	s := env.NewTestEnv(comp.TestBackendAuthUsingIamIdTokenWithDelegates, platform.EchoRemote)
+	s := env.NewTestEnv(platform.TestBackendAuthUsingIamIdTokenWithDelegates, platform.EchoRemote)
 	serviceAccount := "fakeServiceAccount@google.com"
 
 	s.SetBackendAuthIamServiceAccount(serviceAccount)

--- a/tests/integration_test/backend_auth_using_imds_test.go
+++ b/tests/integration_test/backend_auth_using_imds_test.go
@@ -25,14 +25,12 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
-
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 )
 
 func TestBackendAuthWithImdsIdToken(t *testing.T) {
 	t.Parallel()
 
-	s := env.NewTestEnv(comp.TestBackendAuthWithImdsIdToken, platform.EchoRemote)
+	s := env.NewTestEnv(platform.TestBackendAuthWithImdsIdToken, platform.EchoRemote)
 	s.OverrideMockMetadata(
 		map[string]string{
 			util.IdentityTokenPath + "?format=standard&audience=https://localhost/bearertoken/constant": "ya29.constant",
@@ -90,7 +88,7 @@ func TestBackendAuthWithImdsIdToken(t *testing.T) {
 func TestBackendAuthWithImdsIdTokenRetries(t *testing.T) {
 	t.Parallel()
 
-	s := env.NewTestEnv(comp.TestBackendAuthWithImdsIdTokenRetries, platform.EchoRemote)
+	s := env.NewTestEnv(platform.TestBackendAuthWithImdsIdTokenRetries, platform.EchoRemote)
 	// Health checks prevent envoy from starting up due to bad responses from IMDS for tokens.
 	s.SkipHealthChecks()
 
@@ -161,7 +159,7 @@ func TestBackendAuthWithImdsIdTokenWhileAllowCors(t *testing.T) {
 	corsRequestHeader := "X-PINGOTHER"
 	corsOrigin := "http://cloud.google.com"
 
-	s := env.NewTestEnv(comp.TestBackendAuthWithImdsIdTokenWhileAllowCors, platform.EchoRemote)
+	s := env.NewTestEnv(platform.TestBackendAuthWithImdsIdTokenWhileAllowCors, platform.EchoRemote)
 	s.OverrideMockMetadata(
 		map[string]string{
 			util.IdentityTokenPath + "?format=standard&audience=https://localhost/bearertoken/constant": "ya29.constant",

--- a/tests/integration_test/backend_protocol_test.go
+++ b/tests/integration_test/backend_protocol_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
 
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
 )
 
@@ -73,7 +72,7 @@ func TestBackendHttpProtocol(t *testing.T) {
 			}
 
 			// Setup the protocol in the backend rule for the endpoint under test.
-			s := env.NewTestEnv(comp.TestBackendHttpProtocol, platform.EchoRemote)
+			s := env.NewTestEnv(platform.TestBackendHttpProtocol, platform.EchoRemote)
 			s.RemoveAllBackendRules()
 			s.AppendBackendRules([]*confpb.BackendRule{
 				{

--- a/tests/integration_test/cors_integration_test.go
+++ b/tests/integration_test/cors_integration_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
 	apipb "google.golang.org/genproto/protobuf/api"
 
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 	annotationspb "google.golang.org/genproto/googleapis/api/annotations"
 )
 
@@ -46,7 +45,7 @@ func TestSimpleCorsWithBasicPreset(t *testing.T) {
 		"--cors_allow_origin=" + corsAllowOriginValue,
 		"--cors_expose_headers=" + corsExposeHeadersValue}
 
-	s := env.NewTestEnv(comp.TestSimpleCorsWithBasicPreset, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestSimpleCorsWithBasicPreset, platform.EchoSidecar)
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
@@ -110,7 +109,7 @@ func TestDifferentOriginSimpleCors(t *testing.T) {
 		"--cors_allow_origin=" + corsAllowOriginValue,
 		"--cors_expose_headers=" + corsExposeHeadersValue}
 
-	s := env.NewTestEnv(comp.TestDifferentOriginSimpleCors, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestDifferentOriginSimpleCors, platform.EchoSidecar)
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
@@ -152,7 +151,7 @@ func TestSimpleCorsWithRegexPreset(t *testing.T) {
 		"--cors_allow_origin_regex=" + corsAllowOriginRegex,
 		"--cors_expose_headers=" + corsExposeHeadersValue}
 
-	s := env.NewTestEnv(comp.TestSimpleCorsWithRegexPreset, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestSimpleCorsWithRegexPreset, platform.EchoSidecar)
 	// UseWrongBackendCertForDR shouldn't impact simple Cors.
 	s.UseWrongBackendCertForDR(true)
 	defer s.TearDown(t)
@@ -203,7 +202,7 @@ func TestPreflightCorsWithBasicPreset(t *testing.T) {
 		"--cors_allow_headers=" + corsAllowHeadersValue,
 		"--cors_expose_headers=" + corsExposeHeadersValue, "--cors_allow_credentials"}
 
-	s := env.NewTestEnv(comp.TestPreflightCorsWithBasicPreset, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestPreflightCorsWithBasicPreset, platform.EchoSidecar)
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
@@ -257,7 +256,7 @@ func TestDifferentOriginPreflightCors(t *testing.T) {
 		"--cors_allow_headers=" + corsAllowHeadersValue,
 		"--cors_expose_headers=" + corsExposeHeadersValue, "--cors_allow_credentials"}
 
-	s := env.NewTestEnv(comp.TestDifferentOriginPreflightCors, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestDifferentOriginPreflightCors, platform.EchoSidecar)
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
@@ -304,7 +303,7 @@ func TestGrpcBackendSimpleCors(t *testing.T) {
 		"--cors_allow_origin=" + corsAllowOriginValue,
 		"--cors_expose_headers=" + corsExposeHeadersValue}
 
-	s := env.NewTestEnv(comp.TestGrpcBackendSimpleCors, platform.GrpcBookstoreSidecar)
+	s := env.NewTestEnv(platform.TestGrpcBackendSimpleCors, platform.GrpcBookstoreSidecar)
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
@@ -352,7 +351,7 @@ func TestGrpcBackendPreflightCors(t *testing.T) {
 		"--cors_allow_headers=" + corsAllowHeadersValue,
 		"--cors_expose_headers=" + corsExposeHeadersValue, "--cors_allow_credentials"}
 
-	s := env.NewTestEnv(comp.TestGrpcBackendPreflightCors, platform.GrpcBookstoreSidecar)
+	s := env.NewTestEnv(platform.TestGrpcBackendPreflightCors, platform.GrpcBookstoreSidecar)
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
@@ -403,7 +402,7 @@ func TestPreflightRequestWithAllowCors(t *testing.T) {
 	args := []string{"--service=" + serviceName, "--service_config_id=" + configId,
 		"--rollout_strategy=fixed"}
 
-	s := env.NewTestEnv(comp.TestPreflightRequestWithAllowCors, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestPreflightRequestWithAllowCors, platform.EchoSidecar)
 	s.SetAllowCors()
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
@@ -473,7 +472,7 @@ func TestServiceControlRequestWithAllowCors(t *testing.T) {
 	args := []string{"--service=" + serviceName, "--service_config_id=" + configId,
 		"--rollout_strategy=fixed", "--suppress_envoy_headers"}
 
-	s := env.NewTestEnv(comp.TestServiceControlRequestWithAllowCors, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestServiceControlRequestWithAllowCors, platform.EchoSidecar)
 	s.SetAllowCors()
 	s.AppendApiMethods([]*apipb.Method{
 		{
@@ -658,7 +657,7 @@ func TestServiceControlRequestWithoutAllowCors(t *testing.T) {
 	args := []string{"--service=" + serviceName, "--service_config_id=" + configId,
 		"--rollout_strategy=fixed", "--suppress_envoy_headers"}
 
-	s := env.NewTestEnv(comp.TestServiceControlRequestWithoutAllowCors, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestServiceControlRequestWithoutAllowCors, platform.EchoSidecar)
 	s.AppendHttpRules([]*annotationspb.HttpRule{
 		{
 			Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.ListShelves",
@@ -792,7 +791,7 @@ func TestServiceControlRequestWithoutAllowCors(t *testing.T) {
 func TestStartupDuplicatedPathsWithAllowCors(t *testing.T) {
 	t.Parallel()
 
-	s := env.NewTestEnv(comp.TestStartupDuplicatedPathsWithAllowCors, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestStartupDuplicatedPathsWithAllowCors, platform.EchoSidecar)
 	s.SetAllowCors()
 	s.AppendHttpRules([]*annotationspb.HttpRule{
 		{

--- a/tests/integration_test/dns_resolver_test.go
+++ b/tests/integration_test/dns_resolver_test.go
@@ -69,7 +69,7 @@ func TestDnsResolver(t *testing.T) {
 
 	for _, tc := range testCase {
 		func() {
-			s := env.NewTestEnv(comp.TestDnsResolver, platform.EchoSidecar)
+			s := env.NewTestEnv(platform.TestDnsResolver, platform.EchoSidecar)
 
 			// Setup dns resolver.
 			dnsRecords := map[string]string{

--- a/tests/integration_test/dynamic_routing_integration_test.go
+++ b/tests/integration_test/dynamic_routing_integration_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
 
 	bsclient "github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/bookstore_grpc/client"
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 )
 
 func NewDynamicRoutingTestEnv(port uint16) *env.TestEnv {
@@ -37,7 +36,7 @@ func NewDynamicRoutingTestEnv(port uint16) *env.TestEnv {
 
 func TestDynamicRouting(t *testing.T) {
 	t.Parallel()
-	s := NewDynamicRoutingTestEnv(comp.TestDynamicRouting)
+	s := NewDynamicRoutingTestEnv(platform.TestDynamicRouting)
 	defer s.TearDown(t)
 
 	if err := s.Setup(utils.CommonArgs()); err != nil {
@@ -295,7 +294,7 @@ func TestDynamicRoutingWithAllowCors(t *testing.T) {
 	respHeaderMap["Access-Control-Expose-Headers"] = "Cache-Control,Content-Type,Authorization, X-PINGOTHER"
 	respHeaderMap["Access-Control-Allow-Credentials"] = "true"
 
-	s := NewDynamicRoutingTestEnv(comp.TestDynamicRoutingWithAllowCors)
+	s := NewDynamicRoutingTestEnv(platform.TestDynamicRoutingWithAllowCors)
 	s.SetAllowCors()
 
 	defer s.TearDown(t)
@@ -360,7 +359,7 @@ func TestDynamicRoutingCorsByEnvoy(t *testing.T) {
 		"--cors_expose_headers=" + corsExposeHeadersValue,
 		"--cors_allow_credentials"}...)
 
-	s := NewDynamicRoutingTestEnv(comp.TestDynamicRoutingCorsByEnvoy)
+	s := NewDynamicRoutingTestEnv(platform.TestDynamicRoutingCorsByEnvoy)
 	defer s.TearDown(t)
 
 	if err := s.Setup(dynamicRoutingArgs); err != nil {
@@ -401,7 +400,7 @@ func TestDynamicRoutingCorsByEnvoy(t *testing.T) {
 func TestServiceControlRequestForDynamicRouting(t *testing.T) {
 	t.Parallel()
 
-	s := NewDynamicRoutingTestEnv(comp.TestServiceControlRequestForDynamicRouting)
+	s := NewDynamicRoutingTestEnv(platform.TestServiceControlRequestForDynamicRouting)
 	defer s.TearDown(t)
 
 	if err := s.Setup(utils.CommonArgs()); err != nil {
@@ -639,7 +638,7 @@ func TestDynamicBackendRoutingTLS(t *testing.T) {
 
 	for _, tc := range testData {
 		func() {
-			s := env.NewTestEnv(comp.TestDynamicBackendRoutingTLS, platform.EchoRemote)
+			s := env.NewTestEnv(platform.TestDynamicBackendRoutingTLS, platform.EchoRemote)
 			s.UseWrongBackendCertForDR(tc.useWrongCert)
 			defer s.TearDown(t)
 
@@ -763,7 +762,7 @@ func TestDynamicBackendRoutingMutualTLS(t *testing.T) {
 
 	for _, tc := range testData {
 		func() {
-			s := env.NewTestEnv(comp.TestDynamicBackendRoutingMutualTLS, platform.EchoRemote)
+			s := env.NewTestEnv(platform.TestDynamicBackendRoutingMutualTLS, platform.EchoRemote)
 			s.SetBackendMTLSCert(tc.mtlsCertFile)
 			defer s.TearDown(t)
 
@@ -859,7 +858,7 @@ func TestDynamicGrpcBackendTLS(t *testing.T) {
 	for _, tc := range tests {
 		args := utils.CommonArgs()
 		func() {
-			s := env.NewTestEnv(comp.TestDynamicGrpcBackendTLS, platform.GrpcBookstoreRemote)
+			s := env.NewTestEnv(platform.TestDynamicGrpcBackendTLS, platform.GrpcBookstoreRemote)
 			defer s.TearDown(t)
 			s.UseWrongBackendCertForDR(tc.useWrongBackendCert)
 			if tc.mtlsCertFile != "" {

--- a/tests/integration_test/generated_header_prefix_test.go
+++ b/tests/integration_test/generated_header_prefix_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/testdata"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
 
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
 )
 
@@ -80,7 +79,7 @@ func TestGeneratedHeaders(t *testing.T) {
 				args = append(args, tc.generatedHeaderPrefixArg)
 			}
 
-			s := env.NewTestEnv(comp.TestGeneratedHeaders, platform.EchoSidecar)
+			s := env.NewTestEnv(platform.TestGeneratedHeaders, platform.EchoSidecar)
 			s.OverrideAuthentication(&confpb.Authentication{
 				Rules: []*confpb.AuthenticationRule{
 					{

--- a/tests/integration_test/grpc_deadline_test.go
+++ b/tests/integration_test/grpc_deadline_test.go
@@ -23,15 +23,13 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
-
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 )
 
 // Tests the deadlines configured in backend rules for a gRPC remote backends.
 func TestDeadlinesForGrpcDynamicRouting(t *testing.T) {
 	t.Parallel()
 
-	s := env.NewTestEnv(comp.TestDeadlinesForGrpcDynamicRouting, platform.GrpcEchoRemote)
+	s := env.NewTestEnv(platform.TestDeadlinesForGrpcDynamicRouting, platform.GrpcEchoRemote)
 
 	defer s.TearDown(t)
 	if err := s.Setup(utils.CommonArgs()); err != nil {
@@ -125,7 +123,7 @@ plans {
 func TestDeadlinesForGrpcCatchAllBackend(t *testing.T) {
 	t.Parallel()
 
-	s := env.NewTestEnv(comp.TestDeadlinesForGrpcCatchAllBackend, platform.GrpcEchoSidecar)
+	s := env.NewTestEnv(platform.TestDeadlinesForGrpcCatchAllBackend, platform.GrpcEchoSidecar)
 
 	defer s.TearDown(t)
 	if err := s.Setup(utils.CommonArgs()); err != nil {

--- a/tests/integration_test/grpc_errors_test.go
+++ b/tests/integration_test/grpc_errors_test.go
@@ -21,8 +21,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/grpc_echo/client"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
-
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 )
 
 func TestGRPCErrors(t *testing.T) {
@@ -33,7 +31,7 @@ func TestGRPCErrors(t *testing.T) {
 	args := []string{"--service=" + serviceName, "--service_config_id=" + configID,
 		"--rollout_strategy=fixed"}
 
-	s := env.NewTestEnv(comp.TestGRPCErrors, platform.GrpcEchoSidecar)
+	s := env.NewTestEnv(platform.TestGRPCErrors, platform.GrpcEchoSidecar)
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)

--- a/tests/integration_test/grpc_fallback_test.go
+++ b/tests/integration_test/grpc_fallback_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
 
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 	annotationspb "google.golang.org/genproto/googleapis/api/annotations"
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
 	apipb "google.golang.org/genproto/protobuf/api"
@@ -38,7 +37,7 @@ func TestGRPCFallback(t *testing.T) {
 		"--rollout_strategy=fixed"}
 
 	// Setup the service config for gRPC Bookstore.
-	s := env.NewTestEnv(comp.TestGRPCFallback, platform.GrpcBookstoreSidecar)
+	s := env.NewTestEnv(platform.TestGRPCFallback, platform.GrpcBookstoreSidecar)
 
 	// But then spin up the gRPC Echo backend.
 	s.OverrideBackendService(platform.GrpcEchoSidecar)

--- a/tests/integration_test/grpc_integration_test.go
+++ b/tests/integration_test/grpc_integration_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/testdata"
 
 	grpcEchoClient "github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/grpc_echo/client"
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 )
 
 var successTrailer, abortedTrailer, dataLossTrailer, internalTrailer client.GRPCWebTrailer
@@ -45,7 +44,7 @@ func TestGRPC(t *testing.T) {
 	configID := "test-config-id"
 	args := []string{"--service_config_id=" + configID, "--rollout_strategy=fixed", "--healthz=healthz"}
 
-	s := env.NewTestEnv(comp.TestGRPC, platform.GrpcBookstoreSidecar)
+	s := env.NewTestEnv(platform.TestGRPC, platform.GrpcBookstoreSidecar)
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
@@ -151,7 +150,7 @@ func TestGRPCWeb(t *testing.T) {
 	args := []string{"--service=" + serviceName, "--service_config_id=" + configID,
 		"--rollout_strategy=fixed"}
 
-	s := env.NewTestEnv(comp.TestGRPCWeb, platform.GrpcBookstoreSidecar)
+	s := env.NewTestEnv(platform.TestGRPCWeb, platform.GrpcBookstoreSidecar)
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
@@ -235,7 +234,7 @@ func TestGRPCJwt(t *testing.T) {
 	args := []string{"--service=" + serviceName, "--service_config_id=" + configID,
 		"--rollout_strategy=fixed"}
 
-	s := env.NewTestEnv(comp.TestGRPCJwt, platform.GrpcBookstoreSidecar)
+	s := env.NewTestEnv(platform.TestGRPCJwt, platform.GrpcBookstoreSidecar)
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
@@ -500,7 +499,7 @@ func TestGRPCMetadata(t *testing.T) {
 	args := []string{"--service_config_id=" + configID,
 		"--rollout_strategy=fixed"}
 
-	s := env.NewTestEnv(comp.TestGRPCMetadata, platform.GrpcEchoSidecar)
+	s := env.NewTestEnv(platform.TestGRPCMetadata, platform.GrpcEchoSidecar)
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)

--- a/tests/integration_test/grpc_interop_test.go
+++ b/tests/integration_test/grpc_interop_test.go
@@ -23,8 +23,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
-
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 )
 
 func runAndWait(cmd *exec.Cmd, t *testing.T) {
@@ -51,7 +49,7 @@ func TestGRPCInterops(t *testing.T) {
 	args := []string{"--service=" + serviceName, "--service_config_id=" + configID,
 		"--rollout_strategy=fixed"}
 
-	s := env.NewTestEnv(comp.TestGRPCInterops, platform.GrpcInteropSidecar)
+	s := env.NewTestEnv(platform.TestGRPCInterops, platform.GrpcInteropSidecar)
 	clientPath := platform.GetFilePath(platform.GrpcInteropClient)
 	_, err := os.Stat(clientPath)
 	if os.IsNotExist(err) {
@@ -96,7 +94,7 @@ func TestGRPCInteropMiniStress(t *testing.T) {
 	args := []string{"--service=" + serviceName, "--service_config_id=" + configID,
 		"--rollout_strategy=fixed"}
 
-	s := env.NewTestEnv(comp.TestGRPCInteropMiniStress, platform.GrpcInteropSidecar)
+	s := env.NewTestEnv(platform.TestGRPCInteropMiniStress, platform.GrpcInteropSidecar)
 	clientPath := platform.GetFilePath(platform.GrpcInteropStressClient)
 	_, err := os.Stat(clientPath)
 	if os.IsNotExist(err) {

--- a/tests/integration_test/grpc_ministress_test.go
+++ b/tests/integration_test/grpc_ministress_test.go
@@ -21,8 +21,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/grpc_echo/client"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
-
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 )
 
 func TestGRPCMinistress(t *testing.T) {
@@ -32,7 +30,7 @@ func TestGRPCMinistress(t *testing.T) {
 	args := []string{"--service_config_id=" + configID,
 		"--rollout_strategy=fixed"}
 
-	s := env.NewTestEnv(comp.TestGRPCMinistress, platform.GrpcEchoSidecar)
+	s := env.NewTestEnv(platform.TestGRPCMinistress, platform.GrpcEchoSidecar)
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)

--- a/tests/integration_test/grpc_streaming_test.go
+++ b/tests/integration_test/grpc_streaming_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
 
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 	scpb "google.golang.org/genproto/googleapis/api/servicecontrol/v1"
 )
 
@@ -35,7 +34,7 @@ func TestGRPCStreaming(t *testing.T) {
 	args := []string{"--service_config_id=" + configID,
 		"--rollout_strategy=fixed"}
 
-	s := env.NewTestEnv(comp.TestGRPCStreaming, platform.GrpcEchoSidecar)
+	s := env.NewTestEnv(platform.TestGRPCStreaming, platform.GrpcEchoSidecar)
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)

--- a/tests/integration_test/http1_deadline_test.go
+++ b/tests/integration_test/http1_deadline_test.go
@@ -24,8 +24,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
-
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 )
 
 type ConfiguredDeadline int
@@ -39,7 +37,7 @@ const (
 func TestDeadlinesForDynamicRouting(t *testing.T) {
 	t.Parallel()
 
-	s := env.NewTestEnv(comp.TestDeadlinesForDynamicRouting, platform.EchoRemote)
+	s := env.NewTestEnv(platform.TestDeadlinesForDynamicRouting, platform.EchoRemote)
 
 	defer s.TearDown(t)
 	if err := s.Setup(utils.CommonArgs()); err != nil {
@@ -119,7 +117,7 @@ func TestDeadlinesForDynamicRouting(t *testing.T) {
 func TestDeadlinesForCatchAllBackend(t *testing.T) {
 	t.Parallel()
 
-	s := env.NewTestEnv(comp.TestDeadlinesForCatchAllBackend, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestDeadlinesForCatchAllBackend, platform.EchoSidecar)
 
 	defer s.TearDown(t)
 	if err := s.Setup(utils.CommonArgs()); err != nil {

--- a/tests/integration_test/http1_integration_test.go
+++ b/tests/integration_test/http1_integration_test.go
@@ -24,8 +24,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/testdata"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
-
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 )
 
 const (
@@ -40,7 +38,7 @@ func TestHttp1Basic(t *testing.T) {
 	args := []string{"--service_config_id=" + configID,
 		"--rollout_strategy=fixed", "--healthz=/healthz"}
 
-	s := env.NewTestEnv(comp.TestHttp1Basic, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestHttp1Basic, platform.EchoSidecar)
 	defer s.TearDown(t)
 
 	if err := s.Setup(args); err != nil {
@@ -113,7 +111,7 @@ func TestHttp1JWT(t *testing.T) {
 	args := []string{"--service=" + serviceName, "--service_config_id=" + configID,
 		"--skip_service_control_filter=true", "--rollout_strategy=fixed"}
 
-	s := env.NewTestEnv(comp.TestHttp1JWT, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestHttp1JWT, platform.EchoSidecar)
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
@@ -213,7 +211,7 @@ func TestHttpHeaders(t *testing.T) {
 	}
 	for _, tc := range testData {
 		func() {
-			s := env.NewTestEnv(comp.TestHttpHeaders, platform.GrpcBookstoreSidecar)
+			s := env.NewTestEnv(platform.TestHttpHeaders, platform.GrpcBookstoreSidecar)
 			defer s.TearDown(t)
 			args := utils.CommonArgs()
 			if tc.underscoresInHeaders {

--- a/tests/integration_test/http_method_override_test.go
+++ b/tests/integration_test/http_method_override_test.go
@@ -25,14 +25,13 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
 
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 	annotationspb "google.golang.org/genproto/googleapis/api/annotations"
 )
 
 func TestMethodOverrideBackendMethod(t *testing.T) {
 	t.Parallel()
 
-	s := env.NewTestEnv(comp.TestMethodOverrideBackendMethod, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestMethodOverrideBackendMethod, platform.EchoSidecar)
 	s.AppendHttpRules([]*annotationspb.HttpRule{
 		{
 			Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.echoGET",
@@ -113,7 +112,7 @@ func TestMethodOverrideBackendMethod(t *testing.T) {
 func TestMethodOverrideBackendBody(t *testing.T) {
 	t.Parallel()
 
-	s := env.NewTestEnv(comp.TestMethodOverrideBackendBody, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestMethodOverrideBackendBody, platform.EchoSidecar)
 	defer s.TearDown(t)
 	if err := s.Setup(utils.CommonArgs()); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
@@ -183,7 +182,7 @@ func TestMethodOverrideBackendBody(t *testing.T) {
 func TestMethodOverrideScReport(t *testing.T) {
 	t.Parallel()
 
-	s := env.NewTestEnv(comp.TestMethodOverrideScReport, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestMethodOverrideScReport, platform.EchoSidecar)
 	defer s.TearDown(t)
 	if err := s.Setup(utils.CommonArgs()); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)

--- a/tests/integration_test/iam_imds_data_path_test.go
+++ b/tests/integration_test/iam_imds_data_path_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
 	"github.com/golang/glog"
-
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 )
 
 func TestIamImdsDataPath(t *testing.T) {
@@ -65,7 +63,7 @@ func TestIamImdsDataPath(t *testing.T) {
 		func() {
 
 			// By default, IMDS will be used for service control and backend auth.
-			s := env.NewTestEnv(comp.TestIamImdsDataPath, platform.EchoRemote)
+			s := env.NewTestEnv(platform.TestIamImdsDataPath, platform.EchoRemote)
 
 			if tc.useIam {
 				// Use IAM for service control and backend auth.

--- a/tests/integration_test/jwt_auth_integration_test.go
+++ b/tests/integration_test/jwt_auth_integration_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
 
 	echo_client "github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/echo/client"
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
 )
 
@@ -39,7 +38,7 @@ func TestAsymmetricKeys(t *testing.T) {
 	args := []string{"--service_config_id=" + configID,
 		"--rollout_strategy=fixed"}
 
-	s := env.NewTestEnv(comp.TestAsymmetricKeys, platform.GrpcBookstoreSidecar)
+	s := env.NewTestEnv(platform.TestAsymmetricKeys, platform.GrpcBookstoreSidecar)
 	if err := s.FakeJwtService.SetupValidOpenId(); err != nil {
 		t.Fatalf("fail to setup open id servers: %v", err)
 	}
@@ -214,7 +213,7 @@ func TestInvalidOpenIDConnectDiscovery(t *testing.T) {
 
 	for _, tc := range tests {
 		func() {
-			s := env.NewTestEnv(comp.TestInvalidOpenIDConnectDiscovery, platform.GrpcBookstoreSidecar)
+			s := env.NewTestEnv(platform.TestInvalidOpenIDConnectDiscovery, platform.GrpcBookstoreSidecar)
 			if err := s.FakeJwtService.SetupInvalidOpenId(); err != nil {
 				t.Fatalf("fail to setup open id servers: %v", err)
 			}
@@ -251,7 +250,7 @@ func TestInvalidOpenIDConnectDiscovery(t *testing.T) {
 func TestFrontendAndBackendAuthHeaders(t *testing.T) {
 	t.Parallel()
 
-	s := env.NewTestEnv(comp.TestFrontendAndBackendAuthHeaders, platform.EchoRemote)
+	s := env.NewTestEnv(platform.TestFrontendAndBackendAuthHeaders, platform.EchoRemote)
 	s.OverrideAuthentication(&confpb.Authentication{
 		Rules: []*confpb.AuthenticationRule{
 			{

--- a/tests/integration_test/jwt_locations_test.go
+++ b/tests/integration_test/jwt_locations_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/testdata"
 
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
 )
 
@@ -34,7 +33,7 @@ func TestJwtLocations(t *testing.T) {
 	args := []string{"--service_config_id=" + configID,
 		"--rollout_strategy=fixed"}
 
-	s := env.NewTestEnv(comp.TestJwtLocations, platform.GrpcBookstoreSidecar)
+	s := env.NewTestEnv(platform.TestJwtLocations, platform.GrpcBookstoreSidecar)
 	s.OverrideAuthentication(&confpb.Authentication{
 		Rules: []*confpb.AuthenticationRule{
 			{

--- a/tests/integration_test/managed_service_config_test.go
+++ b/tests/integration_test/managed_service_config_test.go
@@ -36,7 +36,7 @@ func TestManagedServiceConfig(t *testing.T) {
 	t.Parallel()
 
 	args := []string{"--rollout_strategy=managed", "--check_rollout_interval=500ms"}
-	s := env.NewTestEnv(comp.TestManagedServiceConfig, platform.GrpcBookstoreSidecar)
+	s := env.NewTestEnv(platform.TestManagedServiceConfig, platform.GrpcBookstoreSidecar)
 	s.SetEnvoyDrainTimeInSec(1)
 
 	s.OverrideAuthentication(&confpb.Authentication{
@@ -132,7 +132,7 @@ func TestRetryCallServiceManagement(t *testing.T) {
 	args := []string{"--service_config_id=" + configID,
 		"--rollout_strategy=fixed", "--healthz=/healthz"}
 
-	s := env.NewTestEnv(comp.TestRetryCallServiceManagement, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestRetryCallServiceManagement, platform.EchoSidecar)
 	defer s.TearDown(t)
 
 	s.MockServiceManagementServer.ConfigsHandler = &configsHandler{

--- a/tests/integration_test/multi_grpc_services_test.go
+++ b/tests/integration_test/multi_grpc_services_test.go
@@ -25,8 +25,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
-
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 )
 
 func TestMultiGrpcServices(t *testing.T) {
@@ -34,7 +32,7 @@ func TestMultiGrpcServices(t *testing.T) {
 	configID := "test-config-id"
 	args := []string{"--service_config_id=" + configID, "--rollout_strategy=fixed"}
 
-	s := env.NewTestEnv(comp.TestMultiGrpcServices, platform.GrpcBookstoreSidecar)
+	s := env.NewTestEnv(platform.TestMultiGrpcServices, platform.GrpcBookstoreSidecar)
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)

--- a/tests/integration_test/non_gcp_test.go
+++ b/tests/integration_test/non_gcp_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/echo/client"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
 )
@@ -89,7 +88,7 @@ func TestMetadataRequestsPerPlatform(t *testing.T) {
 
 		// Place in closure to allow deferring in loop.
 		func() {
-			s := env.NewTestEnv(comp.TestMetadataRequestsPerPlatform, platform.EchoSidecar)
+			s := env.NewTestEnv(platform.TestMetadataRequestsPerPlatform, platform.EchoSidecar)
 			defer s.TearDown(t)
 			if err := s.Setup(tc.confArgs); err != nil {
 				t.Fatalf("fail to setup test env, %v", err)

--- a/tests/integration_test/report_gcp_attributes_test.go
+++ b/tests/integration_test/report_gcp_attributes_test.go
@@ -23,8 +23,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
-
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 )
 
 const (
@@ -157,7 +155,7 @@ func TestReportGCPAttributes(t *testing.T) {
 			args = append(args, fmt.Sprintf("--compute_platform_override=%v", tc.platformOverride))
 		}
 		func() {
-			s := env.NewTestEnv(comp.TestReportGCPAttributes, platform.EchoSidecar)
+			s := env.NewTestEnv(platform.TestReportGCPAttributes, platform.EchoSidecar)
 			s.OverrideMockMetadata(tc.mockMetadataOverride, 0)
 
 			defer s.TearDown(t)
@@ -222,7 +220,7 @@ func TestReportGCPAttributesPerPlatform(t *testing.T) {
 
 	for _, tc := range testdata {
 		func() {
-			s := env.NewTestEnv(comp.TestReportGCPAttributesPerPlatform, platform.EchoSidecar)
+			s := env.NewTestEnv(platform.TestReportGCPAttributesPerPlatform, platform.EchoSidecar)
 
 			defer s.TearDown(t)
 			if err := s.Setup(tc.confArgs); err != nil {

--- a/tests/integration_test/service_control_access_token_test.go
+++ b/tests/integration_test/service_control_access_token_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/echo/client"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
 )
@@ -33,7 +32,7 @@ func TestServiceControlAccessTokenFromIam(t *testing.T) {
 	args := []string{"--service_config_id=" + configId,
 		"--rollout_strategy=fixed", "--suppress_envoy_headers"}
 
-	s := env.NewTestEnv(comp.TestServiceControlAccessTokenFromIam, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestServiceControlAccessTokenFromIam, platform.EchoSidecar)
 	serviceAccount := "ServiceAccount@google.com"
 	s.SetServiceControlIamServiceAccount(serviceAccount)
 	s.SetServiceControlIamDelegates("delegate_foo,delegate_bar,delegate_baz")
@@ -111,7 +110,7 @@ func TestServiceControlAccessTokenFromTokenAgent(t *testing.T) {
 	args := []string{"--service_config_id=test-config-id",
 		"--rollout_strategy=fixed", "--suppress_envoy_headers", "--service_account_key=" + customSa.FileName}
 
-	s := env.NewTestEnv(comp.TestServiceControlAccessTokenFromTokenAgent, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestServiceControlAccessTokenFromTokenAgent, platform.EchoSidecar)
 
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {

--- a/tests/integration_test/service_control_apikey_location_test.go
+++ b/tests/integration_test/service_control_apikey_location_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
 
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
 )
 
@@ -35,7 +34,7 @@ func TestServiceControlAPIKeyDefaultLocation(t *testing.T) {
 	args := []string{"--service_config_id=" + configId,
 		"--rollout_strategy=fixed", "--suppress_envoy_headers"}
 
-	s := env.NewTestEnv(comp.TestServiceControlAPIKeyDefaultLocation, platform.GrpcBookstoreSidecar)
+	s := env.NewTestEnv(platform.TestServiceControlAPIKeyDefaultLocation, platform.GrpcBookstoreSidecar)
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
@@ -109,7 +108,7 @@ func TestServiceControlAPIKeyCustomLocation(t *testing.T) {
 	args := []string{"--service=" + serviceName, "--service_config_id=" + configId,
 		"--rollout_strategy=fixed", "--suppress_envoy_headers"}
 
-	s := env.NewTestEnv(comp.TestServiceControlAPIKeyCustomLocation, platform.GrpcBookstoreSidecar)
+	s := env.NewTestEnv(platform.TestServiceControlAPIKeyCustomLocation, platform.GrpcBookstoreSidecar)
 	s.OverrideSystemParameters(&confpb.SystemParameters{
 		Rules: []*confpb.SystemParameterRule{
 			{

--- a/tests/integration_test/service_control_apikey_restriction_test.go
+++ b/tests/integration_test/service_control_apikey_restriction_test.go
@@ -23,8 +23,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
-
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 )
 
 type testDataStruct struct {
@@ -47,7 +45,7 @@ func TestServiceControlAPIKeyRestriction(t *testing.T) {
 		"--rollout_strategy=fixed",
 	}
 
-	s := env.NewTestEnv(comp.TestServiceControlAPIKeyRestriction, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestServiceControlAPIKeyRestriction, platform.EchoSidecar)
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("failed to setup test env, %v", err)
@@ -142,7 +140,7 @@ func TestServiceControlAPIKeyIpRestriction(t *testing.T) {
 		"--envoy_xff_num_trusted_hops=1",
 	}
 
-	s := env.NewTestEnv(comp.TestServiceControlAPIKeyIpRestriction, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestServiceControlAPIKeyIpRestriction, platform.EchoSidecar)
 
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {

--- a/tests/integration_test/service_control_auth_fail_test.go
+++ b/tests/integration_test/service_control_auth_fail_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/testdata"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
 
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
 )
 
@@ -39,7 +38,7 @@ func TestServiceControlJwtAuthFail(t *testing.T) {
 	args := []string{"--service_config_id=" + configID,
 		"--rollout_strategy=fixed"}
 
-	s := env.NewTestEnv(comp.TestServiceControlJwtAuthFail, platform.GrpcBookstoreSidecar)
+	s := env.NewTestEnv(platform.TestServiceControlJwtAuthFail, platform.GrpcBookstoreSidecar)
 	s.OverrideAuthentication(&confpb.Authentication{
 		Rules: []*confpb.AuthenticationRule{
 			{

--- a/tests/integration_test/service_control_basic_test.go
+++ b/tests/integration_test/service_control_basic_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
 
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 	annotationspb "google.golang.org/genproto/googleapis/api/annotations"
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
 )
@@ -38,7 +37,7 @@ func TestServiceControlBasic(t *testing.T) {
 	args := []string{"--service_config_id=" + configId,
 		"--rollout_strategy=fixed", "--suppress_envoy_headers"}
 
-	s := env.NewTestEnv(comp.TestServiceControlBasic, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestServiceControlBasic, platform.EchoSidecar)
 	s.AppendHttpRules([]*annotationspb.HttpRule{
 		{
 			Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Simpleget",

--- a/tests/integration_test/service_control_cache_test.go
+++ b/tests/integration_test/service_control_cache_test.go
@@ -24,8 +24,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
-
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 )
 
 func TestServiceControlCache(t *testing.T) {
@@ -36,7 +34,7 @@ func TestServiceControlCache(t *testing.T) {
 	args := []string{"--service_config_id=" + configId,
 		"--rollout_strategy=fixed", "--suppress_envoy_headers"}
 
-	s := env.NewTestEnv(comp.TestServiceControlCache, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestServiceControlCache, platform.EchoSidecar)
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)

--- a/tests/integration_test/service_control_check_fail_test.go
+++ b/tests/integration_test/service_control_check_fail_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/testdata"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
 
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 	scpb "google.golang.org/genproto/googleapis/api/servicecontrol/v1"
 )
 
@@ -39,7 +38,7 @@ func TestServiceControlCheckError(t *testing.T) {
 	args := []string{"--service_config_id=" + configId,
 		"--rollout_strategy=fixed", "--suppress_envoy_headers"}
 
-	s := env.NewTestEnv(comp.TestServiceControlCheckError, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestServiceControlCheckError, platform.EchoSidecar)
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)

--- a/tests/integration_test/service_control_check_network_fail_test.go
+++ b/tests/integration_test/service_control_check_network_fail_test.go
@@ -54,7 +54,7 @@ func TestServiceControlCheckNetworkFail(t *testing.T) {
 			httpMethod:        "GET",
 			method:            "/v1/shelves/100?key=api-key-1",
 			serviceControlURL: "http://unavaliable_service_control_server_name",
-			allocatedPort:     comp.TestServiceControlCheckWrongServerName,
+			allocatedPort:     platform.TestServiceControlCheckWrongServerName,
 			wantError:         `503 Service Unavailable, {"code":503,"message":"UNAVAILABLE:Calling Google Service Control API failed with: 503 and body: no healthy upstream"}`,
 		},
 		{
@@ -63,7 +63,7 @@ func TestServiceControlCheckNetworkFail(t *testing.T) {
 			httpMethod:        "GET",
 			method:            "/v1/shelves/100?key=api-key-2",
 			serviceControlURL: "http://localhost:28753",
-			allocatedPort:     comp.TestServiceControlCheckWrongServerName,
+			allocatedPort:     platform.TestServiceControlCheckWrongServerName,
 			wantError:         `503 Service Unavailable, {"code":503,"message":"UNAVAILABLE:Calling Google Service Control API failed with: 503 and body: upstream connect error or disconnect/reset before headers. reset reason: connection failure"}`,
 		},
 	}
@@ -101,7 +101,7 @@ func TestServiceControlCheckTimeout(t *testing.T) {
 	args := []string{"--service=" + serviceName, "--service_config_id=" + configID,
 		"--rollout_strategy=fixed"}
 
-	s := env.NewTestEnv(comp.TestServiceControlCheckTimeout, platform.GrpcBookstoreSidecar)
+	s := env.NewTestEnv(platform.TestServiceControlCheckTimeout, platform.GrpcBookstoreSidecar)
 	s.ServiceControlServer.SetURL("http://wrong_service_control_server_name")
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
@@ -237,7 +237,7 @@ func TestServiceControlNetworkFailFlagForTimeout(t *testing.T) {
 
 	for _, tc := range tests {
 		func() {
-			s := env.NewTestEnv(comp.TestServiceControlNetworkFailFlagForTimeout, platform.GrpcBookstoreSidecar)
+			s := env.NewTestEnv(platform.TestServiceControlNetworkFailFlagForTimeout, platform.GrpcBookstoreSidecar)
 			s.ServiceControlServer.OverrideCheckHandler(&localServiceHandler{
 				m: s.ServiceControlServer,
 			})
@@ -341,7 +341,7 @@ func TestServiceControlNetworkFailFlagForUnavailableCheckResponse(t *testing.T) 
 
 	for _, tc := range tests {
 		func() {
-			s := env.NewTestEnv(comp.TestServiceControlNetworkFailFlagForUnavailableCheckResponse, platform.GrpcBookstoreSidecar)
+			s := env.NewTestEnv(platform.TestServiceControlNetworkFailFlagForUnavailableCheckResponse, platform.GrpcBookstoreSidecar)
 			s.ServiceControlServer.SetCheckResponse(&tc.checkResponse)
 			if tc.networkFailOpen {
 				s.EnableScNetworkFailOpen()

--- a/tests/integration_test/service_control_check_server_fail_test.go
+++ b/tests/integration_test/service_control_check_server_fail_test.go
@@ -100,7 +100,7 @@ func TestServiceControlCheckServerFailFlag(t *testing.T) {
 
 	for _, tc := range tests {
 		func() {
-			s := env.NewTestEnv(comp.TestServiceControlCheckServerFail, platform.GrpcBookstoreSidecar)
+			s := env.NewTestEnv(platform.TestServiceControlCheckServerFail, platform.GrpcBookstoreSidecar)
 			handler := &serverFailCheckHandler{
 				m:        s.ServiceControlServer,
 				respCode: tc.respCode,

--- a/tests/integration_test/service_control_credential_id_test.go
+++ b/tests/integration_test/service_control_credential_id_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
 
 	bsClient "github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/bookstore_grpc/client"
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
 )
 
@@ -38,7 +37,7 @@ func TestServiceControlCredentialId(t *testing.T) {
 	args := []string{"--service_config_id=" + configId,
 		"--rollout_strategy=fixed", "--suppress_envoy_headers",
 	}
-	s := env.NewTestEnv(comp.TestServiceControlCredentialId, platform.GrpcBookstoreSidecar)
+	s := env.NewTestEnv(platform.TestServiceControlCredentialId, platform.GrpcBookstoreSidecar)
 
 	s.OverrideAuthentication(&confpb.Authentication{Rules: []*confpb.AuthenticationRule{
 		{

--- a/tests/integration_test/service_control_failed_request_report_test.go
+++ b/tests/integration_test/service_control_failed_request_report_test.go
@@ -25,8 +25,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/testdata"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
-
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 )
 
 func TestServiceControlFailedRequestReport(t *testing.T) {
@@ -35,7 +33,7 @@ func TestServiceControlFailedRequestReport(t *testing.T) {
 	configId := "test-config-id"
 	args := []string{"--service_config_id=" + configId,
 		"--rollout_strategy=fixed", "--suppress_envoy_headers"}
-	s := env.NewTestEnv(comp.TestServiceControlFailedRequestReport, platform.GrpcBookstoreSidecar)
+	s := env.NewTestEnv(platform.TestServiceControlFailedRequestReport, platform.GrpcBookstoreSidecar)
 	defer s.TearDown(t)
 
 	if err := s.Setup(args); err != nil {

--- a/tests/integration_test/service_control_http_method_test.go
+++ b/tests/integration_test/service_control_http_method_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
 
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 	annotationspb "google.golang.org/genproto/googleapis/api/annotations"
 )
 
@@ -37,7 +36,7 @@ func TestServiceControlAllHTTPMethods(t *testing.T) {
 	args := []string{"--service_config_id=" + configId,
 		"--rollout_strategy=fixed", "--suppress_envoy_headers"}
 
-	s := env.NewTestEnv(comp.TestServiceControlAllHTTPMethod, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestServiceControlAllHTTPMethod, platform.EchoSidecar)
 	s.AppendHttpRules([]*annotationspb.HttpRule{
 		{
 			Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.echoGET",

--- a/tests/integration_test/service_control_http_path_test.go
+++ b/tests/integration_test/service_control_http_path_test.go
@@ -24,8 +24,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
-
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 )
 
 func TestServiceControlAllHTTPPath(t *testing.T) {
@@ -36,7 +34,7 @@ func TestServiceControlAllHTTPPath(t *testing.T) {
 	args := []string{"--service_config_id=" + configId,
 		"--rollout_strategy=fixed", "--suppress_envoy_headers"}
 
-	s := env.NewTestEnv(comp.TestServiceControlAllHTTPPath, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestServiceControlAllHTTPPath, platform.EchoSidecar)
 	s.EnableEchoServerRootPathHandler()
 
 	defer s.TearDown(t)

--- a/tests/integration_test/service_control_log_test.go
+++ b/tests/integration_test/service_control_log_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
 
 	bsClient "github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/bookstore_grpc/client"
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 	annotationspb "google.golang.org/genproto/googleapis/api/annotations"
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
 )
@@ -41,7 +40,7 @@ func TestServiceControlLogHeaders(t *testing.T) {
 	args := []string{"--service_config_id=" + configId,
 		"--rollout_strategy=fixed", "--suppress_envoy_headers", "--log_request_headers=Fake-Header-Key0,Fake-Header-Key1,Fake-Header-Key2,Non-Existing-Header-Key", "--log_response_headers=Echo-Fake-Header-Key0,Echo-Fake-Header-Key1,Echo-Fake-Header-Key2,Non-Existing-Header-Key"}
 
-	s := env.NewTestEnv(comp.TestServiceControlLogHeaders, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestServiceControlLogHeaders, platform.EchoSidecar)
 	s.AppendHttpRules([]*annotationspb.HttpRule{
 		{
 			Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Simpleget",
@@ -157,7 +156,7 @@ func TestServiceControlLogJwtPayloads(t *testing.T) {
 		"--rollout_strategy=fixed", "--suppress_envoy_headers", `--log_jwt_payloads=exp,foo.foo_list,google,google.compute_engine.project_id,google.project_number,google.google_bool,foo.foo_bool,google.compute_engine.not_existed,aud,not_existed`,
 	}
 
-	s := env.NewTestEnv(comp.TestServiceControlLogJwtPayloads, platform.GrpcBookstoreSidecar)
+	s := env.NewTestEnv(platform.TestServiceControlLogJwtPayloads, platform.GrpcBookstoreSidecar)
 	s.OverrideAuthentication(&confpb.Authentication{
 		Rules: []*confpb.AuthenticationRule{
 			{

--- a/tests/integration_test/service_control_protocol_test.go
+++ b/tests/integration_test/service_control_protocol_test.go
@@ -27,7 +27,6 @@ import (
 
 	bookstore "github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/bookstore_grpc/client"
 	echoclient "github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/echo/client"
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 )
 
 func TestServiceControlProtocolWithGRPCBackend(t *testing.T) {
@@ -43,7 +42,7 @@ func TestServiceControlProtocolWithGRPCBackend(t *testing.T) {
 
 	headerWithAPIKey := http.Header{bookstore.APIKeyHeaderKey: []string{"foobar"}}
 
-	s := env.NewTestEnv(comp.TestServiceControlProtocolWithGRPCBackend, platform.GrpcBookstoreSidecar)
+	s := env.NewTestEnv(platform.TestServiceControlProtocolWithGRPCBackend, platform.GrpcBookstoreSidecar)
 
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
@@ -155,7 +154,7 @@ func TestServiceControlProtocolWithHTTPBackend(t *testing.T) {
 		"--rollout_strategy=fixed",
 	}
 
-	s := env.NewTestEnv(comp.TestServiceControlProtocolWithHTTPBackend, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestServiceControlProtocolWithHTTPBackend, platform.EchoSidecar)
 
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {

--- a/tests/integration_test/service_control_quota_test.go
+++ b/tests/integration_test/service_control_quota_test.go
@@ -41,7 +41,7 @@ func TestServiceControlQuota(t *testing.T) {
 	args := []string{"--service_config_id=" + configId,
 		"--rollout_strategy=fixed", "--suppress_envoy_headers"}
 
-	s := env.NewTestEnv(comp.TestServiceControlQuota, platform.GrpcBookstoreSidecar)
+	s := env.NewTestEnv(platform.TestServiceControlQuota, platform.GrpcBookstoreSidecar)
 	s.OverrideQuota(&confpb.Quota{
 		MetricRules: []*confpb.MetricRule{
 			{
@@ -218,7 +218,7 @@ func TestServiceControlQuotaUnavailable(t *testing.T) {
 	args := []string{"--service=" + serviceName, "--service_config_id=" + configId,
 		"--rollout_strategy=fixed", "--suppress_envoy_headers"}
 
-	s := env.NewTestEnv(comp.TestServiceControlQuotaUnavailable, platform.GrpcBookstoreSidecar)
+	s := env.NewTestEnv(platform.TestServiceControlQuotaUnavailable, platform.GrpcBookstoreSidecar)
 	s.OverrideQuota(&confpb.Quota{
 		MetricRules: []*confpb.MetricRule{
 			{
@@ -287,7 +287,7 @@ func TestServiceControlQuotaExhausted(t *testing.T) {
 	args := []string{"--service=" + serviceName, "--service_config_id=" + configId,
 		"--rollout_strategy=fixed", "--suppress_envoy_headers"}
 
-	s := env.NewTestEnv(comp.TestServiceControlQuotaExhausted, platform.GrpcBookstoreSidecar)
+	s := env.NewTestEnv(platform.TestServiceControlQuotaExhausted, platform.GrpcBookstoreSidecar)
 	s.OverrideQuota(&confpb.Quota{
 		MetricRules: []*confpb.MetricRule{
 			{

--- a/tests/integration_test/service_control_report_network_fail_test.go
+++ b/tests/integration_test/service_control_report_network_fail_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 
 	bsclient "github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/bookstore_grpc/client"
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 )
 
 func TestServiceControlReportNetworkFail(t *testing.T) {
@@ -35,7 +34,7 @@ func TestServiceControlReportNetworkFail(t *testing.T) {
 	args := []string{"--service_config_id=" + configID,
 		"--rollout_strategy=fixed", "--service_control_report_retries=0"}
 
-	s := env.NewTestEnv(comp.TestServiceControlReportNetworkFail, platform.GrpcBookstoreSidecar)
+	s := env.NewTestEnv(platform.TestServiceControlReportNetworkFail, platform.GrpcBookstoreSidecar)
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)

--- a/tests/integration_test/service_control_response_code_test.go
+++ b/tests/integration_test/service_control_response_code_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
 
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 	annotationspb "google.golang.org/genproto/googleapis/api/annotations"
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
 )
@@ -38,7 +37,7 @@ func TestServiceControlReportResponseCode(t *testing.T) {
 	args := []string{"--service_config_id=" + configId,
 		"--rollout_strategy=fixed"}
 
-	s := env.NewTestEnv(comp.TestServiceControlReportResponseCode, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestServiceControlReportResponseCode, platform.EchoSidecar)
 	s.AppendHttpRules([]*annotationspb.HttpRule{
 		{
 			Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.SimplegetNotModified",

--- a/tests/integration_test/service_control_retry_timeout_test.go
+++ b/tests/integration_test/service_control_retry_timeout_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
 
 	bsclient "github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/bookstore_grpc/client"
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
 )
 
@@ -36,7 +35,7 @@ func TestServiceControlCheckRetry(t *testing.T) {
 	configID := "test-config-id"
 	args := []string{"--service_config_id=" + configID,
 		"--rollout_strategy=fixed", "--service_control_check_retries=2", "--service_control_check_timeout_ms=100"}
-	s := env.NewTestEnv(comp.TestServiceControlCheckRetry, platform.GrpcBookstoreSidecar)
+	s := env.NewTestEnv(platform.TestServiceControlCheckRetry, platform.GrpcBookstoreSidecar)
 	handler := utils.RetryServiceHandler{}
 	s.ServiceControlServer.OverrideCheckHandler(&handler)
 	defer s.TearDown(t)
@@ -117,7 +116,7 @@ func TestServiceControlQuotaRetry(t *testing.T) {
 	configID := "test-config-id"
 	args := []string{"--service=" + serviceName, "--service_config_id=" + configID,
 		"--rollout_strategy=fixed", "--service_control_quota_retries=2", "--service_control_quota_timeout_ms=100"}
-	s := env.NewTestEnv(comp.TestServiceControlQuotaRetry, platform.GrpcBookstoreSidecar)
+	s := env.NewTestEnv(platform.TestServiceControlQuotaRetry, platform.GrpcBookstoreSidecar)
 	s.OverrideQuota(&confpb.Quota{
 		MetricRules: []*confpb.MetricRule{
 			{
@@ -206,7 +205,7 @@ func TestServiceControlReportRetry(t *testing.T) {
 		// How long each report request waits before timing out (and possibly being retried)
 		"--service_control_report_timeout_ms=500",
 	}
-	s := env.NewTestEnv(comp.TestServiceControlReportRetry, platform.GrpcBookstoreSidecar)
+	s := env.NewTestEnv(platform.TestServiceControlReportRetry, platform.GrpcBookstoreSidecar)
 
 	handler := utils.RetryServiceHandler{}
 	s.ServiceControlServer.OverrideReportHandler(&handler)

--- a/tests/integration_test/service_control_skip_test.go
+++ b/tests/integration_test/service_control_skip_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
 )
 
@@ -35,7 +34,7 @@ func TestServiceControlSkipUsage(t *testing.T) {
 	args := []string{"--service_config_id=" + configId,
 		"--rollout_strategy=fixed", "--suppress_envoy_headers"}
 
-	s := env.NewTestEnv(comp.TestServiceControlSkipUsage, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestServiceControlSkipUsage, platform.EchoSidecar)
 	s.AppendUsageRules(
 		[]*confpb.UsageRule{
 			{

--- a/tests/integration_test/statistics_test.go
+++ b/tests/integration_test/statistics_test.go
@@ -25,14 +25,13 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
 
 	bsclient "github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/bookstore_grpc/client"
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
 )
 
 func TestStatistics(t *testing.T) {
 	t.Parallel()
 
-	s := env.NewTestEnv(comp.TestStatistics, platform.EchoRemote)
+	s := env.NewTestEnv(platform.TestStatistics, platform.EchoRemote)
 
 	defer s.TearDown(t)
 	if err := s.Setup(utils.CommonArgs()); err != nil {
@@ -147,7 +146,7 @@ func TestStatisticsServiceControlCallStatus(t *testing.T) {
 
 	for _, tc := range tests {
 		func() {
-			s := env.NewTestEnv(comp.TestStatisticsServiceControlCallStatus, platform.GrpcBookstoreSidecar)
+			s := env.NewTestEnv(platform.TestStatisticsServiceControlCallStatus, platform.GrpcBookstoreSidecar)
 
 			if tc.checkRespCode != 0 {
 				s.ServiceControlServer.SetCheckResponseStatus(tc.checkRespCode)

--- a/tests/integration_test/transcoding_bindings_test.go
+++ b/tests/integration_test/transcoding_bindings_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
 )
 
@@ -49,7 +48,7 @@ func TestTranscodingBindings(t *testing.T) {
 		wantGRPCWebTrailer client.GRPCWebTrailer
 	}
 
-	s := env.NewTestEnv(comp.TestTranscodingBindings, platform.GrpcBookstoreSidecar)
+	s := env.NewTestEnv(platform.TestTranscodingBindings, platform.GrpcBookstoreSidecar)
 	s.OverrideAuthentication(&confpb.Authentication{
 		Rules: []*confpb.AuthenticationRule{},
 	})

--- a/tests/integration_test/transcoding_errors_test.go
+++ b/tests/integration_test/transcoding_errors_test.go
@@ -23,8 +23,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/testdata"
-
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 )
 
 type TranscodingTestType struct {
@@ -48,7 +46,7 @@ func TestTranscodingServiceUnavailableError(t *testing.T) {
 	args := []string{"--service_config_id=" + configID,
 		"--rollout_strategy=fixed"}
 
-	s := env.NewTestEnv(comp.TestTranscodingServiceUnavailableError, platform.GrpcBookstoreSidecar)
+	s := env.NewTestEnv(platform.TestTranscodingServiceUnavailableError, platform.GrpcBookstoreSidecar)
 
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
@@ -86,7 +84,7 @@ func TestTranscodingErrors(t *testing.T) {
 	args := []string{"--service=" + serviceName, "--service_config_id=" + configID,
 		"--rollout_strategy=fixed"}
 
-	s := env.NewTestEnv(comp.TestTranscodingErrors, platform.GrpcBookstoreSidecar)
+	s := env.NewTestEnv(platform.TestTranscodingErrors, platform.GrpcBookstoreSidecar)
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)

--- a/tests/integration_test/transcoding_options_test.go
+++ b/tests/integration_test/transcoding_options_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
 )
 
@@ -96,7 +95,7 @@ func TestTranscodingPrintOptions(t *testing.T) {
 				args = append(args, "--transcoding_preserve_proto_field_names=true")
 			}
 
-			s := env.NewTestEnv(comp.TestTranscodingPrintOptions, platform.GrpcBookstoreSidecar)
+			s := env.NewTestEnv(platform.TestTranscodingPrintOptions, platform.GrpcBookstoreSidecar)
 			s.OverrideAuthentication(&confpb.Authentication{
 				Rules: []*confpb.AuthenticationRule{},
 			})
@@ -183,7 +182,7 @@ func TestTranscodingIgnoreParameters(t *testing.T) {
 				args = append(args, "--transcoding_ignore_query_parameters="+tc.transcodingIgnoreQueryParameters)
 			}
 
-			s := env.NewTestEnv(comp.TestTranscodingIgnoreQueryParameters, platform.GrpcBookstoreSidecar)
+			s := env.NewTestEnv(platform.TestTranscodingIgnoreQueryParameters, platform.GrpcBookstoreSidecar)
 			s.OverrideAuthentication(&confpb.Authentication{
 				Rules: []*confpb.AuthenticationRule{},
 			})

--- a/tests/integration_test/transport_security_test.go
+++ b/tests/integration_test/transport_security_test.go
@@ -49,7 +49,7 @@ func TestServiceManagementWithTLS(t *testing.T) {
 			confArgs: append([]string{
 				"--ssl_sidestream_client_root_certs_path", platform.GetFilePath(platform.ProxyCert),
 			}, utils.CommonArgs()...),
-			port:     comp.TestServiceManagementWithValidCert,
+			port:     platform.TestServiceManagementWithValidCert,
 			wantResp: `{"message":"hello"}`,
 		},
 		{
@@ -59,7 +59,7 @@ func TestServiceManagementWithTLS(t *testing.T) {
 			confArgs: append([]string{
 				"--ssl_sidestream_client_root_certs_path", platform.GetFilePath(platform.ProxyCert),
 			}, utils.CommonArgs()...),
-			port:         comp.TestServiceManagementWithInvalidCert,
+			port:         platform.TestServiceManagementWithInvalidCert,
 			wantSetupErr: "health check response was not healthy",
 		},
 		{
@@ -70,7 +70,7 @@ func TestServiceManagementWithTLS(t *testing.T) {
 			certPath:     platform.GetFilePath(platform.ProxyCert),
 			keyPath:      platform.GetFilePath(platform.ProxyKey),
 			confArgs:     utils.CommonArgs(),
-			port:         comp.TestServiceManagementWithInvalidCert,
+			port:         platform.TestServiceManagementWithInvalidCert,
 			wantSetupErr: "health check response was not healthy",
 		},
 	}
@@ -134,7 +134,7 @@ func TestServiceControlWithTLS(t *testing.T) {
 		{
 			desc:      "Failed to call ServiceControl HTTPS server, with different Cert as proxy",
 			token:     testdata.FakeCloudTokenMultiAudiences,
-			port:      comp.TestServiceControlTLSWithValidCert,
+			port:      platform.TestServiceControlTLSWithValidCert,
 			certPath:  platform.GetFilePath(platform.ServerCert),
 			keyPath:   platform.GetFilePath(platform.ServerKey),
 			wantError: "UNAVAILABLE:Calling Google Service Control API failed with: 503 and body: upstream connect error or disconnect/reset before headers. reset reason: connection failure",
@@ -172,7 +172,7 @@ func TestHttpsClients(t *testing.T) {
 	args := utils.CommonArgs()
 	args = append(args, "--ssl_server_cert_path=../env/testdata/")
 
-	s := env.NewTestEnv(comp.TestHttpsClients, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestHttpsClients, platform.EchoSidecar)
 	defer s.TearDown(t)
 	s.AppendHttpRules([]*annotationspb.HttpRule{
 		{
@@ -246,7 +246,7 @@ func TestHSTS(t *testing.T) {
 	args = append(args, "--ssl_server_cert_path=../env/testdata/")
 	args = append(args, "--enable_strict_transport_security")
 
-	s := env.NewTestEnv(comp.TestHttpsClients, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestHttpsClients, platform.EchoSidecar)
 	defer s.TearDown(t)
 	s.AppendHttpRules([]*annotationspb.HttpRule{
 		{

--- a/tests/integration_test/websocket_test.go
+++ b/tests/integration_test/websocket_test.go
@@ -25,13 +25,11 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/testdata"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
-
-	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
 )
 
 func TestWebsocket(t *testing.T) {
 	t.Parallel()
-	s := env.NewTestEnv(comp.TestWebsocket, platform.EchoSidecar)
+	s := env.NewTestEnv(platform.TestWebsocket, platform.EchoSidecar)
 	defer s.TearDown(t)
 	if err := s.Setup(utils.CommonArgs()); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)


### PR DESCRIPTION
Small cleanup to our integration test framework:
- Move `ports.go` from components to platform package. It is not a component, not sure why it's located there.
- For dynamic routing service configs, make it clear which port should be used with constants `platform.WorkingBackendPort` and `platform.InvalidBackendPort`.

Diff is large due to package name change. Main diff is in the `tests/env/...` folder.

Signed-off-by: Teju Nareddy <nareddyt@google.com>