### PR TITLE
Fix quota test

### DIFF
--- a/tests/e2e/client/apiproxy_bookstore_quota_test.py
+++ b/tests/e2e/client/apiproxy_bookstore_quota_test.py
@@ -57,14 +57,12 @@ class ApiProxyBookstoreTest(ApiProxyClientTest):
 
     # exhaust the quota in the current window.
     print("Exhaust current quota...");
-    response = _try_call_quota_read()
-    if response.status_code != 429:
-        while True:
-          # service control quota call has 1s cache.
-          time.sleep(1)
-          response = _try_call_quota_read()
-          if response and response.status_code == 429:
-              break;
+    while True:
+      # service control quota call has 1s cache.
+      time.sleep(1)
+      response = _try_call_quota_read()
+      if response and response.status_code == 429:
+          break;
 
     # waiting for the next quota refill.
     print("Wait for the next quota refill...")


### PR DESCRIPTION
The quota test often [failed](https://oss-prow.knative.dev/view/gs/oss-prow/pr-logs/pull/GoogleCloudPlatform_esp-v2/337/ESPv2-cloud-run-e2e-cloud-run-http-bookstore/1306763442949984257) because read on null response returned by exception. Fix it by removing first redundant attempt.

