### PR TITLE
b/168231721: Support BackendRule deadline configuration in sidecar mode

### DIFF
--- a/examples/testdata/sidecar_backend/envoy_config.json
+++ b/examples/testdata/sidecar_backend/envoy_config.json
@@ -191,7 +191,7 @@
                             },
                             "route": {
                               "cluster": "backend-cluster-examples-sidecar-backend.endpoints.cloudesf-testing.cloud.goog_local",
-                              "timeout": "15s"
+                              "timeout": "7.500s"
                             }
                           },
                           {
@@ -209,7 +209,7 @@
                             },
                             "route": {
                               "cluster": "backend-cluster-examples-sidecar-backend.endpoints.cloudesf-testing.cloud.goog_local",
-                              "timeout": "15s"
+                              "timeout": "25s"
                             }
                           }
                         ]

--- a/src/go/configgenerator/cluster_generator.go
+++ b/src/go/configgenerator/cluster_generator.go
@@ -32,7 +32,7 @@ import (
 // This must be called before MakeListeners.
 func MakeClusters(serviceInfo *sc.ServiceInfo) ([]*clusterpb.Cluster, error) {
 	var clusters []*clusterpb.Cluster
-	backendCluster, err := makeCatchAllBackendCluster(serviceInfo)
+	backendCluster, err := makeLocalBackendCluster(serviceInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func MakeClusters(serviceInfo *sc.ServiceInfo) ([]*clusterpb.Cluster, error) {
 		clusters = append(clusters, scCluster)
 	}
 
-	brClusters, err := makeBackendRoutingClusters(serviceInfo)
+	brClusters, err := makeRemoteBackendClusters(serviceInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -286,8 +286,8 @@ func makeBackendCluster(opt *options.ConfigGeneratorOptions, brc *sc.BackendRout
 	return c, nil
 }
 
-func makeCatchAllBackendCluster(serviceInfo *sc.ServiceInfo) (*clusterpb.Cluster, error) {
-	c, err := makeBackendCluster(&serviceInfo.Options, serviceInfo.CatchAllBackend)
+func makeLocalBackendCluster(serviceInfo *sc.ServiceInfo) (*clusterpb.Cluster, error) {
+	c, err := makeBackendCluster(&serviceInfo.Options, serviceInfo.LocalBackendCluster)
 	if err != nil {
 		return nil, err
 	}
@@ -337,10 +337,10 @@ func makeServiceControlCluster(serviceInfo *sc.ServiceInfo) (*clusterpb.Cluster,
 	return c, nil
 }
 
-func makeBackendRoutingClusters(serviceInfo *sc.ServiceInfo) ([]*clusterpb.Cluster, error) {
+func makeRemoteBackendClusters(serviceInfo *sc.ServiceInfo) ([]*clusterpb.Cluster, error) {
 	var brClusters []*clusterpb.Cluster
 
-	for _, v := range serviceInfo.BackendRoutingClusters {
+	for _, v := range serviceInfo.RemoteBackendClusters {
 		c, err := makeBackendCluster(&serviceInfo.Options, v)
 		if err != nil {
 			return nil, err

--- a/src/go/configgenerator/cluster_generator_test.go
+++ b/src/go/configgenerator/cluster_generator_test.go
@@ -565,7 +565,7 @@ func TestMakeBackendRoutingCluster(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		clusters, err := makeBackendRoutingClusters(fakeServiceInfo)
+		clusters, err := makeRemoteBackendClusters(fakeServiceInfo)
 		if err != nil {
 			if tc.wantedError == "" || !strings.Contains(err.Error(), tc.wantedError) {
 				t.Fatal(err)
@@ -574,7 +574,7 @@ func TestMakeBackendRoutingCluster(t *testing.T) {
 		}
 
 		if tc.wantedClusters != nil && !cmp.Equal(clusters, tc.wantedClusters, cmp.Comparer(proto.Equal)) {
-			t.Errorf("Test Desc(%d): %s, makeBackendRoutingClusters\ngot: %v,\nwant: %v", i, tc.desc, clusters, tc.wantedClusters)
+			t.Errorf("Test Desc(%d): %s, makeRemoteBackendClusters\ngot: %v,\nwant: %v", i, tc.desc, clusters, tc.wantedClusters)
 		}
 	}
 }
@@ -779,7 +779,7 @@ func TestMakeIamCluster(t *testing.T) {
 		}
 
 		if !proto.Equal(cluster, tc.wantedCluster) {
-			t.Errorf("Test Desc(%d): %s, makeBackendRoutingClusters\ngot: %v,\nwant: %v", i, tc.desc, cluster, tc.wantedCluster)
+			t.Errorf("Test Desc(%d): %s, makeRemoteBackendClusters\ngot: %v,\nwant: %v", i, tc.desc, cluster, tc.wantedCluster)
 		}
 	}
 }

--- a/src/go/configgenerator/listener_generator_test.go
+++ b/src/go/configgenerator/listener_generator_test.go
@@ -537,9 +537,6 @@ func TestBackendRoutingFilter(t *testing.T) {
 				Backend: &confpb.Backend{
 					Rules: []*confpb.BackendRule{
 						{
-							Selector: "ignore_me",
-						},
-						{
 							Selector:        "testapi.foo",
 							Address:         "https://testapipb.com/foo",
 							PathTranslation: confpb.BackendRule_CONSTANT_ADDRESS,
@@ -619,9 +616,6 @@ func TestBackendRoutingFilter(t *testing.T) {
 				},
 				Backend: &confpb.Backend{
 					Rules: []*confpb.BackendRule{
-						{
-							Selector: "ignore_me",
-						},
 						{
 							Selector:        "testapi.foo",
 							Address:         "https://testapipb.com/foo?query=ignored",
@@ -706,9 +700,6 @@ func TestBackendRoutingFilter(t *testing.T) {
 				},
 				Backend: &confpb.Backend{
 					Rules: []*confpb.BackendRule{
-						{
-							Selector: "ignore_me",
-						},
 						{
 							Selector:        "testapi.foo",
 							Address:         "https://testapipb.com",
@@ -853,9 +844,6 @@ func TestBackendAuthFilter(t *testing.T) {
 				Backend: &confpb.Backend{
 					Rules: []*confpb.BackendRule{
 						{
-							Selector: "ignore_me",
-						},
-						{
 							Selector:        "testapipb.foo",
 							Address:         "https://testapipb.com/foo",
 							PathTranslation: confpb.BackendRule_CONSTANT_ADDRESS,
@@ -939,9 +927,6 @@ func TestBackendAuthFilter(t *testing.T) {
 				},
 				Backend: &confpb.Backend{
 					Rules: []*confpb.BackendRule{
-						{
-							Selector: "ignore_me",
-						},
 						{
 							Selector:        "get_testapi.foo",
 							Address:         "https://testapipb.com/foo",

--- a/src/go/configgenerator/route_generator.go
+++ b/src/go/configgenerator/route_generator.go
@@ -120,7 +120,7 @@ func MakeRouteConfig(serviceInfo *configinfo.ServiceInfo) (*routepb.RouteConfigu
 			Action: &routepb.Route_Route{
 				Route: &routepb.RouteAction{
 					ClusterSpecifier: &routepb.RouteAction_Cluster{
-						Cluster: serviceInfo.CatchAllBackendClusterName(),
+						Cluster: serviceInfo.LocalBackendClusterName(),
 					},
 				},
 			},

--- a/src/go/configinfo/service_info_test.go
+++ b/src/go/configinfo/service_info_test.go
@@ -1671,7 +1671,7 @@ func TestProcessBackendRuleForProtocol(t *testing.T) {
 			return
 		}
 
-		for _, gotBackendRoutingCluster := range s.BackendRoutingClusters {
+		for _, gotBackendRoutingCluster := range s.RemoteBackendClusters {
 			gotProtocol := gotBackendRoutingCluster.Protocol
 			wantProtocol, ok := tc.wantedClusterProtocols[gotBackendRoutingCluster.ClusterName]
 
@@ -1799,12 +1799,12 @@ func TestProcessBackendRuleForClusterName(t *testing.T) {
 			return
 		}
 
-		if len(s.BackendRoutingClusters) != 1 {
+		if len(s.RemoteBackendClusters) != 1 {
 			t.Errorf("Test Desc(%s): generated number of clusters is not 1", tc.desc)
 			return
 		}
-		if tc.ClusterName != s.BackendRoutingClusters[0].ClusterName {
-			t.Errorf("Test Desc(%s): cluster name is different, want: %s, got %s", tc.desc, tc.ClusterName, s.BackendRoutingClusters[0].ClusterName)
+		if tc.ClusterName != s.RemoteBackendClusters[0].ClusterName {
+			t.Errorf("Test Desc(%s): cluster name is different, want: %s, got %s", tc.desc, tc.ClusterName, s.RemoteBackendClusters[0].ClusterName)
 		}
 	}
 }

--- a/tests/env/env.go
+++ b/tests/env/env.go
@@ -255,6 +255,11 @@ func (e *TestEnv) SkipHealthChecks() {
 // Replace them as needed.
 func addDynamicRoutingBackendPort(serviceConfig *confpb.Service, port uint16) error {
 	for _, rule := range serviceConfig.Backend.GetRules() {
+		if rule.Address == "" {
+			// Empty address is now allowed, ESPv2 will override with `--backend` flag.
+			continue
+		}
+
 		if !strings.Contains(rule.Address, platform.WorkingBackendPort) && !strings.Contains(rule.Address, platform.InvalidBackendPort) {
 			return fmt.Errorf("backend rule address (%v) is not properly formatted", rule.Address)
 		}

--- a/tests/env/platform/ports.go
+++ b/tests/env/platform/ports.go
@@ -41,7 +41,7 @@ const (
 	TestBackendAuthWithImdsIdTokenRetries
 	TestBackendAuthWithImdsIdTokenWhileAllowCors
 	TestBackendHttpProtocol
-	TestDeadlinesForCatchAllBackend
+	TestDeadlinesForLocalBackend
 	TestDeadlinesForDynamicRouting
 	TestDeadlinesForGrpcCatchAllBackend
 	TestDeadlinesForGrpcDynamicRouting

--- a/tests/env/testdata/fake_echo_service_config.go
+++ b/tests/env/testdata/fake_echo_service_config.go
@@ -56,8 +56,26 @@ var (
 						RequestTypeUrl:  "type.googleapis.com/google.protobuf.Empty",
 						ResponseTypeUrl: "type.googleapis.com/AuthInfoResponse",
 					},
+					{
+						Name: "Sleep",
+					},
+					{
+						Name: "SleepWithBackendRule",
+					},
 				},
 				Version: "1.0.0",
+			},
+		},
+		Backend: &confpb.Backend{
+			// ESPv2 supports backend rules even in sidecar mode.
+			Rules: []*confpb.BackendRule{
+				{
+					Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.SleepWithBackendRule",
+					Deadline: 5,
+					Authentication: &confpb.BackendRule_DisableAuth{
+						DisableAuth: true,
+					},
+				},
 			},
 		},
 		Http: &annotationspb.Http{
@@ -134,6 +152,12 @@ var (
 					Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Sleep",
 					Pattern: &annotationspb.HttpRule_Get{
 						Get: "/sleep",
+					},
+				},
+				{
+					Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.SleepWithBackendRule",
+					Pattern: &annotationspb.HttpRule_Get{
+						Get: "/sleep/with/backend/rule",
 					},
 				},
 			},
@@ -215,6 +239,10 @@ var (
 				},
 				{
 					Selector:               "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Sleep",
+					AllowUnregisteredCalls: true,
+				},
+				{
+					Selector:               "1.echo_api_endpoints_cloudesf_testing_cloud_goog.SleepWithBackendRule",
 					AllowUnregisteredCalls: true,
 				},
 			},


### PR DESCRIPTION
**Background**: PR #358 moves away from a "catch-all" local backend route to per-selector routes. With this change, we can now support configuring per-route Envoy config based on `backend.rules` from the service config. 

**Implementation detail**: 
- This PR allows `deadline` from the `BackendRule` to be applied for routes when ESPv2 is running in sidecar mode. If the `BackendRule.Address` is empty, it will associate that method with the local backend. Otherwise, it will follow the pre-existing logic to associate it with a remote backend.
- Some minor renaming, we don't have a "catch-all" backend anymore.

**Testing**
- Update canonical example config
- Fix some unit tests
- Add integration test for user-defined deadline for ESPv2 in sidecar mode

**Follow-up PRs**:
- Update documentation on `x-google-backend` (and maybe even `BackendRule`) to clarify the address can be empty.
