### PR TITLE
Envoy route config for sidecar with x-google-backend

### DIFF
--- a/examples/testdata/README.md
+++ b/examples/testdata/README.md
@@ -25,3 +25,12 @@ All other fields in the proto contain references to the operation name via the `
 - Under certain scenarios, the path matcher filter must parse these variable bindings.
 See [Understanding path translation](https://cloud.google.com/endpoints/docs/openapi/openapi-extensions#understanding_path_translation)
 for more information.
+
+## [Sidecar Backend](sidecar_backend)
+
+Configuration for ESPv2 in sidecar mode, but with `x-google-backend` defined to configure timeouts per route.
+
+Historically, ESPv2 could not handle per-route configs when running in sidecar mode (for GKE/GCE).
+It was only usable when running in remote proxy mode (for serverless platforms).
+
+This example validates per-route configs in sidecar mode.

--- a/examples/testdata/sidecar_backend/envoy_config.json
+++ b/examples/testdata/sidecar_backend/envoy_config.json
@@ -1,0 +1,212 @@
+{
+  "admin": {},
+  "layeredRuntime": {
+    "layers": [
+      {
+        "name": "deprecation",
+        "staticLayer": {
+          "re2.max_program_size.error_level": 1000
+        }
+      }
+    ]
+  },
+  "node": {
+    "cluster": "ESPv2_cluster",
+    "id": "ESPv2"
+  },
+  "staticResources": {
+    "clusters": [
+      {
+        "connectTimeout": "20s",
+        "loadAssignment": {
+          "clusterName": "127.0.0.1",
+          "endpoints": [
+            {
+              "lbEndpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socketAddress": {
+                        "address": "127.0.0.1",
+                        "portValue": 8082
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "name": "backend-cluster-examples-sidecar-backend.endpoints.cloudesf-testing.cloud.goog_local",
+        "type": "LOGICAL_DNS"
+      },
+      {
+        "connectTimeout": "20s",
+        "loadAssignment": {
+          "clusterName": "169.254.169.254",
+          "endpoints": [
+            {
+              "lbEndpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socketAddress": {
+                        "address": "169.254.169.254",
+                        "portValue": 80
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "name": "metadata-cluster",
+        "type": "STRICT_DNS"
+      },
+      {
+        "connectTimeout": "5s",
+        "dnsLookupFamily": "V4_ONLY",
+        "loadAssignment": {
+          "clusterName": "servicecontrol.googleapis.com",
+          "endpoints": [
+            {
+              "lbEndpoints": [
+                {
+                  "endpoint": {
+                    "address": {
+                      "socketAddress": {
+                        "address": "servicecontrol.googleapis.com",
+                        "portValue": 443
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "name": "service-control-cluster",
+        "transportSocket": {
+          "name": "envoy.transport_sockets.tls",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+            "commonTlsContext": {
+              "validationContext": {
+                "trustedCa": {
+                  "filename": "/etc/ssl/certs/ca-certificates.crt"
+                }
+              }
+            },
+            "sni": "servicecontrol.googleapis.com"
+          }
+        },
+        "type": "LOGICAL_DNS"
+      }
+    ],
+    "listeners": [
+      {
+        "address": {
+          "socketAddress": {
+            "address": "0.0.0.0",
+            "portValue": 8080
+          }
+        },
+        "filterChains": [
+          {
+            "filters": [
+              {
+                "name": "envoy.filters.network.http_connection_manager",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                  "commonHttpProtocolOptions": {
+                    "headersWithUnderscoresAction": "REJECT_REQUEST"
+                  },
+                  "httpFilters": [
+                    {
+                      "name": "com.google.espv2.filters.http.path_matcher",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/espv2.api.envoy.v8.http.path_matcher.FilterConfig",
+                        "rules": [
+                          {
+                            "operation": "1.examples_sidecar_backend_endpoints_cloudesf_testing_cloud_goog.ListShelves",
+                            "pattern": {
+                              "httpMethod": "GET",
+                              "uriTemplate": "/shelves"
+                            }
+                          },
+                          {
+                            "operation": "1.examples_sidecar_backend_endpoints_cloudesf_testing_cloud_goog.CreateShelf",
+                            "pattern": {
+                              "httpMethod": "POST",
+                              "uriTemplate": "/shelves"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "name": "com.google.espv2.filters.http.grpc_metadata_scrubber"
+                    },
+                    {
+                      "name": "envoy.filters.http.router",
+                      "typedConfig": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
+                        "suppressEnvoyHeaders": true
+                      }
+                    }
+                  ],
+                  "httpProtocolOptions": {
+                    "enableTrailers": true
+                  },
+                  "localReplyConfig": {
+                    "bodyFormat": {
+                      "jsonFormat": {
+                        "code": "%RESPONSE_CODE%",
+                        "message": "%LOCAL_REPLY_BODY%"
+                      }
+                    }
+                  },
+                  "routeConfig": {
+                    "name": "local_route",
+                    "virtualHosts": [
+                      {
+                        "domains": [
+                          "*"
+                        ],
+                        "name": "backend",
+                        "routes": [
+                          {
+                            "decorator": {
+                              "operation": "ingress"
+                            },
+                            "match": {
+                              "prefix": "/"
+                            },
+                            "route": {
+                              "cluster": "backend-cluster-examples-sidecar-backend.endpoints.cloudesf-testing.cloud.goog_local",
+                              "timeout": "15s"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "statPrefix": "ingress_http",
+                  "upgradeConfigs": [
+                    {
+                      "upgradeType": "websocket"
+                    }
+                  ],
+                  "useRemoteAddress": false,
+                  "xffNumTrustedHops": 2
+                }
+              }
+            ]
+          }
+        ],
+        "name": "ingress_listener"
+      }
+    ]
+  }
+}

--- a/examples/testdata/sidecar_backend/openapi_swagger.json
+++ b/examples/testdata/sidecar_backend/openapi_swagger.json
@@ -1,0 +1,96 @@
+{
+  "consumes": [
+    "application/json"
+  ],
+  "definitions": {
+    "listShelvesResponse": {
+      "properties": {
+        "shelves": {
+          "items": {
+            "$ref": "#/definitions/shelf"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "shelf": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "theme": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "theme"
+      ]
+    }
+  },
+  "host": "examples-sidecar-backend.endpoints.cloudesf-testing.cloud.goog",
+  "info": {
+    "description": "Configuration for ESPv2 in sidecar mode where x-google-backend is defined without an address.",
+    "title": "Examples - Sidecar Backend",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/shelves": {
+      "get": {
+        "description": "Returns all shelves in the bookstore.",
+        "operationId": "listShelves",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "List of shelves in the bookstore.",
+            "schema": {
+              "$ref": "#/definitions/listShelvesResponse"
+            }
+          }
+        },
+        "x-google-backend": {
+          "deadline": "7.5"
+        }
+      },
+      "post": {
+        "description": "Creates a new shelf in the bookstore.",
+        "operationId": "createShelf",
+        "parameters": [
+          {
+            "description": "A shelf resource to create.",
+            "in": "body",
+            "name": "shelf",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/shelf"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "A newly created shelf resource.",
+            "schema": {
+              "$ref": "#/definitions/shelf"
+            }
+          }
+        }
+      }
+    }
+  },
+  "produces": [
+    "application/json"
+  ],
+  "schemes": [
+    "https"
+  ],
+  "swagger": "2.0",
+  "x-google-backend": {
+    "deadline": "25"
+  }
+}

--- a/examples/testdata/sidecar_backend/service_config_generated.json
+++ b/examples/testdata/sidecar_backend/service_config_generated.json
@@ -29,7 +29,7 @@
         "selector": "1.examples_sidecar_backend_endpoints_cloudesf_testing_cloud_goog.ListShelves"
       },
       {
-        "deadline": 25.0,
+        "deadline": 25,
         "disableAuth": true,
         "selector": "1.examples_sidecar_backend_endpoints_cloudesf_testing_cloud_goog.CreateShelf"
       }

--- a/examples/testdata/sidecar_backend/service_config_generated.json
+++ b/examples/testdata/sidecar_backend/service_config_generated.json
@@ -1,0 +1,653 @@
+{
+  "apis": [
+    {
+      "methods": [
+        {
+          "name": "ListShelves",
+          "requestTypeUrl": "type.googleapis.com/google.protobuf.Empty",
+          "responseTypeUrl": "type.googleapis.com/ListShelvesResponse"
+        },
+        {
+          "name": "CreateShelf",
+          "requestTypeUrl": "type.googleapis.com/CreateShelfRequest",
+          "responseTypeUrl": "type.googleapis.com/Shelf"
+        }
+      ],
+      "name": "1.examples_sidecar_backend_endpoints_cloudesf_testing_cloud_goog",
+      "sourceContext": {
+        "fileName": "openapi_swagger.json"
+      },
+      "version": "1.0.0"
+    }
+  ],
+  "authentication": {},
+  "backend": {
+    "rules": [
+      {
+        "deadline": 7.5,
+        "disableAuth": true,
+        "selector": "1.examples_sidecar_backend_endpoints_cloudesf_testing_cloud_goog.ListShelves"
+      },
+      {
+        "deadline": 25.0,
+        "disableAuth": true,
+        "selector": "1.examples_sidecar_backend_endpoints_cloudesf_testing_cloud_goog.CreateShelf"
+      }
+    ]
+  },
+  "configVersion": 3,
+  "control": {
+    "environment": "servicecontrol.googleapis.com"
+  },
+  "documentation": {
+    "summary": "Configuration for ESPv2 in sidecar mode where x-google-backend is defined without an address."
+  },
+  "endpoints": [
+    {
+      "name": "examples-sidecar-backend.endpoints.cloudesf-testing.cloud.goog"
+    }
+  ],
+  "http": {
+    "rules": [
+      {
+        "get": "/shelves",
+        "selector": "1.examples_sidecar_backend_endpoints_cloudesf_testing_cloud_goog.ListShelves"
+      },
+      {
+        "body": "shelf",
+        "post": "/shelves",
+        "selector": "1.examples_sidecar_backend_endpoints_cloudesf_testing_cloud_goog.CreateShelf"
+      }
+    ]
+  },
+  "id": "2020-09-29r0",
+  "logging": {
+    "producerDestinations": [
+      {
+        "logs": [
+          "endpoints_log"
+        ],
+        "monitoredResource": "api"
+      }
+    ]
+  },
+  "logs": [
+    {
+      "name": "endpoints_log"
+    }
+  ],
+  "metrics": [
+    {
+      "labels": [
+        {
+          "key": "/credential_id"
+        },
+        {
+          "key": "/protocol"
+        },
+        {
+          "key": "/response_code"
+        },
+        {
+          "key": "/response_code_class"
+        },
+        {
+          "key": "/status_code"
+        }
+      ],
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/consumer/request_count",
+      "type": "serviceruntime.googleapis.com/api/consumer/request_count",
+      "valueType": "INT64"
+    },
+    {
+      "labels": [
+        {
+          "key": "/credential_id"
+        },
+        {
+          "key": "/error_type"
+        }
+      ],
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/consumer/error_count",
+      "type": "serviceruntime.googleapis.com/api/consumer/error_count",
+      "valueType": "INT64"
+    },
+    {
+      "labels": [
+        {
+          "key": "/credential_id"
+        }
+      ],
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/consumer/total_latencies",
+      "type": "serviceruntime.googleapis.com/api/consumer/total_latencies",
+      "valueType": "DISTRIBUTION"
+    },
+    {
+      "labels": [
+        {
+          "key": "/protocol"
+        },
+        {
+          "key": "/response_code"
+        },
+        {
+          "key": "/response_code_class"
+        },
+        {
+          "key": "/status_code"
+        }
+      ],
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/producer/request_count",
+      "type": "serviceruntime.googleapis.com/api/producer/request_count",
+      "valueType": "INT64"
+    },
+    {
+      "labels": [
+        {
+          "key": "/error_type"
+        }
+      ],
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/producer/error_count",
+      "type": "serviceruntime.googleapis.com/api/producer/error_count",
+      "valueType": "INT64"
+    },
+    {
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/producer/total_latencies",
+      "type": "serviceruntime.googleapis.com/api/producer/total_latencies",
+      "valueType": "DISTRIBUTION"
+    },
+    {
+      "labels": [
+        {
+          "key": "/credential_id"
+        },
+        {
+          "key": "/end_user"
+        }
+      ],
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user",
+      "type": "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user",
+      "valueType": "INT64"
+    },
+    {
+      "labels": [
+        {
+          "key": "/credential_id"
+        },
+        {
+          "key": "/end_user_country"
+        }
+      ],
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user_country",
+      "type": "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user_country",
+      "valueType": "INT64"
+    },
+    {
+      "labels": [
+        {
+          "key": "/credential_id"
+        },
+        {
+          "key": "/referer"
+        }
+      ],
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/consumer/top_request_count_by_referer",
+      "type": "serviceruntime.googleapis.com/api/consumer/top_request_count_by_referer",
+      "valueType": "INT64"
+    },
+    {
+      "labels": [
+        {
+          "key": "/protocol"
+        },
+        {
+          "key": "/response_code"
+        },
+        {
+          "key": "/consumer_id"
+        },
+        {
+          "key": "/status_code"
+        }
+      ],
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/producer/top_request_count_by_consumer",
+      "type": "serviceruntime.googleapis.com/api/producer/top_request_count_by_consumer",
+      "valueType": "INT64"
+    },
+    {
+      "labels": [
+        {
+          "key": "/credential_id"
+        },
+        {
+          "key": "/quota_group_name"
+        }
+      ],
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/consumer/quota_used_count",
+      "type": "serviceruntime.googleapis.com/api/consumer/quota_used_count",
+      "valueType": "INT64"
+    },
+    {
+      "labels": [
+        {
+          "key": "/credential_id"
+        }
+      ],
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/consumer/request_overhead_latencies",
+      "type": "serviceruntime.googleapis.com/api/consumer/request_overhead_latencies",
+      "valueType": "DISTRIBUTION"
+    },
+    {
+      "labels": [
+        {
+          "key": "/credential_id"
+        }
+      ],
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/consumer/backend_latencies",
+      "type": "serviceruntime.googleapis.com/api/consumer/backend_latencies",
+      "valueType": "DISTRIBUTION"
+    },
+    {
+      "labels": [
+        {
+          "key": "/credential_id"
+        }
+      ],
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/consumer/request_sizes",
+      "type": "serviceruntime.googleapis.com/api/consumer/request_sizes",
+      "valueType": "DISTRIBUTION"
+    },
+    {
+      "labels": [
+        {
+          "key": "/credential_id"
+        }
+      ],
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/consumer/response_sizes",
+      "type": "serviceruntime.googleapis.com/api/consumer/response_sizes",
+      "valueType": "DISTRIBUTION"
+    },
+    {
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/producer/request_overhead_latencies",
+      "type": "serviceruntime.googleapis.com/api/producer/request_overhead_latencies",
+      "valueType": "DISTRIBUTION"
+    },
+    {
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/producer/backend_latencies",
+      "type": "serviceruntime.googleapis.com/api/producer/backend_latencies",
+      "valueType": "DISTRIBUTION"
+    },
+    {
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/producer/request_sizes",
+      "type": "serviceruntime.googleapis.com/api/producer/request_sizes",
+      "valueType": "DISTRIBUTION"
+    },
+    {
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/producer/response_sizes",
+      "type": "serviceruntime.googleapis.com/api/producer/response_sizes",
+      "valueType": "DISTRIBUTION"
+    },
+    {
+      "labels": [
+        {
+          "key": "/consumer_id"
+        }
+      ],
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/producer/top_request_sizes_by_consumer",
+      "type": "serviceruntime.googleapis.com/api/producer/top_request_sizes_by_consumer",
+      "valueType": "DISTRIBUTION"
+    },
+    {
+      "labels": [
+        {
+          "key": "/consumer_id"
+        }
+      ],
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/producer/top_response_sizes_by_consumer",
+      "type": "serviceruntime.googleapis.com/api/producer/top_response_sizes_by_consumer",
+      "valueType": "DISTRIBUTION"
+    },
+    {
+      "labels": [
+        {
+          "key": "/credential_id"
+        },
+        {
+          "key": "/protocol"
+        },
+        {
+          "key": "/response_code"
+        },
+        {
+          "key": "/response_code_class"
+        },
+        {
+          "key": "/status_code"
+        }
+      ],
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/producer/by_consumer/request_count",
+      "type": "serviceruntime.googleapis.com/api/producer/by_consumer/request_count",
+      "valueType": "INT64"
+    },
+    {
+      "labels": [
+        {
+          "key": "/credential_id"
+        },
+        {
+          "key": "/error_type"
+        }
+      ],
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/producer/by_consumer/error_count",
+      "type": "serviceruntime.googleapis.com/api/producer/by_consumer/error_count",
+      "valueType": "INT64"
+    },
+    {
+      "labels": [
+        {
+          "key": "/credential_id"
+        }
+      ],
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/producer/by_consumer/total_latencies",
+      "type": "serviceruntime.googleapis.com/api/producer/by_consumer/total_latencies",
+      "valueType": "DISTRIBUTION"
+    },
+    {
+      "labels": [
+        {
+          "key": "/credential_id"
+        },
+        {
+          "key": "/quota_group_name"
+        }
+      ],
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/producer/by_consumer/quota_used_count",
+      "type": "serviceruntime.googleapis.com/api/producer/by_consumer/quota_used_count",
+      "valueType": "INT64"
+    },
+    {
+      "labels": [
+        {
+          "key": "/credential_id"
+        }
+      ],
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/producer/by_consumer/request_overhead_latencies",
+      "type": "serviceruntime.googleapis.com/api/producer/by_consumer/request_overhead_latencies",
+      "valueType": "DISTRIBUTION"
+    },
+    {
+      "labels": [
+        {
+          "key": "/credential_id"
+        }
+      ],
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/producer/by_consumer/backend_latencies",
+      "type": "serviceruntime.googleapis.com/api/producer/by_consumer/backend_latencies",
+      "valueType": "DISTRIBUTION"
+    },
+    {
+      "labels": [
+        {
+          "key": "/credential_id"
+        }
+      ],
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/producer/by_consumer/request_sizes",
+      "type": "serviceruntime.googleapis.com/api/producer/by_consumer/request_sizes",
+      "valueType": "DISTRIBUTION"
+    },
+    {
+      "labels": [
+        {
+          "key": "/credential_id"
+        }
+      ],
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/producer/by_consumer/response_sizes",
+      "type": "serviceruntime.googleapis.com/api/producer/by_consumer/response_sizes",
+      "valueType": "DISTRIBUTION"
+    },
+    {
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/producer/streaming_request_message_counts",
+      "type": "serviceruntime.googleapis.com/api/producer/streaming_request_message_counts",
+      "valueType": "DISTRIBUTION"
+    },
+    {
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/producer/streaming_response_message_counts",
+      "type": "serviceruntime.googleapis.com/api/producer/streaming_response_message_counts",
+      "valueType": "DISTRIBUTION"
+    },
+    {
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/consumer/streaming_request_message_counts",
+      "type": "serviceruntime.googleapis.com/api/consumer/streaming_request_message_counts",
+      "valueType": "DISTRIBUTION"
+    },
+    {
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/consumer/streaming_response_message_counts",
+      "type": "serviceruntime.googleapis.com/api/consumer/streaming_response_message_counts",
+      "valueType": "DISTRIBUTION"
+    },
+    {
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/producer/streaming_durations",
+      "type": "serviceruntime.googleapis.com/api/producer/streaming_durations",
+      "valueType": "DISTRIBUTION"
+    },
+    {
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/consumer/streaming_durations",
+      "type": "serviceruntime.googleapis.com/api/consumer/streaming_durations",
+      "valueType": "DISTRIBUTION"
+    },
+    {
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/producer/request_bytes",
+      "type": "serviceruntime.googleapis.com/api/producer/request_bytes",
+      "valueType": "INT64"
+    },
+    {
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/producer/response_bytes",
+      "type": "serviceruntime.googleapis.com/api/producer/response_bytes",
+      "valueType": "INT64"
+    },
+    {
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/consumer/request_bytes",
+      "type": "serviceruntime.googleapis.com/api/consumer/request_bytes",
+      "valueType": "INT64"
+    },
+    {
+      "metricKind": "DELTA",
+      "name": "serviceruntime.googleapis.com/api/consumer/response_bytes",
+      "type": "serviceruntime.googleapis.com/api/consumer/response_bytes",
+      "valueType": "INT64"
+    }
+  ],
+  "monitoredResources": [
+    {
+      "labels": [
+        {
+          "key": "cloud.googleapis.com/location"
+        },
+        {
+          "key": "cloud.googleapis.com/uid"
+        },
+        {
+          "key": "serviceruntime.googleapis.com/api_version"
+        },
+        {
+          "key": "serviceruntime.googleapis.com/api_method"
+        },
+        {
+          "key": "serviceruntime.googleapis.com/consumer_project"
+        },
+        {
+          "key": "cloud.googleapis.com/project"
+        },
+        {
+          "key": "cloud.googleapis.com/service"
+        }
+      ],
+      "type": "api"
+    }
+  ],
+  "monitoring": {
+    "consumerDestinations": [
+      {
+        "metrics": [
+          "serviceruntime.googleapis.com/api/consumer/request_count",
+          "serviceruntime.googleapis.com/api/consumer/error_count",
+          "serviceruntime.googleapis.com/api/consumer/quota_used_count",
+          "serviceruntime.googleapis.com/api/consumer/total_latencies",
+          "serviceruntime.googleapis.com/api/consumer/request_overhead_latencies",
+          "serviceruntime.googleapis.com/api/consumer/backend_latencies",
+          "serviceruntime.googleapis.com/api/consumer/request_sizes",
+          "serviceruntime.googleapis.com/api/consumer/response_sizes",
+          "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user",
+          "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user_country",
+          "serviceruntime.googleapis.com/api/consumer/top_request_count_by_referer",
+          "serviceruntime.googleapis.com/api/consumer/streaming_request_message_counts",
+          "serviceruntime.googleapis.com/api/consumer/streaming_response_message_counts",
+          "serviceruntime.googleapis.com/api/consumer/streaming_durations",
+          "serviceruntime.googleapis.com/api/consumer/request_bytes",
+          "serviceruntime.googleapis.com/api/consumer/response_bytes"
+        ],
+        "monitoredResource": "api"
+      }
+    ],
+    "producerDestinations": [
+      {
+        "metrics": [
+          "serviceruntime.googleapis.com/api/producer/request_count",
+          "serviceruntime.googleapis.com/api/producer/error_count",
+          "serviceruntime.googleapis.com/api/producer/total_latencies",
+          "serviceruntime.googleapis.com/api/producer/request_overhead_latencies",
+          "serviceruntime.googleapis.com/api/producer/backend_latencies",
+          "serviceruntime.googleapis.com/api/producer/request_sizes",
+          "serviceruntime.googleapis.com/api/producer/response_sizes",
+          "serviceruntime.googleapis.com/api/producer/top_request_count_by_consumer",
+          "serviceruntime.googleapis.com/api/producer/top_request_sizes_by_consumer",
+          "serviceruntime.googleapis.com/api/producer/top_response_sizes_by_consumer",
+          "serviceruntime.googleapis.com/api/producer/streaming_request_message_counts",
+          "serviceruntime.googleapis.com/api/producer/streaming_response_message_counts",
+          "serviceruntime.googleapis.com/api/producer/streaming_durations",
+          "serviceruntime.googleapis.com/api/producer/request_bytes",
+          "serviceruntime.googleapis.com/api/producer/response_bytes",
+          "serviceruntime.googleapis.com/api/producer/by_consumer/request_count",
+          "serviceruntime.googleapis.com/api/producer/by_consumer/error_count",
+          "serviceruntime.googleapis.com/api/producer/by_consumer/total_latencies",
+          "serviceruntime.googleapis.com/api/producer/by_consumer/quota_used_count",
+          "serviceruntime.googleapis.com/api/producer/by_consumer/request_overhead_latencies",
+          "serviceruntime.googleapis.com/api/producer/by_consumer/backend_latencies",
+          "serviceruntime.googleapis.com/api/producer/by_consumer/request_sizes",
+          "serviceruntime.googleapis.com/api/producer/by_consumer/response_sizes"
+        ],
+        "monitoredResource": "api"
+      }
+    ]
+  },
+  "name": "examples-sidecar-backend.endpoints.cloudesf-testing.cloud.goog",
+  "producerProjectId": "cloudesf-testing",
+  "systemParameters": {},
+  "title": "Examples - Sidecar Backend",
+  "types": [
+    {
+      "fields": [
+        {
+          "cardinality": "CARDINALITY_OPTIONAL",
+          "jsonName": "name",
+          "kind": "TYPE_STRING",
+          "name": "name",
+          "number": 1
+        },
+        {
+          "cardinality": "CARDINALITY_OPTIONAL",
+          "jsonName": "theme",
+          "kind": "TYPE_STRING",
+          "name": "theme",
+          "number": 2
+        }
+      ],
+      "name": "Shelf",
+      "sourceContext": {}
+    },
+    {
+      "fields": [
+        {
+          "cardinality": "CARDINALITY_REPEATED",
+          "jsonName": "shelves",
+          "kind": "TYPE_MESSAGE",
+          "name": "shelves",
+          "number": 1,
+          "typeUrl": "type.googleapis.com/Shelf"
+        }
+      ],
+      "name": "ListShelvesResponse",
+      "sourceContext": {}
+    },
+    {
+      "fields": [
+        {
+          "cardinality": "CARDINALITY_OPTIONAL",
+          "jsonName": "shelf",
+          "kind": "TYPE_MESSAGE",
+          "name": "shelf",
+          "number": 1,
+          "typeUrl": "type.googleapis.com/Shelf"
+        }
+      ],
+      "name": "CreateShelfRequest",
+      "sourceContext": {}
+    },
+    {
+      "name": "google.protobuf.Empty",
+      "sourceContext": {
+        "fileName": "struct.proto"
+      }
+    }
+  ],
+  "usage": {
+    "rules": [
+      {
+        "allowUnregisteredCalls": true,
+        "selector": "1.examples_sidecar_backend_endpoints_cloudesf_testing_cloud_goog.ListShelves"
+      },
+      {
+        "allowUnregisteredCalls": true,
+        "selector": "1.examples_sidecar_backend_endpoints_cloudesf_testing_cloud_goog.CreateShelf"
+      }
+    ]
+  }
+}

--- a/tests/env/platform/files.go
+++ b/tests/env/platform/files.go
@@ -57,6 +57,8 @@ const (
 	DrEnvoyConfig
 	PmServiceConfig
 	PmEnvoyConfig
+	SbServiceConfig
+	SbEnvoyConfig
 	GrpcEchoServiceConfig
 	GrpcEchoEnvoyConfig
 
@@ -103,6 +105,8 @@ var fileMap = map[RuntimeFile]string{
 	DrEnvoyConfig:         "../../../../examples/dynamic_routing/envoy_config.json",
 	PmServiceConfig:       "../../../../examples/testdata/path_matcher/service_config_generated.json",
 	PmEnvoyConfig:         "../../../../examples/testdata/path_matcher/envoy_config.json",
+	SbServiceConfig:       "../../../../examples/testdata/sidecar_backend/service_config_generated.json",
+	SbEnvoyConfig:         "../../../../examples/testdata/sidecar_backend/envoy_config.json",
 	GrpcEchoServiceConfig: "../../../../examples/grpc_dynamic_routing/service_config_generated.json",
 	GrpcEchoEnvoyConfig:   "../../../../examples/grpc_dynamic_routing/envoy_config.json",
 


### PR DESCRIPTION
Configuration for ESPv2 in sidecar mode, but with `x-google-backend` defined to configure timeouts per route.

NOTE: Currently we **do not generate the correct config**, the `deadline` in `x-google-backend` is ignored in sidecar mode. But let's check in this config for now, it will make it easier for me to reason about what needs to change in config generator. And it will give me a good test case for per-route config implementation.

Ref #321 (does not fix the issue)