### PR TITLE
b/170679093: Format with `clang-format-10`

### DIFF
--- a/api/envoy/v9/http/grpc_metadata_scrubber/config.proto
+++ b/api/envoy/v9/http/grpc_metadata_scrubber/config.proto
@@ -19,5 +19,4 @@ package espv2.api.envoy.v9.http.grpc_metadata_scrubber;
 // grpc_metadata_scrubber filter doesn't need any config.
 // But a config protobuf type is required by FilterFactory.
 // Hence defines an empty FilterConfig here.
-message FilterConfig {
-}
+message FilterConfig {}

--- a/src/api_proxy/path_matcher/http_template.cc
+++ b/src/api_proxy/path_matcher/http_template.cc
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "src/api_proxy/path_matcher/http_template.h"
+
 #include <cassert>
 #include <string>
 #include <vector>
-
-#include "src/api_proxy/path_matcher/http_template.h"
 
 namespace espv2 {
 namespace api_proxy {

--- a/src/api_proxy/path_matcher/http_template_fuzz_test.cc
+++ b/src/api_proxy/path_matcher/http_template_fuzz_test.cc
@@ -1,7 +1,6 @@
 #include "src/api_proxy/path_matcher/http_template.h"
 #include "test/fuzz/fuzz_runner.h"
 #include "test/fuzz/utility.h"
-
 #include "tests/fuzz/structured_inputs/http_template.pb.validate.h"
 
 namespace espv2 {

--- a/src/api_proxy/path_matcher/http_template_test.cc
+++ b/src/api_proxy/path_matcher/http_template_test.cc
@@ -13,11 +13,12 @@
 // limitations under the License.
 
 #include "src/api_proxy/path_matcher/http_template.h"
-#include "gtest/gtest.h"
 
 #include <ostream>
 #include <string>
 #include <vector>
+
+#include "gtest/gtest.h"
 
 namespace espv2 {
 namespace api_proxy {

--- a/src/api_proxy/path_matcher/path_matcher_node.cc
+++ b/src/api_proxy/path_matcher/path_matcher_node.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "src/api_proxy/path_matcher/path_matcher_node.h"
+
 #include "src/api_proxy/path_matcher/http_template.h"
 
 namespace espv2 {

--- a/src/api_proxy/service_control/logs_metrics_loader.cc
+++ b/src/api_proxy/service_control/logs_metrics_loader.cc
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 #include "src/api_proxy/service_control/logs_metrics_loader.h"
-#include "src/api_proxy/service_control/request_builder.h"
 
 #include <algorithm>
+
+#include "src/api_proxy/service_control/request_builder.h"
 
 namespace espv2 {
 namespace api_proxy {

--- a/src/api_proxy/service_control/logs_metrics_loader_test.cc
+++ b/src/api_proxy/service_control/logs_metrics_loader_test.cc
@@ -14,10 +14,9 @@
 
 #include "src/api_proxy/service_control/logs_metrics_loader.h"
 
+#include "gmock/gmock.h"
 #include "google/protobuf/io/zero_copy_stream_impl_lite.h"
 #include "google/protobuf/text_format.h"
-
-#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace espv2 {

--- a/src/api_proxy/service_control/request_builder.cc
+++ b/src/api_proxy/service_control/request_builder.cc
@@ -14,6 +14,7 @@
 #include "src/api_proxy/service_control/request_builder.h"
 
 #include <time.h>
+
 #include <chrono>
 #include <functional>
 

--- a/src/api_proxy/service_control/request_builder.h
+++ b/src/api_proxy/service_control/request_builder.h
@@ -22,7 +22,6 @@
 #include "google/api/servicecontrol/v1/service_controller.pb.h"
 #include "google/protobuf/stubs/status.h"
 #include "google/protobuf/timestamp.pb.h"
-
 #include "src/api_proxy/service_control/request_info.h"
 
 namespace espv2 {

--- a/src/api_proxy/service_control/request_builder_test.cc
+++ b/src/api_proxy/service_control/request_builder_test.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "src/api_proxy/service_control/request_builder.h"
-#include "gtest/gtest.h"
 
 #include <assert.h>
+
 #include <chrono>
 #include <fstream>
 #include <string>
@@ -24,7 +24,7 @@
 #include "absl/strings/str_replace.h"
 #include "google/protobuf/struct.pb.h"
 #include "google/protobuf/text_format.h"
-
+#include "gtest/gtest.h"
 #include "src/api_proxy/utils/version.h"
 
 namespace espv2 {

--- a/src/api_proxy/service_control/request_info.h
+++ b/src/api_proxy/service_control/request_info.h
@@ -14,12 +14,12 @@
 
 #pragma once
 
-#include "google/api/quota.pb.h"
-#include "google/protobuf/stubs/status.h"
-
 #include <chrono>
 #include <memory>
 #include <string>
+
+#include "google/api/quota.pb.h"
+#include "google/protobuf/stubs/status.h"
 
 namespace espv2 {
 namespace api_proxy {

--- a/src/envoy/http/backend_auth/config_parser_impl.cc
+++ b/src/envoy/http/backend_auth/config_parser_impl.cc
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "src/envoy/http/backend_auth/config_parser_impl.h"
+
 #include <memory>
 
 #include "common/common/assert.h"
 #include "google/protobuf/util/time_util.h"
-#include "src/envoy/http/backend_auth/config_parser_impl.h"
 
 namespace espv2 {
 namespace envoy {

--- a/src/envoy/http/backend_auth/config_parser_impl_test.cc
+++ b/src/envoy/http/backend_auth/config_parser_impl_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "src/envoy/http/backend_auth/config_parser_impl.h"
+
 #include "common/common/empty_string.h"
 #include "gmock/gmock.h"
 #include "google/protobuf/text_format.h"

--- a/src/envoy/http/backend_routing/filter_fuzz_test.cc
+++ b/src/envoy/http/backend_routing/filter_fuzz_test.cc
@@ -1,15 +1,13 @@
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "src/envoy/http/backend_routing/filter.h"
+#include "src/envoy/utils/filter_state_utils.h"
 #include "test/extensions/filters/http/common/fuzz/uber_filter.h"
 #include "test/fuzz/fuzz_runner.h"
 #include "test/fuzz/utility.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/server/mocks.h"
-
-#include "src/envoy/http/backend_routing/filter.h"
-#include "src/envoy/utils/filter_state_utils.h"
 #include "tests/fuzz/structured_inputs/backend_routing_filter.pb.validate.h"
-
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 
 namespace espv2 {
 namespace envoy {

--- a/src/envoy/http/grpc_metadata_scrubber/filter.cc
+++ b/src/envoy/http/grpc_metadata_scrubber/filter.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <string>
-
 #include "src/envoy/http/grpc_metadata_scrubber/filter.h"
+
+#include <string>
 
 #include "common/grpc/common.h"
 #include "common/http/headers.h"

--- a/src/envoy/http/grpc_metadata_scrubber/filter.h
+++ b/src/envoy/http/grpc_metadata_scrubber/filter.h
@@ -14,10 +14,10 @@
 
 #pragma once
 
+#include <string>
+
 #include "extensions/filters/http/common/pass_through_filter.h"
 #include "src/envoy/http/grpc_metadata_scrubber/filter_config.h"
-
-#include <string>
 
 namespace espv2 {
 namespace envoy {

--- a/src/envoy/http/grpc_metadata_scrubber/filter_factory.cc
+++ b/src/envoy/http/grpc_metadata_scrubber/filter_factory.cc
@@ -14,10 +14,9 @@
 
 #include "api/envoy/v9/http/grpc_metadata_scrubber/config.pb.h"
 #include "api/envoy/v9/http/grpc_metadata_scrubber/config.pb.validate.h"
-#include "src/envoy/http/grpc_metadata_scrubber/filter.h"
-
 #include "envoy/registry/registry.h"
 #include "extensions/filters/http/common/factory_base.h"
+#include "src/envoy/http/grpc_metadata_scrubber/filter.h"
 
 namespace espv2 {
 namespace envoy {

--- a/src/envoy/http/grpc_metadata_scrubber/filter_test.cc
+++ b/src/envoy/http/grpc_metadata_scrubber/filter_test.cc
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 #include "src/envoy/http/grpc_metadata_scrubber/filter.h"
+
 #include "common/common/empty_string.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/server/mocks.h"
 #include "test/test_common/utility.h"
-
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 
 namespace espv2 {
 namespace envoy {

--- a/src/envoy/http/path_matcher/filter.cc
+++ b/src/envoy/http/path_matcher/filter.cc
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "src/envoy/http/path_matcher/filter.h"
+
 #include <string>
 
 #include "common/http/utility.h"
-
 #include "src/api_proxy/path_matcher/variable_binding_utils.h"
-#include "src/envoy/http/path_matcher/filter.h"
 #include "src/envoy/utils/filter_state_utils.h"
 #include "src/envoy/utils/http_header_utils.h"
 #include "src/envoy/utils/rc_detail_utils.h"

--- a/src/envoy/http/path_matcher/filter.h
+++ b/src/envoy/http/path_matcher/filter.h
@@ -14,10 +14,10 @@
 
 #pragma once
 
+#include <string>
+
 #include "extensions/filters/http/common/pass_through_filter.h"
 #include "src/envoy/http/path_matcher/filter_config.h"
-
-#include <string>
 
 namespace espv2 {
 namespace envoy {

--- a/src/envoy/http/path_matcher/filter_config.cc
+++ b/src/envoy/http/path_matcher/filter_config.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "src/envoy/http/path_matcher/filter_config.h"
+
 #include "common/common/empty_string.h"
 
 namespace espv2 {

--- a/src/envoy/http/path_matcher/filter_config_test.cc
+++ b/src/envoy/http/path_matcher/filter_config_test.cc
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 #include "src/envoy/http/path_matcher/filter_config.h"
-#include "common/common/empty_string.h"
-#include "test/mocks/server/mocks.h"
-#include "test/test_common/utility.h"
 
+#include "common/common/empty_string.h"
 #include "gmock/gmock.h"
 #include "google/protobuf/text_format.h"
 #include "gtest/gtest.h"
+#include "test/mocks/server/mocks.h"
+#include "test/test_common/utility.h"
 
 namespace espv2 {
 namespace envoy {

--- a/src/envoy/http/path_matcher/filter_factory.cc
+++ b/src/envoy/http/path_matcher/filter_factory.cc
@@ -14,11 +14,10 @@
 
 #include "api/envoy/v9/http/path_matcher/config.pb.h"
 #include "api/envoy/v9/http/path_matcher/config.pb.validate.h"
-#include "src/envoy/http/path_matcher/filter.h"
-#include "src/envoy/http/path_matcher/filter_config.h"
-
 #include "envoy/registry/registry.h"
 #include "extensions/filters/http/common/factory_base.h"
+#include "src/envoy/http/path_matcher/filter.h"
+#include "src/envoy/http/path_matcher/filter_config.h"
 
 namespace espv2 {
 namespace envoy {

--- a/src/envoy/http/path_matcher/filter_fuzz_test.cc
+++ b/src/envoy/http/path_matcher/filter_fuzz_test.cc
@@ -1,15 +1,13 @@
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "src/envoy/http/path_matcher/filter.h"
+#include "src/envoy/utils/filter_state_utils.h"
 #include "test/extensions/filters/http/common/fuzz/uber_filter.h"
 #include "test/fuzz/fuzz_runner.h"
 #include "test/fuzz/utility.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/server/mocks.h"
-
-#include "src/envoy/http/path_matcher/filter.h"
-#include "src/envoy/utils/filter_state_utils.h"
 #include "tests/fuzz/structured_inputs/path_matcher_filter.pb.validate.h"
-
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 
 namespace espv2 {
 namespace envoy {

--- a/src/envoy/http/path_matcher/filter_test.cc
+++ b/src/envoy/http/path_matcher/filter_test.cc
@@ -13,14 +13,14 @@
 // limitations under the License.
 
 #include "src/envoy/http/path_matcher/filter.h"
-#include "common/common/empty_string.h"
-#include "src/envoy/utils/filter_state_utils.h"
-#include "test/mocks/server/mocks.h"
-#include "test/test_common/utility.h"
 
+#include "common/common/empty_string.h"
 #include "gmock/gmock.h"
 #include "google/protobuf/text_format.h"
 #include "gtest/gtest.h"
+#include "src/envoy/utils/filter_state_utils.h"
+#include "test/mocks/server/mocks.h"
+#include "test/test_common/utility.h"
 
 namespace espv2 {
 namespace envoy {

--- a/src/envoy/http/service_control/client_cache.cc
+++ b/src/envoy/http/service_control/client_cache.cc
@@ -344,11 +344,12 @@ CancelFunc ClientCache::callCheck(const CheckRequest& request,
                   "Service Control cache query: Check");
 
   auto* response = new CheckResponse;
-  client_->Check(request, response,
-                 [this, response, on_done](const Status& http_status) {
-                   handleCheckResponse(http_status, response, on_done);
-                 },
-                 check_transport);
+  client_->Check(
+      request, response,
+      [this, response, on_done](const Status& http_status) {
+        handleCheckResponse(http_status, response, on_done);
+      },
+      check_transport);
   return cancel_fn;
 }
 

--- a/src/envoy/http/service_control/client_cache_test.cc
+++ b/src/envoy/http/service_control/client_cache_test.cc
@@ -14,11 +14,10 @@
 
 #include "src/envoy/http/service_control/client_cache.h"
 
+#include "absl/functional/bind_front.h"
 #include "common/common/empty_string.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-
-#include "absl/functional/bind_front.h"
 #include "src/envoy/http/service_control/mocks.h"
 #include "src/envoy/http/service_control/service_control_callback_func.h"
 #include "test/mocks/common.h"

--- a/src/envoy/http/service_control/config_parser.h
+++ b/src/envoy/http/service_control/config_parser.h
@@ -16,12 +16,10 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/strings/string_view.h"
-
-#include "common/protobuf/utility.h"
-#include "envoy/router/router.h"
-
 #include "api/envoy/v9/http/service_control/config.pb.h"
 #include "api/envoy/v9/http/service_control/requirement.pb.h"
+#include "common/protobuf/utility.h"
+#include "envoy/router/router.h"
 #include "src/envoy/http/service_control/service_control_call.h"
 
 namespace espv2 {

--- a/src/envoy/http/service_control/config_parser_test.cc
+++ b/src/envoy/http/service_control/config_parser_test.cc
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 #include "src/envoy/http/service_control/config_parser.h"
-#include "src/envoy/http/service_control/mocks.h"
-#include "test/test_common/utility.h"
 
 #include "gmock/gmock.h"
 #include "google/protobuf/text_format.h"
 #include "gtest/gtest.h"
+#include "src/envoy/http/service_control/mocks.h"
+#include "test/test_common/utility.h"
 
 namespace espv2 {
 namespace envoy {

--- a/src/envoy/http/service_control/filter.cc
+++ b/src/envoy/http/service_control/filter.cc
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "src/envoy/http/service_control/filter.h"
+
 #include <chrono>
 
 #include "common/grpc/status.h"
 #include "envoy/http/header_map.h"
-#include "src/envoy/http/service_control/filter.h"
 #include "src/envoy/http/service_control/handler.h"
 #include "src/envoy/utils/http_header_utils.h"
 #include "src/envoy/utils/rc_detail_utils.h"

--- a/src/envoy/http/service_control/filter.h
+++ b/src/envoy/http/service_control/filter.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "common/common/logger.h"
 #include "envoy/access_log/access_log.h"
 #include "envoy/http/filter.h"
@@ -21,8 +23,6 @@
 #include "extensions/filters/http/common/pass_through_filter.h"
 #include "src/envoy/http/service_control/filter_stats.h"
 #include "src/envoy/http/service_control/handler.h"
-
-#include <string>
 
 namespace espv2 {
 namespace envoy {

--- a/src/envoy/http/service_control/filter_factory.cc
+++ b/src/envoy/http/service_control/filter_factory.cc
@@ -14,11 +14,10 @@
 
 #include "api/envoy/v9/http/service_control/config.pb.h"
 #include "api/envoy/v9/http/service_control/config.pb.validate.h"
-#include "src/envoy/http/service_control/filter.h"
-#include "src/envoy/http/service_control/filter_config.h"
-
 #include "envoy/registry/registry.h"
 #include "extensions/filters/http/common/factory_base.h"
+#include "src/envoy/http/service_control/filter.h"
+#include "src/envoy/http/service_control/filter_config.h"
 
 namespace espv2 {
 namespace envoy {

--- a/src/envoy/http/service_control/filter_fuzz_test.cc
+++ b/src/envoy/http/service_control/filter_fuzz_test.cc
@@ -1,24 +1,22 @@
+#include <fstream>
+#include <stdexcept>
+#include <string>
+
+#include "api/envoy/v9/http/service_control/config.pb.validate.h"
 #include "common/http/message_impl.h"
 #include "common/tracing/http_tracer_impl.h"
+#include "gmock/gmock.h"
 #include "google/protobuf/text_format.h"
+#include "gtest/gtest.h"
+#include "src/envoy/http/service_control/filter.h"
+#include "src/envoy/http/service_control/filter_config.h"
+#include "src/envoy/utils/filter_state_utils.h"
 #include "test/extensions/filters/http/common/fuzz/uber_filter.h"
 #include "test/fuzz/fuzz_runner.h"
 #include "test/fuzz/utility.h"
 #include "test/mocks/http/mocks.h"
 #include "test/mocks/server/mocks.h"
-
-#include "api/envoy/v9/http/service_control/config.pb.validate.h"
-#include "src/envoy/http/service_control/filter.h"
-#include "src/envoy/http/service_control/filter_config.h"
-#include "src/envoy/utils/filter_state_utils.h"
 #include "tests/fuzz/structured_inputs/service_control_filter.pb.validate.h"
-
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-
-#include <fstream>
-#include <stdexcept>
-#include <string>
 
 namespace espv2 {
 namespace envoy {

--- a/src/envoy/http/service_control/filter_stats.cc
+++ b/src/envoy/http/service_control/filter_stats.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/protobuf/stubs/status.h"
-
 #include "src/envoy/http/service_control/filter_stats.h"
+
+#include "google/protobuf/stubs/status.h"
 
 using ::google::protobuf::util::Status;
 using ::google::protobuf::util::error::Code;

--- a/src/envoy/http/service_control/filter_stats_test.cc
+++ b/src/envoy/http/service_control/filter_stats_test.cc
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "src/envoy/http/service_control/filter_stats.h"
+
 #include "test/mocks/server/mocks.h"
 #include "test/test_common/utility.h"
-
-#include "src/envoy/http/service_control/filter_stats.h"
 
 using ::Envoy::Server::Configuration::MockFactoryContext;
 using ::google::protobuf::util::Status;

--- a/src/envoy/http/service_control/filter_test.cc
+++ b/src/envoy/http/service_control/filter_test.cc
@@ -12,19 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "src/envoy/http/service_control/filter.h"
+
 #include "common/common/empty_string.h"
 #include "envoy/http/header_map.h"
 #include "gmock/gmock.h"
 #include "google/protobuf/text_format.h"
 #include "gtest/gtest.h"
+#include "src/envoy/http/service_control/handler.h"
+#include "src/envoy/http/service_control/mocks.h"
 #include "test/mocks/server/mocks.h"
 #include "test/mocks/stats/mocks.h"
 #include "test/mocks/tracing/mocks.h"
 #include "test/test_common/utility.h"
-
-#include "src/envoy/http/service_control/filter.h"
-#include "src/envoy/http/service_control/handler.h"
-#include "src/envoy/http/service_control/mocks.h"
 
 using Envoy::Http::MockStreamDecoderFilterCallbacks;
 using Envoy::Server::Configuration::MockFactoryContext;

--- a/src/envoy/http/service_control/handler_impl.cc
+++ b/src/envoy/http/service_control/handler_impl.cc
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "src/envoy/http/service_control/handler_impl.h"
+
 #include <chrono>
 
 #include "absl/strings/match.h"
 #include "common/common/empty_string.h"
 #include "common/http/headers.h"
 #include "common/http/utility.h"
-#include "src/envoy/http/service_control/handler_impl.h"
 #include "src/envoy/http/service_control/handler_utils.h"
 #include "src/envoy/utils/filter_state_utils.h"
 #include "src/envoy/utils/http_header_utils.h"

--- a/src/envoy/http/service_control/handler_impl_test.cc
+++ b/src/envoy/http/service_control/handler_impl_test.cc
@@ -13,19 +13,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "src/envoy/http/service_control/handler_impl.h"
+
 #include "common/common/empty_string.h"
 #include "envoy/http/header_map.h"
 #include "gmock/gmock.h"
 #include "google/protobuf/text_format.h"
 #include "gtest/gtest.h"
+#include "src/envoy/http/service_control/mocks.h"
+#include "src/envoy/utils/filter_state_utils.h"
 #include "test/mocks/router/mocks.h"
 #include "test/mocks/server/mocks.h"
 #include "test/mocks/tracing/mocks.h"
 #include "test/test_common/test_time.h"
-
-#include "src/envoy/http/service_control/handler_impl.h"
-#include "src/envoy/http/service_control/mocks.h"
-#include "src/envoy/utils/filter_state_utils.h"
 
 namespace espv2 {
 namespace envoy {

--- a/src/envoy/http/service_control/handler_utils.cc
+++ b/src/envoy/http/service_control/handler_utils.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "src/envoy/http/service_control/handler_utils.h"
+
 #include <sstream>
 #include <vector>
 
@@ -24,7 +26,6 @@
 #include "envoy/server/filter_config.h"
 #include "extensions/filters/http/well_known_names.h"
 #include "src/api_proxy/service_control/request_builder.h"
-#include "src/envoy/http/service_control/handler_utils.h"
 
 using ::espv2::api::envoy::v9::http::service_control::ApiKeyLocation;
 using ::espv2::api::envoy::v9::http::service_control::Service;

--- a/src/envoy/http/service_control/http_call_test.cc
+++ b/src/envoy/http/service_control/http_call_test.cc
@@ -13,17 +13,17 @@
 // limitations under the License.
 
 #include "src/envoy/http/service_control/http_call.h"
+
+#include <vector>
+
 #include "absl/strings/string_view.h"
 #include "common/http/headers.h"
 #include "common/http/message_impl.h"
 #include "common/tracing/http_tracer_impl.h"
 #include "envoy/http/async_client.h"
+#include "gmock/gmock.h"
 #include "google/api/servicecontrol/v1/service_controller.pb.h"
 #include "google/protobuf/stubs/status.h"
-
-#include <vector>
-
-#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "test/mocks/common.h"
 #include "test/mocks/event/mocks.h"

--- a/src/envoy/http/service_control/service_control_callback_func.h
+++ b/src/envoy/http/service_control/service_control_callback_func.h
@@ -14,6 +14,7 @@
 
 #pragma once
 #include <functional>
+
 #include "src/api_proxy/service_control/request_info.h"
 
 namespace espv2 {

--- a/src/envoy/token/iam_token_info_fuzz_test.cc
+++ b/src/envoy/token/iam_token_info_fuzz_test.cc
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "src/envoy/token/iam_token_info.h"
 #include "test/fuzz/fuzz_runner.h"
 #include "test/fuzz/utility.h"
-
-#include "src/envoy/token/iam_token_info.h"
 #include "tests/fuzz/structured_inputs/iam_token_info.pb.validate.h"
 
 namespace espv2 {

--- a/src/envoy/token/imds_token_info.cc
+++ b/src/envoy/token/imds_token_info.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "src/envoy/token/imds_token_info.h"
+
 #include "absl/strings/str_cat.h"
 #include "common/http/headers.h"
 #include "common/http/message_impl.h"

--- a/src/envoy/token/imds_token_info_fuzz_test.cc
+++ b/src/envoy/token/imds_token_info_fuzz_test.cc
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "src/envoy/token/imds_token_info.h"
 #include "test/fuzz/fuzz_runner.h"
 #include "test/fuzz/utility.h"
-
-#include "src/envoy/token/imds_token_info.h"
 #include "tests/fuzz/structured_inputs/imds_token_info.pb.validate.h"
 
 namespace espv2 {

--- a/src/envoy/token/token_subscriber.cc
+++ b/src/envoy/token/token_subscriber.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "src/envoy/token/token_subscriber.h"
+
 #include "absl/strings/str_cat.h"
 #include "common/common/assert.h"
 #include "common/common/enum_to_int.h"

--- a/src/envoy/token/token_subscriber_test.cc
+++ b/src/envoy/token/token_subscriber_test.cc
@@ -13,16 +13,15 @@
 // limitations under the License.
 
 #include "src/envoy/token/token_subscriber.h"
-#include "src/envoy/token/mocks.h"
 
 #include "common/http/message_impl.h"
 #include "common/tracing/http_tracer_impl.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "src/envoy/token/mocks.h"
 #include "test/mocks/init/mocks.h"
 #include "test/mocks/server/mocks.h"
 #include "test/test_common/utility.h"
-
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 
 namespace espv2 {
 namespace envoy {

--- a/src/envoy/utils/http_header_utils.cc
+++ b/src/envoy/utils/http_header_utils.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "src/envoy/utils/http_header_utils.h"
+
 #include "common/common/empty_string.h"
 #include "common/http/headers.h"
 

--- a/src/envoy/utils/http_header_utils_test.cc
+++ b/src/envoy/utils/http_header_utils_test.cc
@@ -15,10 +15,9 @@
 #include "src/envoy/utils/http_header_utils.h"
 
 #include "envoy/http/header_map.h"
-#include "test/test_common/utility.h"
-
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "test/test_common/utility.h"
 
 namespace espv2 {
 namespace envoy {

--- a/src/envoy/utils/json_struct.cc
+++ b/src/envoy/utils/json_struct.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "json_struct.h"
+
 #include "google/protobuf/util/time_util.h"
 
 using ::google::protobuf::Value;

--- a/src/envoy/utils/json_struct_fuzz_test.cc
+++ b/src/envoy/utils/json_struct_fuzz_test.cc
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "json_struct.h"
 #include "test/fuzz/fuzz_runner.h"
 #include "test/fuzz/utility.h"
-
-#include "json_struct.h"
 #include "tests/fuzz/structured_inputs/json_struct.pb.validate.h"
 
 namespace espv2 {

--- a/src/envoy/utils/rc_detail_utils.cc
+++ b/src/envoy/utils/rc_detail_utils.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "rc_detail_utils.h"
+
 #include <iostream>
 
 namespace espv2 {

--- a/src/envoy/utils/rc_detail_utils.h
+++ b/src/envoy/utils/rc_detail_utils.h
@@ -14,6 +14,7 @@
 
 #pragma once
 #include <string>
+
 #include "absl/strings/str_cat.h"
 
 namespace espv2 {


### PR DESCRIPTION
No other changes in this PR other than formatting with `clang-format-10`.

Signed-off-by: Teju Nareddy <nareddyt@google.com>