### PR TITLE
b/160645642: use inline headers

### DIFF
--- a/src/envoy/http/service_control/handler_utils.cc
+++ b/src/envoy/http/service_control/handler_utils.cc
@@ -187,11 +187,12 @@ void fillLatency(const Envoy::StreamInfo::StreamInfo& stream_info,
   }
 }
 
-Protocol getFrontendProtocol(const Envoy::Http::HeaderMap* response_headers,
-                             const Envoy::StreamInfo::StreamInfo& stream_info) {
+Protocol getFrontendProtocol(
+    const Envoy::Http::ResponseHeaderMap* response_headers,
+    const Envoy::StreamInfo::StreamInfo& stream_info) {
   if (response_headers != nullptr) {
-    auto content_type =
-        utils::extractHeader(*response_headers, kContentTypeHeader);
+    auto content_type = response_headers->getContentTypeValue();
+
     if (isGrpcRequest(content_type)) {
       return Protocol::GRPC;
     }

--- a/src/envoy/http/service_control/handler_utils.h
+++ b/src/envoy/http/service_control/handler_utils.h
@@ -71,7 +71,7 @@ void fillJwtPayload(const ::envoy::config::core::v3::Metadata& metadata,
 
 // Returns the protocol of the frontend request or UNKNOWN if not found
 ::espv2::api_proxy::service_control::protocol::Protocol getFrontendProtocol(
-    const Envoy::Http::HeaderMap* response_headers,
+    const Envoy::Http::ResponseHeaderMap* response_headers,
     const Envoy::StreamInfo::StreamInfo& stream_info);
 
 // Returns the protocol of the backend service or UNKNOWN if not found

--- a/src/envoy/http/service_control/handler_utils_test.cc
+++ b/src/envoy/http/service_control/handler_utils_test.cc
@@ -407,7 +407,7 @@ TEST(ServiceControlUtils, GetBackendProtocol) {
 }
 
 TEST(ServiceControlUtils, GetFrontendProtocol) {
-  Envoy::Http::TestRequestHeaderMapImpl headers;
+  Envoy::Http::TestResponseHeaderMapImpl headers;
   testing::NiceMock<Envoy::StreamInfo::MockStreamInfo> mock_stream_info;
 
   // Test: header is nullptr and stream_info has no protocol

--- a/src/envoy/utils/http_header_utils.h
+++ b/src/envoy/utils/http_header_utils.h
@@ -27,6 +27,10 @@ namespace utils {
 absl::string_view readHeaderEntry(const Envoy::Http::HeaderEntry* entry);
 
 // Returns HTTP header value if the header is found, otherwise empty string.
+// If the header is one of inline headers, please use inline getter instead for
+// better performance.
+// For details, see
+// https://github.com/envoyproxy/envoy/blob/c5f4302325223765b660f0f366ce25bf8570e7a5/include/envoy/http/header_map.h#L271
 absl::string_view extractHeader(const Envoy::Http::HeaderMap& headers,
                                 const Envoy::Http::LowerCaseString& header);
 


### PR DESCRIPTION
Inspect the ESPv2 side and apply inline headers if possible. It can make header operation O(n) -> O(1).

Overall, update the `Authorization` header and the `Referer` header.
