### PR TITLE
b/169095072: fix path matcher misleading error message

### DIFF
--- a/src/envoy/http/path_matcher/filter.cc
+++ b/src/envoy/http/path_matcher/filter.cc
@@ -77,7 +77,7 @@ Envoy::Http::FilterHeadersStatus Filter::decodeHeaders(
     rejectRequest(
         Envoy::Http::Code::NotFound,
         absl::StrCat("`", method, " ", path, "`"
-                     " does not match any requirement URI template."));
+                     " does not match any defined routes."));
     return Envoy::Http::FilterHeadersStatus::StopIteration;
   }
 

--- a/src/envoy/http/path_matcher/filter.cc
+++ b/src/envoy/http/path_matcher/filter.cc
@@ -76,7 +76,7 @@ Envoy::Http::FilterHeadersStatus Filter::decodeHeaders(
   if (rule == nullptr) {
     rejectRequest(
         Envoy::Http::Code::NotFound,
-        absl::StrCat(method, " ", path,
+        absl::StrCat("`", method, " ", path, "`"
                      " does not match any requirement URI template."));
     return Envoy::Http::FilterHeadersStatus::StopIteration;
   }

--- a/src/envoy/http/path_matcher/filter.cc
+++ b/src/envoy/http/path_matcher/filter.cc
@@ -74,10 +74,10 @@ Envoy::Http::FilterHeadersStatus Filter::decodeHeaders(
   std::string path(headers.Path()->value().getStringView());
   const PathMatcherRule* rule = config_->findRule(method, path);
   if (rule == nullptr) {
-    rejectRequest(
-        Envoy::Http::Code::NotFound,
-        absl::StrCat("`", method, " ", path, "`"
-                     " does not match any defined routes."));
+    rejectRequest(Envoy::Http::Code::NotFound,
+                  absl::StrCat("Request `", method, " ", path,
+                               "`"
+                               " is not defined in the service spec."));
     return Envoy::Http::FilterHeadersStatus::StopIteration;
   }
 

--- a/src/envoy/http/path_matcher/filter.cc
+++ b/src/envoy/http/path_matcher/filter.cc
@@ -76,7 +76,7 @@ Envoy::Http::FilterHeadersStatus Filter::decodeHeaders(
   if (rule == nullptr) {
     rejectRequest(Envoy::Http::Code::NotFound,
                   absl::StrCat("Request `", method, " ", path,
-                               "` is not defined in the service spec."));
+                               "` is not defined by this API."));
     return Envoy::Http::FilterHeadersStatus::StopIteration;
   }
 

--- a/src/envoy/http/path_matcher/filter.cc
+++ b/src/envoy/http/path_matcher/filter.cc
@@ -76,8 +76,7 @@ Envoy::Http::FilterHeadersStatus Filter::decodeHeaders(
   if (rule == nullptr) {
     rejectRequest(Envoy::Http::Code::NotFound,
                   absl::StrCat("Request `", method, " ", path,
-                               "`"
-                               " is not defined in the service spec."));
+                               "` is not defined in the service spec."));
     return Envoy::Http::FilterHeadersStatus::StopIteration;
   }
 

--- a/src/envoy/http/path_matcher/filter_test.cc
+++ b/src/envoy/http/path_matcher/filter_test.cc
@@ -163,11 +163,10 @@ TEST_F(PathMatcherFilterTest, DecodeHeadersNoMatch) {
       setResponseFlag(
           Envoy::StreamInfo::ResponseFlag::UnauthorizedExternalService));
 
-  EXPECT_CALL(
-      mock_cb_,
-      sendLocalReply(Envoy::Http::Code::NotFound,
-                     "Request `POST /bar` is not defined in the service spec.",
-                     _, _, "path_not_defined"));
+  EXPECT_CALL(mock_cb_,
+              sendLocalReply(Envoy::Http::Code::NotFound,
+                             "Request `POST /bar` is not defined by this API.",
+                             _, _, "path_not_defined"));
 
   EXPECT_EQ(Envoy::Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(headers, true));

--- a/src/envoy/http/path_matcher/filter_test.cc
+++ b/src/envoy/http/path_matcher/filter_test.cc
@@ -166,7 +166,7 @@ TEST_F(PathMatcherFilterTest, DecodeHeadersNoMatch) {
   EXPECT_CALL(
       mock_cb_,
       sendLocalReply(Envoy::Http::Code::NotFound,
-                     "POST /bar does not match any requirement URI template.",
+                     "`POST /bar` does not match any requirement URI template.",
                      _, _, "path_not_defined"));
 
   EXPECT_EQ(Envoy::Http::FilterHeadersStatus::StopIteration,

--- a/src/envoy/http/path_matcher/filter_test.cc
+++ b/src/envoy/http/path_matcher/filter_test.cc
@@ -166,7 +166,7 @@ TEST_F(PathMatcherFilterTest, DecodeHeadersNoMatch) {
   EXPECT_CALL(
       mock_cb_,
       sendLocalReply(Envoy::Http::Code::NotFound,
-                     "`POST /bar` does not match any requirement URI template.",
+                     "`POST /bar` does not match any defined routes.",
                      _, _, "path_not_defined"));
 
   EXPECT_EQ(Envoy::Http::FilterHeadersStatus::StopIteration,

--- a/src/envoy/http/path_matcher/filter_test.cc
+++ b/src/envoy/http/path_matcher/filter_test.cc
@@ -166,7 +166,7 @@ TEST_F(PathMatcherFilterTest, DecodeHeadersNoMatch) {
   EXPECT_CALL(
       mock_cb_,
       sendLocalReply(Envoy::Http::Code::NotFound,
-                     "`POST /bar` does not match any defined routes.",
+                     "Request `POST /bar` is not defined in the service spec.",
                      _, _, "path_not_defined"));
 
   EXPECT_EQ(Envoy::Http::FilterHeadersStatus::StopIteration,

--- a/tests/integration_test/access_log_test.go
+++ b/tests/integration_test/access_log_test.go
@@ -84,7 +84,7 @@ func TestAccessLog(t *testing.T) {
 			requestPath: "/noexistpath",
 			wantError:   `http response status is not 200 OK: 404 Not Found`,
 			wantAccessLog: "\"GET /noexistpath?key=test-api-key HTTP/1.1\"404" +
-				" UAEX 0 105\"-\" \"Go-http-client/1.1\" " +
+				" UAEX 0 97\"-\" \"Go-http-client/1.1\" " +
 				"- -\n",
 		},
 	}

--- a/tests/integration_test/access_log_test.go
+++ b/tests/integration_test/access_log_test.go
@@ -84,7 +84,7 @@ func TestAccessLog(t *testing.T) {
 			requestPath: "/noexistpath",
 			wantError:   `http response status is not 200 OK: 404 Not Found`,
 			wantAccessLog: "\"GET /noexistpath?key=test-api-key HTTP/1.1\"404" +
-				" UAEX 0 75\"-\" \"Go-http-client/1.1\" " +
+				" UAEX 0 105\"-\" \"Go-http-client/1.1\" " +
 				"- -\n",
 		},
 	}

--- a/tests/integration_test/service_control_failed_request_report_test.go
+++ b/tests/integration_test/service_control_failed_request_report_test.go
@@ -57,7 +57,7 @@ func TestServiceControlFailedRequestReport(t *testing.T) {
 			url:           fmt.Sprintf("localhost:%v", s.Ports().ListenerPort),
 			httpMethod:    "GET",
 			method:        "/noexistoperation?key=api-key",
-			httpCallError: `404 Not Found, {"code":404,"message":"Path does not match any requirement URI template."}`,
+			httpCallError: "404 Not Found, {\"code\":404,\"message\":\"Request `GET /noexistoperation?key=api-key` is not defined in the service spec.\"}",
 			wantScRequests: []interface{}{
 				&utils.ExpectedReport{
 					Version:         utils.ESPv2Version(),
@@ -85,7 +85,7 @@ func TestServiceControlFailedRequestReport(t *testing.T) {
 			url:           fmt.Sprintf("localhost:%v", s.Ports().ListenerPort),
 			httpMethod:    "GET",
 			method:        "/noexistoperation",
-			httpCallError: `404 Not Found, {"code":404,"message":"Path does not match any requirement URI template."}`,
+			httpCallError: "404 Not Found, {\"code\":404,\"message\":\"Request `GET /noexistoperation` is not defined in the service spec.\"}",
 			wantScRequests: []interface{}{
 				&utils.ExpectedReport{
 					Version:         utils.ESPv2Version(),

--- a/tests/integration_test/service_control_failed_request_report_test.go
+++ b/tests/integration_test/service_control_failed_request_report_test.go
@@ -57,7 +57,7 @@ func TestServiceControlFailedRequestReport(t *testing.T) {
 			url:           fmt.Sprintf("localhost:%v", s.Ports().ListenerPort),
 			httpMethod:    "GET",
 			method:        "/noexistoperation?key=api-key",
-			httpCallError: "404 Not Found, {\"code\":404,\"message\":\"Request `GET /noexistoperation?key=api-key` is not defined in the service spec.\"}",
+			httpCallError: "404 Not Found, {\"code\":404,\"message\":\"Request `GET /noexistoperation?key=api-key` is not defined by this API.\"}",
 			wantScRequests: []interface{}{
 				&utils.ExpectedReport{
 					Version:         utils.ESPv2Version(),
@@ -85,7 +85,7 @@ func TestServiceControlFailedRequestReport(t *testing.T) {
 			url:           fmt.Sprintf("localhost:%v", s.Ports().ListenerPort),
 			httpMethod:    "GET",
 			method:        "/noexistoperation",
-			httpCallError: "404 Not Found, {\"code\":404,\"message\":\"Request `GET /noexistoperation` is not defined in the service spec.\"}",
+			httpCallError: "404 Not Found, {\"code\":404,\"message\":\"Request `GET /noexistoperation` is not defined by this API.\"}",
 			wantScRequests: []interface{}{
 				&utils.ExpectedReport{
 					Version:         utils.ESPv2Version(),


### PR DESCRIPTION
For mismatched request, update error message from `"Path does not match any requirement URI template."`
to `` "Request`METHOD PATH` is not defined by this API"``.

Please see the bug for the detailed discussion.