### PR TITLE
Fix api regression test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,8 +190,6 @@ integration-test-run-parallel:
 
 integration-test: build  build-envoy build-grpc-interop build-grpc-echo integration-test-run-sequential
 
-integration-test-without-configmanager-build: build-envoy build-grpc-interop build-grpc-echo integration-test-run-sequential
-
 integration-debug: build build-envoy-debug build-grpc-interop build-grpc-echo
 	@echo "--> running integration tests and showing debug logs"
 	@go test -timeout 20m ./tests/endpoints/...

--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ integration-test-run-parallel:
 
 integration-test: build  build-envoy build-grpc-interop build-grpc-echo integration-test-run-sequential
 
-integration-test-without-envoy-build: build build-grpc-interop build-grpc-echo integration-test-run-sequential
+integration-test-without-configmanager-build: build-envoy build-grpc-interop build-grpc-echo integration-test-run-sequential
 
 integration-debug: build build-envoy-debug build-grpc-interop build-grpc-echo
 	@echo "--> running integration tests and showing debug logs"

--- a/prow/gcpproxy-api-regression.sh
+++ b/prow/gcpproxy-api-regression.sh
@@ -65,4 +65,4 @@ git checkout ${SHA}
 echo ${VERSION} > ${ROOT}/VERSION
 
 make depend.install
-make integration-test-without-envoy-build
+make integration-test-without-configmanager-build

--- a/prow/gcpproxy-api-regression.sh
+++ b/prow/gcpproxy-api-regression.sh
@@ -44,6 +44,11 @@ exit 1; }
 # The test will use the latest configmanager(configgen library) with the MASTER envoy to
 # run all the MASTER integrations.
 
+# Build latest configmanager.
+make depend.install
+make build
+
+# Checkout to the master.
 # Get the SHA of the head of master
 SHA=$(git ls-remote https://github.com/GoogleCloudPlatform/esp-v2.git HEAD | cut -f 1)
 
@@ -57,14 +62,6 @@ git checkout ${SHA}
 echo ${VERSION} > ${ROOT}/VERSION
 
 make depend.install
-make build build-envoy build-grpc-interop build-grpc-echo
-
-echo '======================================================='
-echo '============ Download latest configmanager ============'
-echo '======================================================='
-wait_apiproxy_image
-download_configmanager_binary
-chmod +x ${ROOT}/bin/configmanager
-chmod +x ${ROOT}/bin/bootstrap
+make build-envoy build-grpc-interop build-grpc-echo
 
 make integration-test-run-sequential

--- a/prow/gcpproxy-api-regression.sh
+++ b/prow/gcpproxy-api-regression.sh
@@ -65,4 +65,4 @@ git checkout ${SHA}
 echo ${VERSION} > ${ROOT}/VERSION
 
 make depend.install
-make integration-test-without-configmanager-build
+make build-envoy build-grpc-interop build-grpc-echo integration-test-run-sequential

--- a/prow/gcpproxy-api-regression.sh
+++ b/prow/gcpproxy-api-regression.sh
@@ -47,14 +47,6 @@ exit 1; }
 # Get the SHA of the head of master
 SHA=$(git ls-remote https://github.com/GoogleCloudPlatform/esp-v2.git HEAD | cut -f 1)
 
-wait_apiproxy_image
-
-echo '======================================================='
-echo '============ Download latest configmanager ============'
-echo '======================================================='
-download_configmanager_binary
-chmod +x ${ROOT}/bin/configmanager
-
 # keep the current version
 VERSION=$(cat ${ROOT}/VERSION)
 
@@ -65,4 +57,14 @@ git checkout ${SHA}
 echo ${VERSION} > ${ROOT}/VERSION
 
 make depend.install
-make build-envoy build-grpc-interop build-grpc-echo integration-test-run-sequential
+make build build-envoy build-grpc-interop build-grpc-echo
+
+echo '======================================================='
+echo '============ Download latest configmanager ============'
+echo '======================================================='
+wait_apiproxy_image
+download_configmanager_binary
+chmod +x ${ROOT}/bin/configmanager
+chmod +x ${ROOT}/bin/bootstrap
+
+make integration-test-run-sequential

--- a/prow/gcpproxy-api-regression.sh
+++ b/prow/gcpproxy-api-regression.sh
@@ -37,16 +37,23 @@ exit 1; }
 . ${ROOT}/tests/e2e/scripts/prow-utilities.sh || { echo 'Cannot load Bash utilities';
 exit 1; }
 
+# This integration test is used to ensure the backward-compatibility between ESPv2
+# and API Gateway use case. Once this test is broken, it reminds us to increment
+# api version if necessary.
+#
+# The test will use the latest configmanager(configgen library) with the MASTER envoy to
+# run all the MASTER integrations.
+
 # Get the SHA of the head of master
 SHA=$(git ls-remote https://github.com/GoogleCloudPlatform/esp-v2.git HEAD | cut -f 1)
 
 wait_apiproxy_image
 
 echo '======================================================='
-echo '================ Download latest envoy ================'
+echo '============ Download latest configmanager ============'
 echo '======================================================='
-download_envoy_binary
-chmod +x ${ROOT}/bin/envoy
+download_configmanager_binary
+chmod +x ${ROOT}/bin/configmanager
 
 # keep the current version
 VERSION=$(cat ${ROOT}/VERSION)

--- a/scripts/all-utilities.sh
+++ b/scripts/all-utilities.sh
@@ -413,17 +413,3 @@ function sleep_wrapper() {
   sleep ${length}
   echo "$(date): End sleep"
 }
-
-function configmanager_binary_gcs_path() {
-  echo -n "gs://apiproxy-testing-configmanager-binaries/$(get_sha)"
-}
-
-function upload_configmanager_binary() {
-  gsutil -m cp ${ROOT}/bin/configmanager $(configmanager_binary_gcs_path)/configmanager
-  gsutil -m cp ${ROOT}/bin/bootstrap $(configmanager_binary_gcs_path)/bootstrap
-}
-
-function download_configmanager_binary() {
-  gsutil -m cp $(configmanager_binary_gcs_path)/configmanager  ${ROOT}/bin/configmanager
-  gsutil -m cp $(configmanager_binary_gcs_path)/bootstrap  ${ROOT}/bin/bootstrap
-}

--- a/scripts/all-utilities.sh
+++ b/scripts/all-utilities.sh
@@ -414,14 +414,14 @@ function sleep_wrapper() {
   echo "$(date): End sleep"
 }
 
-function envoy_binary_gcs_path() {
-  echo -n "gs://apiproxy-testing-envoy-binaries/$(get_sha)"
+function configmanager_binary_gcs_path() {
+  echo -n "gs://apiproxy-testing-configmanager-binaries/$(get_sha)"
 }
 
-function upload_envoy_binary() {
-  gsutil -m cp ${ROOT}/bin/envoy $(envoy_binary_gcs_path)
+function upload_configmanager_binary() {
+  gsutil -m cp ${ROOT}/bin/configmanager $(configmanager_binary_gcs_path)
 }
 
-function download_envoy_binary() {
-  gsutil -m cp $(envoy_binary_gcs_path)  ${ROOT}/bin/envoy
+function download_configmanager_binary() {
+  gsutil -m cp $(configmanager_binary_gcs_path)  ${ROOT}/bin/configmanager
 }

--- a/scripts/all-utilities.sh
+++ b/scripts/all-utilities.sh
@@ -419,9 +419,11 @@ function configmanager_binary_gcs_path() {
 }
 
 function upload_configmanager_binary() {
-  gsutil -m cp ${ROOT}/bin/configmanager $(configmanager_binary_gcs_path)
+  gsutil -m cp ${ROOT}/bin/configmanager $(configmanager_binary_gcs_path)/configmanager
+  gsutil -m cp ${ROOT}/bin/bootstrap $(configmanager_binary_gcs_path)/bootstrap
 }
 
 function download_configmanager_binary() {
-  gsutil -m cp $(configmanager_binary_gcs_path)  ${ROOT}/bin/configmanager
+  gsutil -m cp $(configmanager_binary_gcs_path)/configmanager  ${ROOT}/bin/configmanager
+  gsutil -m cp $(configmanager_binary_gcs_path)/bootstrap  ${ROOT}/bin/bootstrap
 }

--- a/scripts/robot-release.sh
+++ b/scripts/robot-release.sh
@@ -63,8 +63,6 @@ echo '======================================================='
 echo '================= Cloud Build Docker =================='
 echo '======================================================='
 
-# Update latest configmanager binary for API regression test
-upload_configmanager_binary
 
 ${ROOT}/scripts/cloud-build-docker.sh  \
   || error_exit 'Failed to build a generic Docker Image.'

--- a/scripts/robot-release.sh
+++ b/scripts/robot-release.sh
@@ -63,8 +63,8 @@ echo '======================================================='
 echo '================= Cloud Build Docker =================='
 echo '======================================================='
 
-# Update latest configmananger binary for API regression test
-upload_configmananger_binary
+# Update latest configmanager binary for API regression test
+upload_configmanager_binary
 
 ${ROOT}/scripts/cloud-build-docker.sh  \
   || error_exit 'Failed to build a generic Docker Image.'

--- a/scripts/robot-release.sh
+++ b/scripts/robot-release.sh
@@ -63,8 +63,8 @@ echo '======================================================='
 echo '================= Cloud Build Docker =================='
 echo '======================================================='
 
-# Update latest envoy binary for API regression test
-upload_envoy_binary
+# Update latest configmananger binary for API regression test
+upload_configmananger_binary
 
 ${ROOT}/scripts/cloud-build-docker.sh  \
   || error_exit 'Failed to build a generic Docker Image.'


### PR DESCRIPTION
Currently, we are using the latest envoy with the master configmanager to do the api compatibility test for API Gateway uses case. However, its rollout order requires the opposite that uses the master old envoy and the latest configmanager. 