### PR TITLE
b/170765129: Add flags to specify `cipher_suites` for TLS certificate

### DIFF
--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -150,6 +150,10 @@ environment variable or by passing "-k" flag to this script.
         HTTP/2 secure connections on listener_port. Requires the certificate and
         key files "server.crt" and "server.key" within this path.''')
 
+    parser.add_argument('--ssl_server_cipher_suites', default=None, help='''
+        Cipher suites to use for downstream connections as a comma-separated list.
+        Please refer to https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/auth/common.proto#auth-tlsparameters''')
+
     parser.add_argument('--ssl_backend_client_cert_path', default=None, help='''
         Proxy's client cert path. When configured, ESPv2 enables TLS mutual
         authentication for HTTPS backends. Requires the certificate and
@@ -158,6 +162,10 @@ environment variable or by passing "-k" flag to this script.
     parser.add_argument('--ssl_backend_client_root_certs_file', default=None, help='''
         The file path of root certificates that ESPv2 uses to verify backend server certificate.
         If not specified, ESPv2 uses '/etc/ssl/certs/ca-certificates.crt' by default.''')
+
+    parser.add_argument('--ssl_backend_client_cipher_suites', default=None, help='''
+        Cipher suites to use for HTTPS backends as a comma-separated list.
+        Please refer to https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/auth/common.proto#auth-tlsparameters''')
 
     parser.add_argument('--ssl_minimum_protocol', default=None,
         choices=['TLSv1.0', 'TLSv1.1', 'TLSv1.2', 'TLSv1.3'],
@@ -809,6 +817,11 @@ def gen_proxy_config(args):
         proxy_conf.extend(["--ssl_backend_client_root_certs_path", str(args.ssl_backend_client_root_certs_file)])
     if args.ssl_client_root_certs_file:
         proxy_conf.extend(["--ssl_backend_client_root_certs_path", str(args.ssl_client_root_certs_file)])
+
+    if args.ssl_server_cipher_suites:
+        proxy_conf.extend(["--ssl_server_cipher_suites", str(args.ssl_server_cipher_suites)])
+    if args.ssl_backend_client_cipher_suites:
+        proxy_conf.extend(["--ssl_backend_client_cipher_suites", str(args.ssl_backend_client_cipher_suites)])
 
     if args.tls_mutual_auth:
         proxy_conf.extend(["--ssl_backend_client_cert_path", "/etc/nginx/ssl"])

--- a/src/go/configgenerator/cluster_generator.go
+++ b/src/go/configgenerator/cluster_generator.go
@@ -137,7 +137,7 @@ func makeMetadataCluster(serviceInfo *sc.ServiceInfo) (*clusterpb.Cluster, error
 	}
 
 	if scheme == "https" {
-		transportSocket, err := util.CreateUpstreamTransportSocket(hostname, serviceInfo.Options.SslSidestreamClientRootCertsPath, "", nil)
+		transportSocket, err := util.CreateUpstreamTransportSocket(hostname, serviceInfo.Options.SslSidestreamClientRootCertsPath, "", nil, "")
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling tls context to transport_socket config for cluster %s, err=%v",
 				c.Name, err)
@@ -182,7 +182,7 @@ func makeIamCluster(serviceInfo *sc.ServiceInfo) (*clusterpb.Cluster, error) {
 	}
 
 	if scheme == "https" {
-		transportSocket, err := util.CreateUpstreamTransportSocket(hostname, serviceInfo.Options.SslSidestreamClientRootCertsPath, "", nil)
+		transportSocket, err := util.CreateUpstreamTransportSocket(hostname, serviceInfo.Options.SslSidestreamClientRootCertsPath, "", nil, "")
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling tls context to transport_socket config for cluster %s, err=%v",
 				c.Name, err)
@@ -229,7 +229,7 @@ func makeJwtProviderClusters(serviceInfo *sc.ServiceInfo) ([]*clusterpb.Cluster,
 			LoadAssignment:       util.CreateLoadAssignment(hostname, port),
 		}
 		if scheme == "https" {
-			transportSocket, err := util.CreateUpstreamTransportSocket(hostname, serviceInfo.Options.SslSidestreamClientRootCertsPath, "", nil)
+			transportSocket, err := util.CreateUpstreamTransportSocket(hostname, serviceInfo.Options.SslSidestreamClientRootCertsPath, "", nil, "")
 			if err != nil {
 				return nil, fmt.Errorf("error marshaling tls context to transport_socket config for cluster %s, err=%v",
 					c.Name, err)
@@ -258,7 +258,7 @@ func makeBackendCluster(opt *options.ConfigGeneratorOptions, brc *sc.BackendRout
 		if isHttp2 {
 			alpnProtocols = []string{"h2"}
 		}
-		transportSocket, err := util.CreateUpstreamTransportSocket(brc.Hostname, opt.SslBackendClientRootCertsPath, opt.SslBackendClientCertPath, alpnProtocols)
+		transportSocket, err := util.CreateUpstreamTransportSocket(brc.Hostname, opt.SslBackendClientRootCertsPath, opt.SslBackendClientCertPath, alpnProtocols, opt.SslBackendClientCipherSuites)
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling tls context to transport_socket config for cluster %s, err=%v",
 				brc.ClusterName, err)
@@ -323,7 +323,7 @@ func makeServiceControlCluster(serviceInfo *sc.ServiceInfo) (*clusterpb.Cluster,
 	}
 
 	if scheme == "https" {
-		transportSocket, err := util.CreateUpstreamTransportSocket(hostname, serviceInfo.Options.SslSidestreamClientRootCertsPath, "", nil)
+		transportSocket, err := util.CreateUpstreamTransportSocket(hostname, serviceInfo.Options.SslSidestreamClientRootCertsPath, "", nil, "")
 		if err != nil {
 			return nil, fmt.Errorf("error marshaling tls context to transport_socket config for cluster %s, err=%v",
 				c.Name, err)

--- a/src/go/configgenerator/cluster_generator_test.go
+++ b/src/go/configgenerator/cluster_generator_test.go
@@ -41,12 +41,12 @@ var (
 )
 
 func createTransportSocket(hostname string) *corepb.TransportSocket {
-	transportSocket, _ := util.CreateUpstreamTransportSocket(hostname, util.DefaultRootCAPaths, "", nil)
+	transportSocket, _ := util.CreateUpstreamTransportSocket(hostname, util.DefaultRootCAPaths, "", nil, "")
 	return transportSocket
 }
 
 func createH2TransportSocket(hostname string) *corepb.TransportSocket {
-	transportSocket, _ := util.CreateUpstreamTransportSocket(hostname, util.DefaultRootCAPaths, "", []string{"h2"})
+	transportSocket, _ := util.CreateUpstreamTransportSocket(hostname, util.DefaultRootCAPaths, "", []string{"h2"}, "")
 	return transportSocket
 }
 

--- a/src/go/configgenerator/listener_generator.go
+++ b/src/go/configgenerator/listener_generator.go
@@ -205,6 +205,7 @@ func makeListener(serviceInfo *sc.ServiceInfo) (*listenerpb.Listener, error) {
 			serviceInfo.Options.SslServerCertPath,
 			serviceInfo.Options.SslMinimumProtocol,
 			serviceInfo.Options.SslMaximumProtocol,
+			serviceInfo.Options.SslServerCipherSuites,
 		)
 		if err != nil {
 			return nil, err

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -55,9 +55,11 @@ var (
 	Healthz      = flag.String("healthz", "", "path for health check of ESPv2 proxy itself")
 
 	SslServerCertPath                = flag.String("ssl_server_cert_path", "", "Path to the certificate and key that ESPv2 uses to act as a HTTPS server")
+	SslServerCipherSuites            = flag.String("ssl_server_cipher_suites", "", "Cipher suites to use for downstream connections as a comma-separated list.")
 	SslSidestreamClientRootCertsPath = flag.String("ssl_sidestream_client_root_certs_path", util.DefaultRootCAPaths, "Path to the root certificates to make TLS connection to all external services other than the backend.")
 	SslBackendClientCertPath         = flag.String("ssl_backend_client_cert_path", "", "Path to the certificate and key that ESPv2 uses to enable TLS mutual authentication for HTTPS backend")
 	SslBackendClientRootCertsPath    = flag.String("ssl_backend_client_root_certs_path", util.DefaultRootCAPaths, "Path to the root certificates to make TLS connection to the HTTPS backend.")
+	SslBackendClientCipherSuites     = flag.String("ssl_backend_client_cipher_suites", "", "Cipher suites to use for HTTPS backends as a comma-separated list.")
 	SslMinimumProtocol               = flag.String("ssl_minimum_protocol", "", "Minimum TLS protocol version for Downstream connections.")
 	SslMaximumProtocol               = flag.String("ssl_maximum_protocol", "", "Maximum TLS protocol version for Downstream connections.")
 	EnableHSTS                       = flag.Bool("enable_strict_transport_security", false, "Enable HSTS (HTTP Strict Transport Security).")
@@ -147,7 +149,9 @@ func EnvoyConfigOptionsFromFlags() options.ConfigGeneratorOptions {
 		SslSidestreamClientRootCertsPath:        *SslSidestreamClientRootCertsPath,
 		SslBackendClientCertPath:                *SslBackendClientCertPath,
 		SslBackendClientRootCertsPath:           *SslBackendClientRootCertsPath,
+		SslBackendClientCipherSuites:            *SslBackendClientCipherSuites,
 		SslServerCertPath:                       *SslServerCertPath,
+		SslServerCipherSuites:                   *SslServerCipherSuites,
 		SslMinimumProtocol:                      *SslMinimumProtocol,
 		SslMaximumProtocol:                      *SslMaximumProtocol,
 		EnableHSTS:                              *EnableHSTS,

--- a/src/go/options/configgenerator.go
+++ b/src/go/options/configgenerator.go
@@ -51,12 +51,14 @@ type ConfigGeneratorOptions struct {
 	ServiceControlURL                string
 	ListenerPort                     int
 	SslServerCertPath                string
+	SslServerCipherSuites            string
 	SslMinimumProtocol               string
 	SslMaximumProtocol               string
 	EnableHSTS                       bool
 	SslSidestreamClientRootCertsPath string
 	SslBackendClientCertPath         string
 	SslBackendClientRootCertsPath    string
+	SslBackendClientCipherSuites     string
 	DnsResolverAddresses             string
 
 	// Flags for non_gcp deployment.

--- a/src/go/util/transport_socket_test.go
+++ b/src/go/util/transport_socket_test.go
@@ -27,6 +27,7 @@ func TestCreateUpstreamTransportSocket(t *testing.T) {
 		rootCertsPath       string
 		sslBackendPath      string
 		alpnProtocols       []string
+		cipherSuites        string
 		wantTransportSocket string
 	}{
 		{
@@ -34,6 +35,7 @@ func TestCreateUpstreamTransportSocket(t *testing.T) {
 			hostName:      "https://echo-http-12345-uc.a.run.app",
 			rootCertsPath: "/etc/ssl/certs/ca-certificates.crt",
 			alpnProtocols: []string{"h2"},
+			cipherSuites:  "ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256",
 			wantTransportSocket: `
 {
    "name":"envoy.transport_sockets.tls",
@@ -43,6 +45,12 @@ func TestCreateUpstreamTransportSocket(t *testing.T) {
          "alpnProtocols":[
             "h2"
          ],
+         "tlsParams":{
+            "cipherSuites":[
+               "ECDHE-ECDSA-AES128-GCM-SHA256",
+               "ECDHE-RSA-AES128-GCM-SHA256"
+            ]
+         },
          "validationContext":{
             "trustedCa":{
                "filename":"/etc/ssl/certs/ca-certificates.crt"
@@ -129,7 +137,7 @@ func TestCreateUpstreamTransportSocket(t *testing.T) {
 	}
 
 	for i, tc := range testData {
-		gotTransportSocket, err := CreateUpstreamTransportSocket(tc.hostName, tc.rootCertsPath, tc.sslBackendPath, tc.alpnProtocols)
+		gotTransportSocket, err := CreateUpstreamTransportSocket(tc.hostName, tc.rootCertsPath, tc.sslBackendPath, tc.alpnProtocols, tc.cipherSuites)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -150,6 +158,7 @@ func TestCreateDownstreamTransportSocket(t *testing.T) {
 		sslPath             string
 		sslMinimumProtocol  string
 		sslMaximumProtocol  string
+		cipherSuites        string
 		wantTransportSocket string
 	}{
 		{
@@ -184,6 +193,7 @@ func TestCreateDownstreamTransportSocket(t *testing.T) {
 			sslPath:            "/etc/ssl/endpoints/",
 			sslMinimumProtocol: "TLSv1.1",
 			sslMaximumProtocol: "TLSv1.3",
+			cipherSuites:       "ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256",
 			wantTransportSocket: `{
 				"name":"envoy.transport_sockets.tls",
 				"typedConfig":{
@@ -201,6 +211,10 @@ func TestCreateDownstreamTransportSocket(t *testing.T) {
 							}
 						],
 						"tlsParams":{
+							"cipherSuites":[
+								"ECDHE-ECDSA-AES128-GCM-SHA256",
+								"ECDHE-RSA-AES128-GCM-SHA256"
+							],
 							"tlsMaximumProtocolVersion":"TLSv1_3",
 							"tlsMinimumProtocolVersion":"TLSv1_1"
 						}
@@ -238,7 +252,7 @@ func TestCreateDownstreamTransportSocket(t *testing.T) {
 	}
 
 	for i, tc := range testData {
-		gotTransportSocket, err := CreateDownstreamTransportSocket(tc.sslPath, tc.sslMinimumProtocol, tc.sslMaximumProtocol)
+		gotTransportSocket, err := CreateDownstreamTransportSocket(tc.sslPath, tc.sslMinimumProtocol, tc.sslMaximumProtocol, tc.cipherSuites)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/tests/start_proxy/start_proxy_test.py
+++ b/tests/start_proxy/start_proxy_test.py
@@ -201,6 +201,17 @@ class TestStartProxy(unittest.TestCase):
               '--listener_port', '8080', '--ssl_minimum_protocol',
               'TLSv1.1','--ssl_maximum_protocol','TLSv1.3', '--disable_tracing'
               ]),
+            # ssl_server_cipher_suites and ssl_backend_client_cipher_suites specified
+            (['-R=managed','--listener_port=8080',  '--disable_tracing',
+              '--ssl_server_cipher_suites=AES128-SHA,AES256-GCM-SHA384',
+              '--ssl_backend_client_cipher_suites=AES256-SHA'],
+             ['bin/configmanager', '--logtostderr', '--rollout_strategy', 'managed',
+              '--backend_address', 'http://127.0.0.1:8082', '--v', '0',
+              '--listener_port', '8080',
+              '--ssl_server_cipher_suites', 'AES128-SHA,AES256-GCM-SHA384',
+              '--ssl_backend_client_cipher_suites', 'AES256-SHA',
+              '--disable_tracing'
+              ]),
             # legacy --ssl_protocols specified
             (['-R=managed','--listener_port=8080',  '--disable_tracing',
               '--ssl_protocols=TLSv1.3', '--ssl_protocols=TLSv1.2'],


### PR DESCRIPTION
**Description**: Added the following flags:
- `--ssl_server_cipher_suites` for the downstream connection
- `--ssl_backend_client_cipher_suites` for any backend connections

**Testing Done**:
- Unit tests only, no integration tests. Similar approach as `--ssl_minimum_version` flags.

Fixes #346
Signed-off-by: Teju Nareddy <nareddyt@google.com>