### PR TITLE
Update DEVELOPER.md to install `lld-10`

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -26,7 +26,7 @@ wget -O- https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add -
 echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-10 main" >> /etc/apt/sources.list
 sudo apt-get update
 sudo apt-get install -y llvm-10-dev libclang-10-dev clang-10 \
-    clang-tools-10 clang-format-10 xz-utils lld
+    clang-tools-10 clang-format-10 xz-utils lld-10
 ```
 
 ## Install Golang


### PR DESCRIPTION
PR #375 changes `.bazelrc` to link with `lld-10` instead of just `lld`. ESPv2 devs need to install `lld-10` specifically, otherwise an older version of the linker may be used.