### PR TITLE
Add path_rewrite filter config and config_parser

### DIFF
--- a/api/envoy/v9/http/path_rewrite/BUILD
+++ b/api/envoy/v9/http/path_rewrite/BUILD
@@ -1,0 +1,21 @@
+load("@envoy_api//bazel:api_build_system.bzl", "api_cc_py_proto_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+package(default_visibility = ["//visibility:public"])
+
+api_cc_py_proto_library(
+    name = "config_proto",
+    srcs = [
+        "config.proto",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "config_go_proto",
+    importpath = "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/v9/http/path_rewrite",
+    proto = ":config_proto",
+    deps = [
+        "@com_envoyproxy_protoc_gen_validate//validate:go_default_library",
+    ],
+)

--- a/api/envoy/v9/http/path_rewrite/config.proto
+++ b/api/envoy/v9/http/path_rewrite/config.proto
@@ -59,7 +59,7 @@ message ConstantPath {
   }];
 
   // If not empty, specify the url template with variable names.
-  // The varaible names and their values will be converted to query parameters.
+  // The variable names and their values will be converted to query parameters.
   string url_template = 2;
 }
 

--- a/api/envoy/v9/http/path_rewrite/config.proto
+++ b/api/envoy/v9/http/path_rewrite/config.proto
@@ -59,20 +59,7 @@ message ConstantPath {
   }];
 
   // If not empty, specify the url template with variable names.
-  // The varaibles and their values will be converted to query parameters.
-  //
-  // Example: if the config is:
-  //   path: "/prefix"
-  //   url_template: "/foo/{bookID}/create"
-  //
-  // Request 1: without query parmeter
-  //   input path:  "/foo/1234/create"
-  //   output path: "/prefix?bookID=1234"
-  //
-  // Request 2: with query parameters
-  //   input path:  "/foo/1234/create?bar=100"
-  //   output path: "/prefix?bar=100&bookID=1234"
-  //
+  // The varaible names and their values will be converted to query parameters.
   string url_template = 2;
 }
 
@@ -82,6 +69,7 @@ message PerRouteFilterConfig {
     option (validate.required) = true;
 
     // Prepend the following path_prefix to the incoming request path.
+    // The whole path including its query parameters will not appended.
     string path_prefix = 1
         [(validate.rules).string = {
             // Should not be empty.

--- a/api/envoy/v9/http/path_rewrite/config.proto
+++ b/api/envoy/v9/http/path_rewrite/config.proto
@@ -1,0 +1,104 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package espv2.api.envoy.v9.http.path_rewrite;
+
+import "validate/validate.proto";
+
+// Translate into a constant path with preserved query parameters
+// If a url_template with path variables is specified, its variables
+// will be converted into query parameters too.
+//
+// All following examples use path: "/prefix"
+//
+// Example 1: no url_template:
+//   path: "/prefix"
+//
+// Request 1.1: without query parmeter
+//   input path:  "/foo/1234/create"
+//   output path: "/prefix"
+//
+// Request 1.2: with query parameters
+//   input path:  "/foo/1234/create?bar=100"
+//   output path: "/prefix?bar=100"
+//
+// Example 2: with url_template
+//   path: "/prefix"
+//   url_template: "/foo/{bookID}/create"
+//
+// Request 2.1: without query parmeter
+//   input path:  "/foo/1234/create"
+//   output path: "/prefix?bookID=1234"
+//
+// Request 2.2: with query parameters
+//   input path:  "/foo/1234/create?bar=100"
+//   output path: "/prefix?bar=100&bookID=1234"
+//
+message ConstantPath {
+  // This is the final path. All incoming request paths will be
+  // translated to this final path.
+  string path = 1 [(validate.rules).string = {
+    // Should not be empty. At minimu it should have "/".
+    min_len: 1,
+    // Does not contain query params ('?'), fragments ('#'), or invalid
+    // HTTP_HEADER_VALUE ('\r', '\n', '\0') characters.
+    pattern: '^[^?#\\r\\n\\0]+$',
+  }];
+
+  // If not empty, specify the url template with variable names.
+  // The varaibles and their values will be converted to query parameters.
+  //
+  // Example: if the config is:
+  //   path: "/prefix"
+  //   url_template: "/foo/{bookID}/create"
+  //
+  // Request 1: without query parmeter
+  //   input path:  "/foo/1234/create"
+  //   output path: "/prefix?bookID=1234"
+  //
+  // Request 2: with query parameters
+  //   input path:  "/foo/1234/create?bar=100"
+  //   output path: "/prefix?bar=100&bookID=1234"
+  //
+  string url_template = 2;
+}
+
+// The per-route configuration specified in RouteEntry PerFilterConfig.
+message PerRouteFilterConfig {
+  oneof path_translation_specifier {
+    option (validate.required) = true;
+
+    // Prepend the following path_prefix to the incoming request path.
+    string path_prefix = 1
+        [(validate.rules).string = {
+            // Should not be empty.
+            min_len: 1,
+            // Does not contain query params ('?'), fragments ('#'), or invalid
+            // HTTP_HEADER_VALUE ('\r', '\n', '\0') characters.
+            pattern: '^[^?#\\r\\n\\0]+$',
+          }];
+
+    // Translate to a constant path.
+    ConstantPath constant_path = 2;
+
+    // In the future, other path translation methods may be added
+  }
+}
+
+// Filter level config is not needed.
+// All configurations are moved to RouteEntry PerFilterConfig as per-route config.
+message FilterConfig {
+}

--- a/api/envoy/v9/http/path_rewrite/config.proto
+++ b/api/envoy/v9/http/path_rewrite/config.proto
@@ -70,14 +70,13 @@ message PerRouteFilterConfig {
 
     // Prepend the following path_prefix to the incoming request path.
     // The whole path including its query parameters will not appended.
-    string path_prefix = 1
-        [(validate.rules).string = {
-            // Should not be empty.
-            min_len: 1,
-            // Does not contain query params ('?'), fragments ('#'), or invalid
-            // HTTP_HEADER_VALUE ('\r', '\n', '\0') characters.
-            pattern: '^[^?#\\r\\n\\0]+$',
-          }];
+    string path_prefix = 1 [(validate.rules).string = {
+      // Should not be empty.
+      min_len: 1,
+      // Does not contain query params ('?'), fragments ('#'), or invalid
+      // HTTP_HEADER_VALUE ('\r', '\n', '\0') characters.
+      pattern: '^[^?#\\r\\n\\0]+$',
+    }];
 
     // Translate to a constant path.
     ConstantPath constant_path = 2;
@@ -87,6 +86,6 @@ message PerRouteFilterConfig {
 }
 
 // Filter level config is not needed.
-// All configurations are moved to RouteEntry PerFilterConfig as per-route config.
-message FilterConfig {
-}
+// All configurations are moved to RouteEntry PerFilterConfig as per-route
+// config.
+message FilterConfig {}

--- a/api/envoy/v9/http/path_rewrite/config.proto
+++ b/api/envoy/v9/http/path_rewrite/config.proto
@@ -51,7 +51,7 @@ message ConstantPath {
   // This is the final path. All incoming request paths will be
   // translated to this final path.
   string path = 1 [(validate.rules).string = {
-    // Should not be empty. At minimu it should have "/".
+    // Must not be empty. At minimu it should have "/".
     min_len: 1,
     // Does not contain query params ('?'), fragments ('#'), or invalid
     // HTTP_HEADER_VALUE ('\r', '\n', '\0') characters.
@@ -71,8 +71,8 @@ message PerRouteFilterConfig {
     // Prepend the following path_prefix to the incoming request path.
     // The whole path including its query parameters will not appended.
     string path_prefix = 1 [(validate.rules).string = {
-      // Should not be empty.
-      min_len: 1,
+      // Must be more than "/".
+      min_len: 2,
       // Does not contain query params ('?'), fragments ('#'), or invalid
       // HTTP_HEADER_VALUE ('\r', '\n', '\0') characters.
       pattern: '^[^?#\\r\\n\\0]+$',

--- a/src/envoy/http/path_rewrite/BUILD
+++ b/src/envoy/http/path_rewrite/BUILD
@@ -1,0 +1,40 @@
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_cc_test",
+)
+
+package(
+    default_visibility = [
+        "//src/envoy:__subpackages__",
+    ],
+)
+
+envoy_cc_library(
+    name = "config_parser_lib",
+    srcs = ["config_parser_impl.cc"],
+    hdrs = [
+        "config_parser.h",
+        "config_parser_impl.h",
+    ],
+    repository = "@envoy",
+    deps = [
+        "//api/envoy/v9/http/path_rewrite:config_proto_cc_proto",
+        "//src/api_proxy/path_matcher:path_matcher_lib",
+        "//src/api_proxy/path_matcher:variable_binding_utils_lib",
+        "@envoy//source/common/common:empty_string",
+        "@envoy//source/common/common:logger_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "config_parser_impl_test",
+    srcs = [
+        "config_parser_impl_test.cc",
+    ],
+    repository = "@envoy",
+    deps = [
+        ":config_parser_lib",
+        "@envoy//test/test_common:utility_lib",
+    ],
+)

--- a/src/envoy/http/path_rewrite/BUILD
+++ b/src/envoy/http/path_rewrite/BUILD
@@ -35,6 +35,7 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         ":config_parser_lib",
+        "@envoy//source/common/protobuf:utility_lib",
         "@envoy//test/test_common:utility_lib",
     ],
 )

--- a/src/envoy/http/path_rewrite/config_parser.h
+++ b/src/envoy/http/path_rewrite/config_parser.h
@@ -26,7 +26,8 @@ class ConfigParser {
 
   // If return false, fails to generate new path due to:
   // origin_path doesn't match with the url_template in the const_path.
-  virtual bool rewrite(absl::string_view origin_path, std::string& new_path) const PURE;
+  virtual bool rewrite(absl::string_view origin_path,
+                       std::string& new_path) const PURE;
 };
 
 using ConstConfigParserPtr = std::unique_ptr<const ConfigParser>;

--- a/src/envoy/http/path_rewrite/config_parser.h
+++ b/src/envoy/http/path_rewrite/config_parser.h
@@ -1,0 +1,37 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include "envoy/common/pure.h"
+
+namespace espv2 {
+namespace envoy {
+namespace http_filters {
+namespace path_rewrite {
+
+class ConfigParser {
+ public:
+  virtual ~ConfigParser() = default;
+
+  // If return false, fails to generate new path due to:
+  // origin_path doesn't match with the url_template in the const_path.
+  virtual bool rewrite(absl::string_view origin_path, std::string& new_path) const PURE;
+};
+
+using ConstConfigParserPtr = std::unique_ptr<const ConfigParser>;
+
+}  // namespace path_rewrite
+}  // namespace http_filters
+}  // namespace envoy
+}  // namespace espv2

--- a/src/envoy/http/path_rewrite/config_parser_impl.cc
+++ b/src/envoy/http/path_rewrite/config_parser_impl.cc
@@ -80,22 +80,24 @@ bool ConfigParserImpl::rewrite(absl::string_view origin_path,
 bool ConfigParserImpl::getVariableBindings(const std::string& origin_path,
                                            std::string& query) const {
   query = Envoy::EMPTY_STRING;
-  if (path_matcher_) {
-    std::vector<espv2::api_proxy::path_matcher::VariableBinding>
-        variable_bindings;
-    if (path_matcher_->Lookup(kHttpMethod, origin_path, &variable_bindings) ==
-        nullptr) {
-      // mismatched case
-      ENVOY_LOG(warn, "Request path: {} doesn't match url_template: {}",
-                origin_path, config_.constant_path().url_template());
-      return false;
-    }
+  if (!path_matcher_) {
+    return true;
+  }
 
-    if (!variable_bindings.empty()) {
-      query = espv2::api_proxy::path_matcher::VariableBindingsToQueryParameters(
-          variable_bindings);
-      ENVOY_LOG(debug, "Extracted query parameters: {}", query);
-    }
+  std::vector<espv2::api_proxy::path_matcher::VariableBinding>
+      variable_bindings;
+  if (path_matcher_->Lookup(kHttpMethod, origin_path, &variable_bindings) ==
+      nullptr) {
+    // mismatched case
+    ENVOY_LOG(warn, "Request path: {} doesn't match url_template: {}",
+              origin_path, config_.constant_path().url_template());
+    return false;
+  }
+
+  if (!variable_bindings.empty()) {
+    query = espv2::api_proxy::path_matcher::VariableBindingsToQueryParameters(
+        variable_bindings);
+    ENVOY_LOG(debug, "Extracted query parameters: {}", query);
   }
   return true;
 }

--- a/src/envoy/http/path_rewrite/config_parser_impl.cc
+++ b/src/envoy/http/path_rewrite/config_parser_impl.cc
@@ -1,0 +1,128 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "absl/strings/str_cat.h"
+
+#include "common/common/empty_string.h"
+
+#include "src/api_proxy/path_matcher/variable_binding_utils.h"
+#include "src/envoy/http/path_rewrite/config_parser_impl.h"
+
+namespace espv2 {
+namespace envoy {
+namespace http_filters {
+namespace path_rewrite {
+namespace {
+
+// Use fixed HTTP method for path_matcher
+constexpr const char kHttpMethod[] = "GET";
+
+}  // namespace
+
+ConfigParserImpl::ConfigParserImpl(
+    const ::espv2::api::envoy::v9::http::path_rewrite::PerRouteFilterConfig&
+    config) : config_(config) {
+  if (config_.has_constant_path()) {
+    const auto& path_cfg = config_.constant_path();
+    if (!path_cfg.url_template().empty()) {
+      ENVOY_LOG(debug, "Building path_matcher for url_template: {}", path_cfg.url_template());
+
+      ::espv2::api_proxy::path_matcher::PathMatcherBuilder<
+          const ::espv2::api::envoy::v9::http::path_rewrite::PerRouteFilterConfig*>
+          pmb;
+      pmb.Register(kHttpMethod, path_cfg.url_template(), Envoy::EMPTY_STRING, &config_);
+      path_matcher_ = pmb.Build();
+    }
+
+    // If the last char of the path is "/", remove it, unless it is just root "/".
+    const std::string& path = path_cfg.path();
+    if (path.size() > 1 && path[path.size() - 1] == '/') {
+      ENVOY_LOG(warn, "Remove last slash of constant_path.path: {}", path);
+      config_.mutable_constant_path()->set_path(path.substr(0, path.size() - 1));
+    }
+  } else {
+    // even "/" should be removed
+    const std::string& path = config_.path_prefix();
+    if (path.size() > 0 && path[path.size() - 1] == '/') {
+      ENVOY_LOG(warn, "Remove last slash of path_prefix: {}", path);
+      config_.set_path_prefix(path.substr(0, path.size() - 1));
+    }
+  }
+}
+
+bool ConfigParserImpl::rewrite(absl::string_view origin_path, std::string& new_path) const {
+  if (config_.has_constant_path()) {
+    return constPath(std::string(origin_path), new_path);
+  }
+
+  new_path = absl::StrCat(config_.path_prefix(), origin_path);
+  ENVOY_LOG(debug, "Use path prefix: new path: {}", new_path);
+  return true;
+}
+
+bool ConfigParserImpl::getVariableBindings(const std::string& origin_path, std::string& query) const {
+  query = Envoy::EMPTY_STRING;
+  if (path_matcher_) {
+    std::vector<espv2::api_proxy::path_matcher::VariableBinding> variable_bindings;
+    if (path_matcher_->Lookup(kHttpMethod, origin_path, &variable_bindings) == nullptr) {
+      // mismatched case
+      ENVOY_LOG(warn, "Request path: {} doesn't match url_template: {}",
+                origin_path, config_.constant_path().url_template());
+      return false;
+    }
+
+    if (!variable_bindings.empty()) {
+      query = espv2::api_proxy::path_matcher::VariableBindingsToQueryParameters(variable_bindings);
+      ENVOY_LOG(debug, "Extracted query parameters: {}", query);
+    }
+  }
+  return true;
+}
+
+bool ConfigParserImpl::constPath(const std::string& origin_path, std::string& new_path) const {
+  std::string extracted_query_params;
+  if (!getVariableBindings(origin_path, extracted_query_params)) {
+    return false;
+  }
+
+  const auto& path_cfg = config_.constant_path();
+  new_path = path_cfg.path();
+
+  std::size_t originalQueryParamPos = origin_path.find('?');
+  if (originalQueryParamPos == std::string::npos) {
+    // No query param in original request.
+    if (!extracted_query_params.empty()) {
+      // Add extracted variable bindings.
+      absl::StrAppend(&new_path, "?", extracted_query_params);
+    }
+    ENVOY_LOG(debug, "Use constant path, new path: {}", new_path);
+    return true;
+  }
+
+  // Has query parameters in original request.
+  const std::string originalQueryParam =
+      origin_path.substr(originalQueryParamPos);
+  absl::StrAppend(&new_path, originalQueryParam);
+  if (!extracted_query_params.empty()) {
+    // Append extracted variable bindings.
+    absl::StrAppend(&new_path, "&", extracted_query_params);
+  }
+  ENVOY_LOG(debug, "Use constant path, new path: {}", new_path);
+  return true;
+}
+
+}  // namespace path_rewrite
+}  // namespace http_filters
+}  // namespace envoy
+}  // namespace espv2

--- a/src/envoy/http/path_rewrite/config_parser_impl.h
+++ b/src/envoy/http/path_rewrite/config_parser_impl.h
@@ -13,9 +13,8 @@
 // limitations under the License.
 #pragma once
 
-#include "common/common/logger.h"
-
 #include "api/envoy/v9/http/path_rewrite/config.pb.h"
+#include "common/common/logger.h"
 #include "src/api_proxy/path_matcher/path_matcher.h"
 #include "src/envoy/http/path_rewrite/config_parser.h"
 
@@ -24,25 +23,29 @@ namespace envoy {
 namespace http_filters {
 namespace path_rewrite {
 
-class ConfigParserImpl : public ConfigParser,
-                         public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
+class ConfigParserImpl
+    : public ConfigParser,
+      public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
  public:
   ConfigParserImpl(
       const ::espv2::api::envoy::v9::http::path_rewrite::PerRouteFilterConfig&
-      config);
+          config);
 
-  bool rewrite(absl::string_view origin_path, std::string& new_path) const override;
+  bool rewrite(absl::string_view origin_path,
+               std::string& new_path) const override;
 
  private:
   // rewrite const path.
   bool constPath(const std::string& origin_path, std::string& new_path) const;
   // extract query parameters from variable bindings
-  bool getVariableBindings(const std::string& origin_path, std::string& query) const;
+  bool getVariableBindings(const std::string& origin_path,
+                           std::string& query) const;
 
   // the per-route config
   ::espv2::api::envoy::v9::http::path_rewrite::PerRouteFilterConfig config_;
   // path matcher for extracting variable binding.
-  ::espv2::api_proxy::path_matcher::PathMatcherPtr<const ::espv2::api::envoy::v9::http::path_rewrite::PerRouteFilterConfig*>
+  ::espv2::api_proxy::path_matcher::PathMatcherPtr<
+      const ::espv2::api::envoy::v9::http::path_rewrite::PerRouteFilterConfig*>
       path_matcher_;
 };
 

--- a/src/envoy/http/path_rewrite/config_parser_impl.h
+++ b/src/envoy/http/path_rewrite/config_parser_impl.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include "api/envoy/v9/http/path_rewrite/config.pb.h"
+#include "api/envoy/v9/http/path_rewrite/config.pb.validate.h"
 #include "common/common/logger.h"
 #include "src/api_proxy/path_matcher/path_matcher.h"
 #include "src/envoy/http/path_rewrite/config_parser.h"

--- a/src/envoy/http/path_rewrite/config_parser_impl.h
+++ b/src/envoy/http/path_rewrite/config_parser_impl.h
@@ -1,0 +1,52 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include "common/common/logger.h"
+
+#include "api/envoy/v9/http/path_rewrite/config.pb.h"
+#include "src/api_proxy/path_matcher/path_matcher.h"
+#include "src/envoy/http/path_rewrite/config_parser.h"
+
+namespace espv2 {
+namespace envoy {
+namespace http_filters {
+namespace path_rewrite {
+
+class ConfigParserImpl : public ConfigParser,
+                         public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
+ public:
+  ConfigParserImpl(
+      const ::espv2::api::envoy::v9::http::path_rewrite::PerRouteFilterConfig&
+      config);
+
+  bool rewrite(absl::string_view origin_path, std::string& new_path) const override;
+
+ private:
+  // rewrite const path.
+  bool constPath(const std::string& origin_path, std::string& new_path) const;
+  // extract query parameters from variable bindings
+  bool getVariableBindings(const std::string& origin_path, std::string& query) const;
+
+  // the per-route config
+  ::espv2::api::envoy::v9::http::path_rewrite::PerRouteFilterConfig config_;
+  // path matcher for extracting variable binding.
+  ::espv2::api_proxy::path_matcher::PathMatcherPtr<const ::espv2::api::envoy::v9::http::path_rewrite::PerRouteFilterConfig*>
+      path_matcher_;
+};
+
+}  // namespace path_rewrite
+}  // namespace http_filters
+}  // namespace envoy
+}  // namespace espv2

--- a/src/envoy/http/path_rewrite/config_parser_impl_test.cc
+++ b/src/envoy/http/path_rewrite/config_parser_impl_test.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "src/envoy/http/path_rewrite/config_parser_impl.h"
+
 #include "google/protobuf/text_format.h"
 #include "gtest/gtest.h"
-
 
 namespace espv2 {
 namespace envoy {
@@ -25,12 +25,12 @@ namespace path_rewrite {
 class ConfigParserImplTest : public ::testing::Test {
  protected:
   void setUp(const std::string& config_str) {
-    google::protobuf::TextFormat::ParseFromString(config_str,
-                                                  &proto_config_);
+    google::protobuf::TextFormat::ParseFromString(config_str, &proto_config_);
     obj_ = std::make_unique<ConfigParserImpl>(proto_config_);
   }
 
-  ::espv2::api::envoy::v9::http::path_rewrite::PerRouteFilterConfig proto_config_;
+  ::espv2::api::envoy::v9::http::path_rewrite::PerRouteFilterConfig
+      proto_config_;
   std::unique_ptr<ConfigParserImpl> obj_;
   std::string new_path_;
 };
@@ -71,7 +71,6 @@ TEST_F(ConfigParserImplTest, PathPrefixBasicRoot) {
   EXPECT_TRUE(obj_->rewrite("/bar?xyz=123", new_path_));
   EXPECT_EQ(new_path_, "/bar?xyz=123");
 }
-
 
 TEST_F(ConfigParserImplTest, ConstantPathNoUrlTemplate) {
   setUp(R"(
@@ -140,7 +139,6 @@ TEST_F(ConfigParserImplTest, ConstantPathNoUrlTemplateRoot) {
   EXPECT_TRUE(obj_->rewrite("/bar?xyz=123", new_path_));
   EXPECT_EQ(new_path_, "/?xyz=123");
 }
-
 
 }  // namespace path_rewrite
 }  // namespace http_filters

--- a/src/envoy/http/path_rewrite/config_parser_impl_test.cc
+++ b/src/envoy/http/path_rewrite/config_parser_impl_test.cc
@@ -1,0 +1,148 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/envoy/http/path_rewrite/config_parser_impl.h"
+#include "google/protobuf/text_format.h"
+#include "gtest/gtest.h"
+
+
+namespace espv2 {
+namespace envoy {
+namespace http_filters {
+namespace path_rewrite {
+
+class ConfigParserImplTest : public ::testing::Test {
+ protected:
+  void setUp(const std::string& config_str) {
+    google::protobuf::TextFormat::ParseFromString(config_str,
+                                                  &proto_config_);
+    obj_ = std::make_unique<ConfigParserImpl>(proto_config_);
+  }
+
+  ::espv2::api::envoy::v9::http::path_rewrite::PerRouteFilterConfig proto_config_;
+  std::unique_ptr<ConfigParserImpl> obj_;
+  std::string new_path_;
+};
+
+TEST_F(ConfigParserImplTest, PathPrefixBasic) {
+  setUp(R"(
+  path_prefix: "/foo"
+)");
+
+  EXPECT_TRUE(obj_->rewrite("/bar", new_path_));
+  EXPECT_EQ(new_path_, "/foo/bar");
+
+  EXPECT_TRUE(obj_->rewrite("/bar?xyz=123", new_path_));
+  EXPECT_EQ(new_path_, "/foo/bar?xyz=123");
+}
+
+TEST_F(ConfigParserImplTest, PathPrefixRemoveLastSlash) {
+  setUp(R"(
+  path_prefix: "/foo/"
+)");
+
+  EXPECT_TRUE(obj_->rewrite("/bar", new_path_));
+  EXPECT_EQ(new_path_, "/foo/bar");
+
+  EXPECT_TRUE(obj_->rewrite("/bar?xyz=123", new_path_));
+  EXPECT_EQ(new_path_, "/foo/bar?xyz=123");
+}
+
+TEST_F(ConfigParserImplTest, PathPrefixBasicRoot) {
+  // This is no-op, should not be used
+  setUp(R"(
+  path_prefix: "/"
+)");
+
+  EXPECT_TRUE(obj_->rewrite("/bar", new_path_));
+  EXPECT_EQ(new_path_, "/bar");
+
+  EXPECT_TRUE(obj_->rewrite("/bar?xyz=123", new_path_));
+  EXPECT_EQ(new_path_, "/bar?xyz=123");
+}
+
+
+TEST_F(ConfigParserImplTest, ConstantPathNoUrlTemplate) {
+  setUp(R"(
+  constant_path: {
+     path: "/foo"
+  }
+)");
+
+  // /bar => /foo
+  EXPECT_TRUE(obj_->rewrite("/bar", new_path_));
+  EXPECT_EQ(new_path_, "/foo");
+
+  // /bar?xyz=123 => /foo?xyz=123
+  EXPECT_TRUE(obj_->rewrite("/bar?xyz=123", new_path_));
+  EXPECT_EQ(new_path_, "/foo?xyz=123");
+}
+
+TEST_F(ConfigParserImplTest, ConstantPathUrlTemplate) {
+  setUp(R"(
+  constant_path: {
+     path: "/foo"
+     url_template: "/bar/{abc}"
+  }
+)");
+
+  // A  mistmatched case
+  EXPECT_FALSE(obj_->rewrite("/foo/bar", new_path_));
+
+  // /bar/567 => /foo?abc=567
+  EXPECT_TRUE(obj_->rewrite("/bar/567", new_path_));
+  EXPECT_EQ(new_path_, "/foo?abc=567");
+
+  // /bar/567?xyz=123 => /foo?xyz=123&abc=567
+  EXPECT_TRUE(obj_->rewrite("/bar/567?xyz=123", new_path_));
+  EXPECT_EQ(new_path_, "/foo?xyz=123&abc=567");
+}
+
+TEST_F(ConfigParserImplTest, ConstantPathNoUrlTemplateRemovedLastSlash) {
+  setUp(R"(
+  constant_path: {
+     path: "/foo/"
+  }
+)");
+
+  // /bar => /foo
+  EXPECT_TRUE(obj_->rewrite("/bar", new_path_));
+  EXPECT_EQ(new_path_, "/foo");
+
+  // /bar?xyz=123 => /foo?xyz=123
+  EXPECT_TRUE(obj_->rewrite("/bar?xyz=123", new_path_));
+  EXPECT_EQ(new_path_, "/foo?xyz=123");
+}
+
+TEST_F(ConfigParserImplTest, ConstantPathNoUrlTemplateRoot) {
+  setUp(R"(
+  constant_path: {
+     path: "/"
+  }
+)");
+
+  // /bar => /
+  EXPECT_TRUE(obj_->rewrite("/bar", new_path_));
+  EXPECT_EQ(new_path_, "/");
+
+  // /bar?xyz=123 => /foo?xyz=123
+  EXPECT_TRUE(obj_->rewrite("/bar?xyz=123", new_path_));
+  EXPECT_EQ(new_path_, "/?xyz=123");
+}
+
+
+}  // namespace path_rewrite
+}  // namespace http_filters
+}  // namespace envoy
+}  // namespace espv2


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

Decide to make it as several small PR.  This is the first PR with
* add per-route filter config
* config_parser and its unit-test.  This is the core logic.  

PR2 add envoy filter related code, and all c++ code changes should be completed
PR3 config-mgr changes to use the new filter, and fix all tests
PR4: remove old backend_router envoy filter.

this pr just adds its config for review.