### PR TITLE
Fix serverless janitor not cleaning up Cloud Functions

### DIFF
--- a/prow/janitor.sh
+++ b/prow/janitor.sh
@@ -49,7 +49,7 @@ echo "Done cleaning up Cloud Run services"
 
 ### Cloud Functions ###
 GOOGLE_FUNCTIONS=$(gcloud functions list \
-    --filter="name ~ ^e2e-test- \
+    --filter="name ~ e2e-test- \
     AND updateTime < ${LIMIT_DATE}" \
   --format="value(name)")
 


### PR DESCRIPTION
Cloud Functions names are full resource ids. Example:
```
projects/cloudesf-testing/locations/us-central1/functions/e2e-test-e25fc32-bookstore--nk2r7
```

Fix the filter so it doesn't check from the start of the name.