### PR TITLE
Fix anthos e2e test due to failed ip allocation

### DIFF
--- a/tests/e2e/scripts/cloud-run/deploy.sh
+++ b/tests/e2e/scripts/cloud-run/deploy.sh
@@ -184,7 +184,7 @@ function setup() {
     # b/142752619: The cluster version should be >= 1.15 to be compatible with istio.
     gcloud beta container clusters create ${CLUSTER_NAME} \
       --addons=HorizontalPodAutoscaling,HttpLoadBalancing,CloudRun \
-      --machine-type=n1-standard-4 \
+      --machine-type=e2-standard-4 \
       --cluster-version=${CLUSTER_VERSION} \
       --enable-stackdriver-kubernetes \
       --service-account=${PROXY_RUNTIME_SERVICE_ACCOUNT} \

--- a/tests/e2e/scripts/cloud-run/deploy.sh
+++ b/tests/e2e/scripts/cloud-run/deploy.sh
@@ -372,9 +372,16 @@ function test() {
   then
     local scheme="http"
     local port="80"
+
     # Get the external ip of cluster
+    sleep_wrapper "3m" "Sleep 3m for external IP to be allocated"
     local host
     host=$( kubectl get svc istio-ingress -n gke-system | awk 'END {print $4}')
+    if [[ $host == *"pending"* ]]; then
+      echo "IP Address not allocated, even after sleep"
+      return 1
+    fi
+
     # Pass the real host by header `HOST`
     local host_header=${PROXY_HOST}
     local service_name=${PROXY_HOST}


### PR DESCRIPTION
- Add sleep time for IP allocation. 3 minutes more should be plenty.
- Change instance to `e2` to solve resource limit issue.

Signed-off-by: Teju Nareddy <nareddyt@google.com>