### PR TITLE
b/170723966: Add option to disable OpenID Connect Discovery

### DIFF
--- a/src/go/configinfo/service_info.go
+++ b/src/go/configinfo/service_info.go
@@ -186,7 +186,12 @@ func (s *ServiceInfo) processEmptyJwksUriByOpenID() error {
 		// Note: When jwksUri is empty, proxy will try to find jwksUri using the
 		// OpenID Connect Discovery protocol.
 		if jwksUri == "" {
-			glog.Infof("jwks_uri is empty, using OpenID Connect Discovery protocol")
+			if s.Options.DisableOidcDiscovery {
+				return fmt.Errorf("jwks_uri is empty for provider (%v), but OpenID Connect Discovery is disabled. "+
+					"Consider specifying the jwks_uri in the provider config", provider.Id)
+			}
+
+			glog.Infof("jwks_uri is empty for provider (%v), using OpenID Connect Discovery protocol", provider.Id)
 			jwksUriByOpenID, err := util.ResolveJwksUriUsingOpenID(provider.GetIssuer())
 			if err != nil {
 				return fmt.Errorf("failed OpenID Connect Discovery protocol: %v", err)

--- a/src/go/configinfo/service_info_test.go
+++ b/src/go/configinfo/service_info_test.go
@@ -2167,13 +2167,14 @@ func TestProcessEmptyJwksUriByOpenID(t *testing.T) {
 	openIDServer := httptest.NewServer(r)
 
 	testData := []struct {
-		desc              string
-		fakeServiceConfig *confpb.Service
-		wantedJwksUri     string
-		wantErr           bool
+		desc                 string
+		fakeServiceConfig    *confpb.Service
+		disableOidcDiscovery bool
+		wantedJwksUri        string
+		wantErr              bool
 	}{
 		{
-			desc: "Empty jwksUri, use jwksUri acquired by openID",
+			desc: "Success, empty JWKS URI, so it's acquired using OpenID Connect Discovery.",
 			fakeServiceConfig: &confpb.Service{
 				Apis: []*apipb.Api{
 					{
@@ -2192,7 +2193,7 @@ func TestProcessEmptyJwksUriByOpenID(t *testing.T) {
 			wantedJwksUri: "this-is-jwksUri",
 		},
 		{
-			desc: "Empty jwksUri and Open ID Connect Discovery failed",
+			desc: "Fail, empty JWKS URI and Open ID Connect Discovery failed.",
 			fakeServiceConfig: &confpb.Service{
 				Apis: []*apipb.Api{
 					{
@@ -2210,10 +2211,31 @@ func TestProcessEmptyJwksUriByOpenID(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			desc: "Fail, empty JWKS URI but OpenID Connect Discovery disabled.",
+			fakeServiceConfig: &confpb.Service{
+				Apis: []*apipb.Api{
+					{
+						Name: testApiName,
+					},
+				},
+				Authentication: &confpb.Authentication{
+					Providers: []*confpb.AuthProvider{
+						{
+							Id:     "auth_provider",
+							Issuer: openIDServer.URL,
+						},
+					},
+				},
+			},
+			disableOidcDiscovery: true,
+			wantErr:              true,
+		},
 	}
 
 	for i, tc := range testData {
 		opts := options.DefaultConfigGeneratorOptions()
+		opts.DisableOidcDiscovery = tc.disableOidcDiscovery
 		serviceInfo, err := NewServiceInfoFromServiceConfig(tc.fakeServiceConfig, testConfigID, opts)
 
 		if tc.wantErr {

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -69,6 +69,10 @@ var (
   omitted, the proxy contacts the metadata service to fetch an access token`)
 	TokenAgentPort = flag.Uint("token_agent_port", 8791, "Port that configmanager use to setup server to provide envoy with access token using service account credential, for accessing servicecontrol.")
 
+	// Flags for external calls.
+	DisableOidcDiscovery = flag.Bool("disable_oidc_discovery", false, `Disable OpenID Connect Discovery, prevents config generator from making external calls to determine the JWKS URI. 
+	This should be disabled when the URLs configured by the API Producer cannot be trusted.`)
+
 	// Envoy configurations.
 	AccessLog       = flag.String("access_log", "", "Path to a local file to which the access log entries will be written")
 	AccessLogFormat = flag.String("access_log_format", "", `String format to specify the format of access log.
@@ -154,6 +158,7 @@ func EnvoyConfigOptionsFromFlags() options.ConfigGeneratorOptions {
 		DnsResolverAddresses:                    *DnsResolverAddresses,
 		ServiceAccountKey:                       *ServiceAccountKey,
 		TokenAgentPort:                          *TokenAgentPort,
+		DisableOidcDiscovery:                    *DisableOidcDiscovery,
 		SkipJwtAuthnFilter:                      *SkipJwtAuthnFilter,
 		SkipServiceControlFilter:                *SkipServiceControlFilter,
 		EnvoyUseRemoteAddress:                   *EnvoyUseRemoteAddress,

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -70,7 +70,8 @@ var (
 	TokenAgentPort = flag.Uint("token_agent_port", 8791, "Port that configmanager use to setup server to provide envoy with access token using service account credential, for accessing servicecontrol.")
 
 	// Flags for external calls.
-	DisableOidcDiscovery = flag.Bool("disable_oidc_discovery", false, `Disable OpenID Connect Discovery, prevents config generator from making external calls to determine the JWKS URI. 
+	DisableOidcDiscovery = flag.Bool("disable_oidc_discovery", false, `Disable OpenID Connect Discovery. 
+  When disabled, config generator will not make external calls to determine the JWKS URI. 
 	This should be disabled when the URLs configured by the API Producer cannot be trusted.`)
 
 	// Envoy configurations.

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -71,7 +71,8 @@ var (
 
 	// Flags for external calls.
 	DisableOidcDiscovery = flag.Bool("disable_oidc_discovery", false, `Disable OpenID Connect Discovery. 
-  When disabled, config generator will not make external calls to determine the JWKS URI. 
+  When disabled, config generator will not make external calls to determine the JWKS URI, 
+	but the 'jwks_uri' field must not be empty in any authentication provider. 
 	This should be disabled when the URLs configured by the API Producer cannot be trusted.`)
 
 	// Envoy configurations.

--- a/src/go/options/configgenerator.go
+++ b/src/go/options/configgenerator.go
@@ -63,6 +63,9 @@ type ConfigGeneratorOptions struct {
 	ServiceAccountKey string
 	TokenAgentPort    uint
 
+	// Flags for external calls.
+	DisableOidcDiscovery bool
+
 	// Flags for testing purpose.
 	SkipJwtAuthnFilter       bool
 	SkipServiceControlFilter bool
@@ -119,6 +122,7 @@ func DefaultConfigGeneratorOptions() ConfigGeneratorOptions {
 		ListenerAddress:                  "0.0.0.0",
 		ListenerPort:                     8080,
 		TokenAgentPort:                   8791,
+		DisableOidcDiscovery:             false,
 		SslSidestreamClientRootCertsPath: util.DefaultRootCAPaths,
 		SslBackendClientRootCertsPath:    util.DefaultRootCAPaths,
 		SuppressEnvoyHeaders:             true,


### PR DESCRIPTION
**Description**: Requirement from Cloud API Gateway, they do not want to make remote calls in config generator. OpenID Connect Discovery is the only place config generator will make remote calls (and we don't plan to add any other calls in the near future), so just add a flag to disable this specifically.

**Testing done**: Unit and integration test. Verified logs in integration test.

Signed-off-by: Teju Nareddy <nareddyt@google.com>