### PR TITLE
b/170259809: Support for complicated http_template in envoy route match

### DIFF
--- a/src/go/util/url_util.go
+++ b/src/go/util/url_util.go
@@ -38,6 +38,10 @@ const (
 )
 
 var (
+	// Match and capture the segment binding for a named field path.
+	// /v1/{resource=shelves/*/books/**} -> /v1/shelves/*/books/**
+	fieldPathSegmentSimplifier = regexp.MustCompile(`{[^{}]+=([^{}]+)}`)
+
 	// Various hacky regular expressions to match a subset of the http template syntax.
 	// Replace segments with single wildcards: /v1/books/*
 	singleWildcardMatcher = regexp.MustCompile(`/\*`)
@@ -45,8 +49,6 @@ var (
 	doubleWildcardMatcher = regexp.MustCompile(`/\*\*`)
 	// Replace any path templates: /v1/books/{book_id}
 	pathParamMatcher = regexp.MustCompile(`/{[^{}]+}`)
-	// Replace path templates with double wildcards: /v1/{name=**}
-	pathParamDoubleWildcardMatcher = regexp.MustCompile(`/{[^{}]+=\*\*}`)
 
 	// Common regex forms that emulate http template syntax.
 	// Matches 1 or more segments of any character except '/'.
@@ -185,7 +187,7 @@ func ExtraAddressFromURI(jwksUri string) (string, error) {
 func WildcardMatcherForPath(uri string) string {
 
 	// Ordering matters, start with most specific and work upwards.
-	matcher := pathParamDoubleWildcardMatcher.ReplaceAllString(uri, doubleWildcardReplacementRegex)
+	matcher := fieldPathSegmentSimplifier.ReplaceAllString(uri, "$1")
 	matcher = pathParamMatcher.ReplaceAllString(matcher, singleWildcardReplacementRegex)
 	matcher = doubleWildcardMatcher.ReplaceAllString(matcher, doubleWildcardReplacementRegex)
 	matcher = singleWildcardMatcher.ReplaceAllString(matcher, singleWildcardReplacementRegex)

--- a/src/go/util/url_util.go
+++ b/src/go/util/url_util.go
@@ -38,19 +38,23 @@ const (
 )
 
 var (
-	// Match and capture the segment binding for a named field path.
-	// /v1/{resource=shelves/*/books/**} -> /v1/shelves/*/books/**
-	fieldPathSegmentSimplifier = regexp.MustCompile(`{[^{}]+=([^{}]+)}`)
-
 	// Various hacky regular expressions to match a subset of the http template syntax.
-	// Replace segments with single wildcards: /v1/books/*
+
+	// Match and capture the segment binding for a named field path.
+	// - /v1/{resource=shelves/*/books/**} -> /v1/shelves/*/books/**
+	fieldPathSegmentSimplifier = regexp.MustCompile(`{[^{}]+=([^{}]+)}`)
+	// Replace segments with single wildcards
+	// - /v1/books/* -> /v1/books/[^/]+
 	singleWildcardMatcher = regexp.MustCompile(`/\*`)
-	// Replace segments with double wildcards: /v1/**
+	// Replace segments with double wildcards
+	// - /v1/** -> /v1/.*
 	doubleWildcardMatcher = regexp.MustCompile(`/\*\*`)
-	// Replace any path templates: /v1/books/{book_id}
+	// Replace any path templates
+	// - /v1/books/{book_id} -> /v1/books/[^/]+
 	pathParamMatcher = regexp.MustCompile(`/{[^{}]+}`)
 
 	// Common regex forms that emulate http template syntax.
+
 	// Matches 1 or more segments of any character except '/'.
 	singleWildcardReplacementRegex = `/[^\/]+`
 	// Matches any character or no characters at all.

--- a/src/go/util/url_util_test.go
+++ b/src/go/util/url_util_test.go
@@ -523,9 +523,19 @@ func TestWildcardMatcherForPath(t *testing.T) {
 			wantMatcher: `^/shelves/[^\/]+/books/[^\/]+$`,
 		},
 		{
+			desc:        "Path params with fieldpath-only bindings and verb",
+			uri:         "/shelves/{shelf_id}/books/{book.id}:checkout",
+			wantMatcher: `^/shelves/[^\/]+/books/[^\/]+:checkout$`,
+		},
+		{
 			desc:        "Path param with wildcard segments",
 			uri:         "/test/*/test/**",
 			wantMatcher: `^/test/[^\/]+/test/.*$`,
+		},
+		{
+			desc:        "Path param with wildcard segments and verb",
+			uri:         "/test/*/test/**:upload",
+			wantMatcher: `^/test/[^\/]+/test/.*:upload$`,
 		},
 		{
 			desc:        "Path param with wildcard in segment binding",
@@ -543,12 +553,20 @@ func TestWildcardMatcherForPath(t *testing.T) {
 			wantMatcher: "",
 		},
 		{
-			// TODO(nareddyt): This is incorrect. But it should be fine, it's only a problem
-			// when user configures gRPC transcoding manually. OpenAPI compiler will
-			// never generate such a segment binding.
 			desc:        "Path params with full segment binding",
 			uri:         "/v1/{name=books/*}",
-			wantMatcher: `^/v1/[^\/]+$`,
+			wantMatcher: `^/v1/books/[^\/]+$`,
+		},
+		{
+			desc:        "Path params with multiple field path segment bindings",
+			uri:         "/v1/{test=a/b/*}/route/{resource_id=shelves/*/books/**}:upload",
+			wantMatcher: `^/v1/a/b/[^\/]+/route/shelves/[^\/]+/books/.*:upload$`,
+		},
+		{
+			// TODO(nareddyt): How can we improve validation once we remove path matcher?
+			desc:        "BUG - Incorrect http template syntax is not validated",
+			uri:         "/v1/{name=/books/*}",
+			wantMatcher: `^/v1//books/[^\/]+$`,
 		},
 	}
 

--- a/tests/env/testdata/fake_echo_service_config_for_dynamic_routing.go
+++ b/tests/env/testdata/fake_echo_service_config_for_dynamic_routing.go
@@ -100,6 +100,9 @@ var (
 					{
 						Name: "dynamic_routing_Wildcards",
 					},
+					{
+						Name: "dynamic_routing_FieldPath",
+					},
 
 					// Regression test for operation ordering: b/145520483.
 					// Config manager should not change method ordering.
@@ -276,6 +279,14 @@ var (
 					},
 				},
 				{
+					// Regression test for b/170259809.
+					// Envoy route config could not handle field path segment bindings.
+					Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_FieldPath",
+					Pattern: &annotationspb.HttpRule_Get{
+						Get: "/field_path/{s_1=a/*/b/*}/{s_2=x/**}:upload",
+					},
+				},
+				{
 					Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.operation_order_first_matched",
 					Pattern: &annotationspb.HttpRule_Post{
 						Post: "/allow-all/abc",
@@ -393,6 +404,10 @@ var (
 				},
 				{
 					Selector:               "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_Wildcards",
+					AllowUnregisteredCalls: true,
+				},
+				{
+					Selector:               "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_FieldPath",
 					AllowUnregisteredCalls: true,
 				},
 				{
@@ -594,6 +609,11 @@ var (
 				},
 				{
 					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_Wildcards",
+					Address:         fmt.Sprintf("https://localhost:%s/dynamicrouting/const_wildcard", platform.WorkingBackendPort),
+					PathTranslation: confpb.BackendRule_CONSTANT_ADDRESS,
+				},
+				{
+					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_FieldPath",
 					Address:         fmt.Sprintf("https://localhost:%s/dynamicrouting/const_wildcard", platform.WorkingBackendPort),
 					PathTranslation: confpb.BackendRule_CONSTANT_ADDRESS,
 				},


### PR DESCRIPTION
**Description**: This introduces support for the HTTP Templates that have variable bindings with non-wildcard segments:
- /v1/{book=books/*}
- /v1/{x=foo/bar}/baz
- /v1/{y=a/*/b/**}

Also verifies that HTTP Templates with wildcards work with a Verb suffix.

**Testing done**: Unit and integration tests.

Signed-off-by: Teju Nareddy <nareddyt@google.com>