### PR TITLE
b/170497119: ordering route match#1 add uriTemplate

### DIFF
--- a/src/go/util/httppattern/uri_template.go
+++ b/src/go/util/httppattern/uri_template.go
@@ -1,0 +1,397 @@
+package httppattern
+
+import (
+	"bytes"
+)
+
+// UriTemplate is used to syntax pairse uri templates. It is based on the grammar
+// on https://github.com/googleapis/googleapis/blob/e5211c547d63632963f9125e2b333185d57ff8f6/google/api/http.proto#L224.
+type UriTemplate struct {
+	Segments  []string
+	Verb      string
+	Variables []*variable
+}
+
+// The info about a variable binding {variable=subpath} in the template.
+type variable struct {
+	// Specifies the range of segments [start_segment, end_segment) the
+	// variable binds to. Both start_segment and end_segment are 0 based.
+	// end_segment can also be negative, which means that the position is
+	// specified relative to the end such that -1 corresponds to the end
+	// of the path.
+	StartSegment int
+	EndSegment   int
+
+	// The path of the protobuf field the variable binds to.
+	FieldPath []string
+
+	// Do we have a ** in the variable template?
+	HasWildcardPath bool
+}
+
+// HTTP Template Grammar:
+// Questions:
+//
+// Template = "/" | "/" Segments [ Verb ] ;
+// Segments = Segment { "/" Segment } ;
+// Segment  = "*" | "**" | LITERAL | Variable ;
+// Variable = "{" FieldPath [ "=" Segments ] "}" ;
+// FieldPath = IDENT { "." IDENT } ;
+// Verb     = ":" LITERAL ;
+type parser struct {
+	input      string
+	tb         int
+	te         int
+	inVariable bool
+	segments   []string
+	verb       string
+	variables  []*variable
+}
+
+func Parse(ht string) *UriTemplate {
+	if ht == "/" {
+		return &UriTemplate{}
+	}
+
+	p := parser{
+		input: ht,
+	}
+	if !p.parse() || !p.validateParts() {
+		return nil
+	}
+
+	return &UriTemplate{
+		Segments:  p.segments,
+		Verb:      p.verb,
+		Variables: p.variables,
+	}
+}
+
+func (p *parser) parse() bool {
+	if !p.parseTemplate() || !p.consumeAllInput() {
+		return false
+	}
+
+	p.postProcessVariables()
+	return true
+}
+
+const (
+	SingleParameterKey  = "/."
+	WildCardPathPartKey = "*"
+	WildCardPathKey     = "**"
+	InvalidChar         = byte(0)
+)
+
+// only constant path segments are allowed after '**'.
+func (p *parser) validateParts() bool {
+	foundWildCard := false
+	for i := 0; i < len(p.segments); i += 1 {
+		if !foundWildCard {
+			if p.segments[i] == WildCardPathKey {
+				foundWildCard = true
+			}
+		} else if p.segments[i] == SingleParameterKey || p.segments[i] == WildCardPathPartKey || p.segments[i] == WildCardPathKey {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Template = "/" Segments [ Verb ] ;
+func (p *parser) parseTemplate() bool {
+	// Expected '/'
+	if !p.consume('/') {
+		return false
+	}
+
+	if !p.parseSegments() {
+		return false
+	}
+
+	if p.ensureCurrent() && p.currentChar() == ':' {
+		if !p.parseVerb() {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Segments = Segment { "/" Segment } ;
+func (p *parser) parseSegments() bool {
+	if !p.parseSegment() {
+		return false
+	}
+
+	for {
+		if !p.consume('/') {
+			break
+		}
+		if !p.parseSegment() {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Segment  = "*" | "**" | LITERAL | Variable ;
+func (p *parser) parseSegment() bool {
+	markVariableHasWildcardPath := func() bool {
+		if p.inVariable && len(p.variables) > 0 {
+			p.currentVariable().HasWildcardPath = true
+			return true
+		}
+		// something's wrong we're not in a variable
+		return false
+	}
+
+	if !p.ensureCurrent() {
+		return false
+	}
+	switch p.currentChar() {
+	case '*':
+		p.consume('*')
+		if p.consume('*') {
+			// **
+			p.segments = append(p.segments, "**")
+			if p.inVariable {
+				return markVariableHasWildcardPath()
+			}
+			return true
+		} else {
+			p.segments = append(p.segments, "*")
+			return true
+		}
+	case '{':
+		return p.parseVariable()
+	default:
+		return p.parseLiteralSegment()
+	}
+}
+
+// Variable = "{" FieldPath [ "=" Segments ] "}" ;
+func (p *parser) parseVariable() bool {
+	if !p.consume('{') {
+		return false
+	}
+	if !p.startVariable() {
+		return false
+	}
+	if !p.parseFieldPath() {
+		return false
+	}
+	if p.consume('=') {
+		if !p.parseSegments() {
+			return false
+		}
+	} else {
+		p.segments = append(p.segments, "*")
+	}
+
+	if !p.endVariable() {
+		return false
+	}
+	if !p.consume('}') {
+		return false
+	}
+
+	return true
+}
+
+// FieldPath = IDENT { "." IDENT } ;
+func (p *parser) parseFieldPath() bool {
+	if !p.parseIdentifier() {
+		return false
+	}
+
+	for p.consume('.') {
+		if !p.parseIdentifier() {
+			return false
+		}
+	}
+	return true
+}
+
+// Verb     = ":" LITERAL ;
+func (p *parser) parseVerb() bool {
+	if !p.consume(':') {
+		return false
+	}
+	verb, result := p.parseLiteral()
+	if !result {
+		return false
+	}
+
+	p.verb = verb
+	return true
+}
+
+func (p *parser) parseIdentifier() bool {
+	addFieldIdentifier := func(id string) bool {
+		if p.inVariable && len(p.variables) > 0 {
+			p.currentVariable().FieldPath = append(p.currentVariable().FieldPath, id)
+			return true
+		} else {
+			// something's wrong we're not in a variable
+			return false
+		}
+	}
+
+	var idf bytes.Buffer
+	// Initialize to false to handle empty literal.
+	result := false
+	for p.nextChar() {
+		switch c := p.currentChar(); c {
+		case '.':
+			fallthrough
+		case '}':
+			fallthrough
+		case '=':
+			return result && addFieldIdentifier(idf.String())
+		default:
+			p.consume(c)
+			idf.WriteByte(c)
+			break
+		}
+		result = true
+	}
+
+	return result && addFieldIdentifier(idf.String())
+}
+
+func (p *parser) parseLiteral() (string, bool) {
+	var buffer bytes.Buffer
+	if !p.ensureCurrent() {
+		return "", false
+	}
+
+	// Initialize to false in case we encounter an empty literal.
+	result := false
+
+	for {
+		switch c := p.currentChar(); c {
+		case '/':
+			fallthrough
+		case ':':
+			fallthrough
+		case '}':
+			return buffer.String(), result
+		default:
+			p.consume(c)
+			buffer.WriteByte(c)
+			break
+		}
+		result = true
+
+		if !p.nextChar() {
+			break
+		}
+	}
+
+	return buffer.String(), result
+}
+
+func (p *parser) parseLiteralSegment() bool {
+	l, result := p.parseLiteral()
+	if !result {
+		return false
+	}
+
+	p.segments = append(p.segments, l)
+	return true
+}
+
+func (p *parser) consume(c byte) bool {
+	if p.tb >= p.te && !p.nextChar() {
+		return false
+	}
+
+	if p.currentChar() != c {
+		return false
+	}
+
+	p.tb += 1
+	return true
+}
+
+func (p *parser) consumeAllInput() bool {
+	return p.tb >= len(p.input)
+}
+
+func (p *parser) currentChar() byte {
+	if p.tb < p.te && p.te <= len(p.input) {
+		return p.input[p.te-1]
+	}
+
+	return InvalidChar
+}
+
+func (p *parser) ensureCurrent() bool {
+	return p.tb < p.te || p.nextChar()
+}
+
+func (p *parser) nextChar() bool {
+	if p.te < len(p.input) {
+		p.te += 1
+		return true
+	}
+	return false
+}
+
+func (p *parser) currentVariable() *variable {
+	if len(p.variables) == 0 {
+		return nil
+	}
+	return p.variables[len(p.variables)-1]
+}
+
+func (p *parser) startVariable() bool {
+	if !p.inVariable {
+		p.variables = append(p.variables, &variable{
+			StartSegment:    len(p.segments),
+			HasWildcardPath: false,
+		})
+		p.inVariable = true
+		return true
+	}
+
+	// nested variables are not allowed
+	return false
+}
+
+func (p *parser) endVariable() bool {
+	var validateVariable = func(v *variable) bool {
+		return len(v.FieldPath) > 0 && v.StartSegment < v.EndSegment && v.EndSegment <= len(p.segments)
+	}
+
+	if p.inVariable && len(p.variables) > 0 {
+		p.currentVariable().EndSegment = len(p.segments)
+		p.inVariable = false
+		return validateVariable(p.currentVariable())
+	}
+
+	// something's wrong we're not in a variable
+	return false
+}
+
+func (p *parser) postProcessVariables() {
+	for _, v := range p.variables {
+		if v.HasWildcardPath {
+			// if the variable contains a '**', store the end_position
+			// relative to the end, such that -1 corresponds to the end
+			// of the path. As we only support fixed path after '**',
+			// this will allow the matcher code to reconstruct the variable
+			// value based on the url segments.
+			v.EndSegment = v.EndSegment - len(p.segments) - 1
+
+			if p.verb != "" {
+				// a custom verb will add an additional segment, so
+				// the end_position needs a -1
+				v.EndSegment -= 1
+			}
+		}
+	}
+}

--- a/src/go/util/httppattern/uri_template.go
+++ b/src/go/util/httppattern/uri_template.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package httppattern
 
 import (

--- a/src/go/util/httppattern/uri_template_test.go
+++ b/src/go/util/httppattern/uri_template_test.go
@@ -988,6 +988,7 @@ func TestUriTemplateParseError(t *testing.T) {
 		"/a/{x}b/s",
 		"/a/b{x}c/s",
 		"/a/{x}b{y}/s",
+		"/a/**/*",
 		// No verb test cases.
 		":",
 		"/:",

--- a/src/go/util/httppattern/uri_template_test.go
+++ b/src/go/util/httppattern/uri_template_test.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package httppattern
 
 import (

--- a/src/go/util/httppattern/uri_template_test.go
+++ b/src/go/util/httppattern/uri_template_test.go
@@ -1,0 +1,994 @@
+package httppattern
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
+)
+
+func TestUriTemplateParse(t *testing.T) {
+	testCases := []struct {
+		desc            string
+		UriTemplate     string
+		wantUriTemplate string
+	}{
+		{
+			desc:        "ParseTest1",
+			UriTemplate: "/shelves/{shelf}/books/{book}",
+			wantUriTemplate: `
+{
+ "Segments": [
+   "shelves",
+   "*",
+   "books",
+   "*"
+ ],
+ "Verb": "",
+ "Variables": [
+   {
+     "StartSegment": 1,
+     "EndSegment": 2,
+     "FieldPath": [
+       "shelf"
+     ],
+     "HasWildcardPath": false
+   },
+   {
+     "StartSegment": 3,
+     "EndSegment": 4,
+     "FieldPath": [
+       "book"
+     ],
+     "HasWildcardPath": false
+   }
+ ]
+}
+`},
+		{
+			desc:        "ParseTest2",
+			UriTemplate: "/shelves/**",
+			wantUriTemplate: `
+{
+ "Segments": [
+   "shelves",
+   "**"
+ ],
+ "Variables": null,
+ "Verb": ""
+}
+`},
+		{
+			desc:        "ParseTest3a",
+			UriTemplate: "/**",
+			wantUriTemplate: `
+{
+ "Segments": [
+   "**"
+ ],
+ "Variables": null,
+ "Verb": ""
+}
+`},
+		{
+			desc:        "ParseTest3b",
+			UriTemplate: "/*",
+			wantUriTemplate: `
+{
+ "Segments": [
+   "*"
+ ],
+ "Variables": null,
+ "Verb": ""
+}
+`},
+		{
+			desc:        "ParseTest4a",
+			UriTemplate: "/a:foo",
+			wantUriTemplate: `
+{
+ "Segments": [
+   "a"
+ ],
+ "Variables": null,
+ "Verb": "foo"
+}
+`},
+		{
+			desc:        "ParseTest4b",
+			UriTemplate: "/a/b/c:foo",
+			wantUriTemplate: `
+{
+ "Segments": [
+   "a",
+   "b",
+   "c"
+ ],
+ "Variables": null,
+ "Verb": "foo"
+}
+`},
+		{
+			desc:        "ParseTest5",
+			UriTemplate: "/*/**",
+			wantUriTemplate: `
+{
+ "Segments": [
+   "*",
+   "**"
+ ],
+ "Variables": null,
+ "Verb": ""
+}
+
+`},
+		{
+			desc:        "ParseTest6",
+			UriTemplate: "/*/a/**",
+			wantUriTemplate: `
+{
+ "Segments": [
+   "*",
+   "a",
+   "**"
+ ],
+ "Variables": null,
+ "Verb": ""
+}
+`},
+		{
+			desc:        "ParseTest7",
+			UriTemplate: "/a/{a.b.c}",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "a",
+    "*"
+  ],
+  "Variables": [
+    {
+      "EndSegment": 2,
+      "FieldPath": [
+        "a",
+        "b",
+        "c"
+      ],
+      "HasWildcardPath": false,
+      "StartSegment": 1
+    }
+  ],
+  "Verb": ""
+}
+		`},
+		{
+			desc:        "ParseTest8",
+			UriTemplate: "/a/{a.b.c=*}",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "a",
+    "*"
+  ],
+  "Variables": [
+    {
+      "EndSegment": 2,
+      "FieldPath": [
+        "a",
+        "b",
+        "c"
+      ],
+      "HasWildcardPath": false,
+      "StartSegment": 1
+    }
+  ],
+  "Verb": ""
+}
+		`},
+		{
+			desc:        "ParseTest9",
+			UriTemplate: "/a/{b=*}",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "a",
+    "*"
+  ],
+  "Variables": [
+    {
+      "EndSegment": 2,
+      "FieldPath": [
+        "b"
+      ],
+      "HasWildcardPath": false,
+      "StartSegment": 1
+    }
+  ],
+  "Verb": ""
+}
+		`},
+		{
+			desc:        "ParseTest10",
+			UriTemplate: "/a/{b=**}",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "a",
+    "**"
+  ],
+  "Variables": [
+    {
+      "EndSegment": -1,
+      "FieldPath": [
+        "b"
+      ],
+      "HasWildcardPath": true,
+      "StartSegment": 1
+    }
+  ],
+  "Verb": ""
+}
+		`},
+		{
+			desc:        "ParseTest11",
+			UriTemplate: "/a/{b=c/*}",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "a",
+    "c",
+    "*"
+  ],
+  "Variables": [
+    {
+      "EndSegment": 3,
+      "FieldPath": [
+        "b"
+      ],
+      "HasWildcardPath": false,
+      "StartSegment": 1
+    }
+  ],
+  "Verb": ""
+}
+		`},
+		{
+			desc:        "ParseTest12",
+			UriTemplate: "/a/{b=c/*/d}",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "a",
+    "c",
+    "*",
+    "d"
+  ],
+  "Variables": [
+    {
+      "EndSegment": 4,
+      "FieldPath": [
+        "b"
+      ],
+      "HasWildcardPath": false,
+      "StartSegment": 1
+    }
+  ],
+  "Verb": ""
+}
+		`},
+		{
+			desc:        "ParseTest13",
+			UriTemplate: "/a/{b=c/**}",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "a",
+    "c",
+    "**"
+  ],
+  "Variables": [
+    {
+      "EndSegment": -1,
+      "FieldPath": [
+        "b"
+      ],
+      "HasWildcardPath": true,
+      "StartSegment": 1
+    }
+  ],
+  "Verb": ""
+}
+		`},
+		{
+			desc:        "ParseTest14",
+			UriTemplate: "/a/{b=c/**}/d/e",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "a",
+    "c",
+    "**",
+    "d",
+    "e"
+  ],
+  "Variables": [
+    {
+      "EndSegment": -3,
+      "FieldPath": [
+        "b"
+      ],
+      "HasWildcardPath": true,
+      "StartSegment": 1
+    }
+  ],
+  "Verb": ""
+}
+		`},
+		{
+			desc:        "ParseTest15",
+			UriTemplate: "/a/{b=c/*/d}/e",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "a",
+    "c",
+    "*",
+    "d",
+    "e"
+  ],
+  "Variables": [
+    {
+      "EndSegment": 4,
+      "FieldPath": [
+        "b"
+      ],
+      "HasWildcardPath": false,
+      "StartSegment": 1
+    }
+  ],
+  "Verb": ""
+}
+		`},
+		{
+			desc:        "ParseTest16",
+			UriTemplate: "/a/{b=c/*/d}/e:verb",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "a",
+    "c",
+    "*",
+    "d",
+    "e"
+  ],
+  "Variables": [
+    {
+      "EndSegment": 4,
+      "FieldPath": [
+        "b"
+      ],
+      "HasWildcardPath": false,
+      "StartSegment": 1
+    }
+  ],
+  "Verb": "verb"
+}
+		`},
+		{
+			desc:        "CustomVerbTests-1",
+			UriTemplate: "/*:verb",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "*"
+  ],
+  "Variables": null,
+  "Verb": "verb"
+}
+		`},
+		{
+			desc:        "CustomVerbTests-2",
+			UriTemplate: "/**:verb",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "**"
+  ],
+  "Variables": null,
+  "Verb": "verb"
+}
+		`},
+		{
+			desc:        "CustomVerbTests-3",
+			UriTemplate: "/{a}:verb",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "*"
+  ],
+  "Variables": [
+    {
+      "EndSegment": 1,
+      "FieldPath": [
+        "a"
+      ],
+      "HasWildcardPath": false,
+      "StartSegment": 0
+    }
+  ],
+  "Verb": "verb"
+}
+		`},
+		{
+			desc:        "CustomVerbTests-4",
+			UriTemplate: "/a/b/*:verb",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "a",
+    "b",
+    "*"
+  ],
+  "Variables": null,
+  "Verb": "verb"
+}
+
+		`},
+		{
+			desc:        "CustomVerbTests-5",
+			UriTemplate: "/a/b/**:verb",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "a",
+    "b",
+    "**"
+  ],
+  "Variables": null,
+  "Verb": "verb"
+}
+		`},
+		{
+			desc:        "CustomVerbTests-6",
+			UriTemplate: "/a/b/{a}:verb",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "a",
+    "b",
+    "*"
+  ],
+  "Variables": [
+    {
+      "EndSegment": 3,
+      "FieldPath": [
+        "a"
+      ],
+      "HasWildcardPath": false,
+      "StartSegment": 2
+    }
+  ],
+  "Verb": "verb"
+}
+		`},
+		{
+			desc:        "MoreVariableTests-1",
+			UriTemplate: "/{x}",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "*"
+  ],
+  "Variables": [
+    {
+      "EndSegment": 1,
+      "FieldPath": [
+        "x"
+      ],
+      "HasWildcardPath": false,
+      "StartSegment": 0
+    }
+  ],
+  "Verb": ""
+}
+		`},
+		{
+			desc:        "MoreVariableTests-2",
+			UriTemplate: "/{x.y.z}",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "*"
+  ],
+  "Variables": [
+    {
+      "EndSegment": 1,
+      "FieldPath": [
+        "x",
+        "y",
+        "z"
+      ],
+      "HasWildcardPath": false,
+      "StartSegment": 0
+    }
+  ],
+  "Verb": ""
+}
+		`},
+		{
+			desc:        "MoreVariableTests-3",
+			UriTemplate: "/{x=*}",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "*"
+  ],
+  "Variables": [
+    {
+      "EndSegment": 1,
+      "FieldPath": [
+        "x"
+      ],
+      "HasWildcardPath": false,
+      "StartSegment": 0
+    }
+  ],
+  "Verb": ""
+}
+		`},
+		{
+			desc:        "MoreVariableTests-4",
+			UriTemplate: "/{x=a/*}",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "a",
+    "*"
+  ],
+  "Variables": [
+    {
+      "EndSegment": 2,
+      "FieldPath": [
+        "x"
+      ],
+      "HasWildcardPath": false,
+      "StartSegment": 0
+    }
+  ],
+  "Verb": ""
+}
+		`},
+		{
+			desc:        "MoreVariableTests-5",
+			UriTemplate: "/{x.y.z=*/a/b}/c",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "*",
+    "a",
+    "b",
+    "c"
+  ],
+  "Variables": [
+    {
+      "EndSegment": 3,
+      "FieldPath": [
+        "x",
+        "y",
+        "z"
+      ],
+      "HasWildcardPath": false,
+      "StartSegment": 0
+    }
+  ],
+  "Verb": ""
+}
+		`},
+		{
+			desc:        "MoreVariableTests-6",
+			UriTemplate: "/{x=**}",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "**"
+  ],
+  "Variables": [
+    {
+      "EndSegment": -1,
+      "FieldPath": [
+        "x"
+      ],
+      "HasWildcardPath": true,
+      "StartSegment": 0
+    }
+  ],
+  "Verb": ""
+}
+		`},
+		{
+			desc:        "MoreVariableTests-7",
+			UriTemplate: "/{x.y.z=**}",
+			wantUriTemplate: `
+      
+{
+  "Segments": [
+    "**"
+  ],
+  "Variables": [
+    {
+      "EndSegment": -1,
+      "FieldPath": [
+        "x",
+        "y",
+        "z"
+      ],
+      "HasWildcardPath": true,
+      "StartSegment": 0
+    }
+  ],
+  "Verb": ""
+}
+		`},
+		{
+			desc:        "MoreVariableTests-8",
+			UriTemplate: "/{x.y.z=a/**/b}",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "a",
+    "**",
+    "b"
+  ],
+  "Variables": [
+    {
+      "EndSegment": -1,
+      "FieldPath": [
+        "x",
+        "y",
+        "z"
+      ],
+      "HasWildcardPath": true,
+      "StartSegment": 0
+    }
+  ],
+  "Verb": ""
+}
+		`},
+		{
+			desc:        "MoreVariableTests-9",
+			UriTemplate: "/{x.y.z=a/**/b}/c/d",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "a",
+    "**",
+    "b",
+    "c",
+    "d"
+  ],
+  "Variables": [
+    {
+      "EndSegment": -3,
+      "FieldPath": [
+        "x",
+        "y",
+        "z"
+      ],
+      "HasWildcardPath": true,
+      "StartSegment": 0
+    }
+  ],
+  "Verb": ""
+}
+		`},
+		{
+			desc:        "VariableAndCustomVerbTests-1",
+			UriTemplate: "/{x}:verb",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "*"
+  ],
+  "Variables": [
+    {
+      "EndSegment": 1,
+      "FieldPath": [
+        "x"
+      ],
+      "HasWildcardPath": false,
+      "StartSegment": 0
+    }
+  ],
+  "Verb": "verb"
+}
+		`},
+		{
+			desc:        "VariableAndCustomVerbTests-2",
+			UriTemplate: "/{x.y.z}:verb",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "*"
+  ],
+  "Variables": [
+    {
+      "EndSegment": 1,
+      "FieldPath": [
+        "x",
+        "y",
+        "z"
+      ],
+      "HasWildcardPath": false,
+      "StartSegment": 0
+    }
+  ],
+  "Verb": "verb"
+}
+		`},
+		{
+			desc:        "VariableAndCustomVerbTests-3",
+			UriTemplate: "/{x.y.z=*/*}:verb",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "*",
+    "*"
+  ],
+  "Variables": [
+    {
+      "EndSegment": 2,
+      "FieldPath": [
+        "x",
+        "y",
+        "z"
+      ],
+      "HasWildcardPath": false,
+      "StartSegment": 0
+    }
+  ],
+  "Verb": "verb"
+}
+		`},
+		{
+			desc:        "VariableAndCustomVerbTests-4",
+			UriTemplate: "/{x=**}:myverb",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "**"
+  ],
+  "Variables": [
+    {
+      "EndSegment": -2,
+      "FieldPath": [
+        "x"
+      ],
+      "HasWildcardPath": true,
+      "StartSegment": 0
+    }
+  ],
+  "Verb": "myverb"
+}
+		`},
+		{
+			desc:        "VariableAndCustomVerbTests-5",
+			UriTemplate: "/{x.y.z=**}:myverb",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "**"
+  ],
+  "Variables": [
+    {
+      "EndSegment": -2,
+      "FieldPath": [
+        "x",
+        "y",
+        "z"
+      ],
+      "HasWildcardPath": true,
+      "StartSegment": 0
+    }
+  ],
+  "Verb": "myverb"
+}
+		`},
+		{
+			desc:        "VariableAndCustomVerbTests-6",
+			UriTemplate: "/{x.y.z=a/**/b}:custom",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "a",
+    "**",
+    "b"
+  ],
+  "Variables": [
+    {
+      "EndSegment": -2,
+      "FieldPath": [
+        "x",
+        "y",
+        "z"
+      ],
+      "HasWildcardPath": true,
+      "StartSegment": 0
+    }
+  ],
+  "Verb": "custom"
+}
+		`},
+		{
+			desc:        "VariableAndCustomVerbTests-7",
+			UriTemplate: "/{x.y.z=a/**/b}/c/d:custom",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "a",
+    "**",
+    "b",
+    "c",
+    "d"
+  ],
+  "Variables": [
+    {
+      "EndSegment": -4,
+      "FieldPath": [
+        "x",
+        "y",
+        "z"
+      ],
+      "HasWildcardPath": true,
+      "StartSegment": 0
+    }
+  ],
+  "Verb": "custom"
+}
+		`},
+		{
+			desc:        "RootPath",
+			UriTemplate: "/",
+			wantUriTemplate: `
+{
+  "Segments": null,
+  "Variables": null,
+  "Verb": ""
+}
+		`},
+		{
+			desc:        "ParseVerbTest2",
+			UriTemplate: "/a/*:verb",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "a",
+    "*"
+  ],
+  "Variables": null,
+  "Verb": "verb"
+}
+		`},
+		{
+			desc:        "ParseVerbTest3",
+			UriTemplate: "/a/**:verb",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "a",
+    "**"
+  ],
+  "Variables": null,
+  "Verb": "verb"
+}
+		`},
+		{
+			desc:        "ParseVerbTest4",
+			UriTemplate: "/a/{b=*}/**:verb",
+			wantUriTemplate: `
+{
+  "Segments": [
+    "a",
+    "*",
+    "**"
+  ],
+  "Variables": [
+    {
+      "EndSegment": 2,
+      "FieldPath": [
+        "b"
+      ],
+      "HasWildcardPath": false,
+      "StartSegment": 1
+    }
+  ],
+  "Verb": "verb"
+}
+		`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			ht := Parse(tc.UriTemplate)
+			if ht == nil {
+				t.Fatal("fail to generate UriTemplate")
+			}
+
+			if tc.wantUriTemplate != "" {
+				bytes, _ := json.Marshal(ht)
+				getUriTemplate := string(bytes)
+
+				if err := util.JsonEqual(tc.wantUriTemplate, getUriTemplate); err != nil {
+					t.Error(err)
+				}
+			}
+		})
+	}
+}
+
+func TestUriTemplateParseError(t *testing.T) {
+	testCases := []string{
+		"",
+		"//",
+		"/{}",
+		"/a/",
+		"/a//b",
+		":verb",
+		"/:verb",
+		"/a/:verb",
+		":",
+		"/:",
+		"/*:",
+		"/**:",
+		"/{{",
+		"/{var}:",
+		"/{var}::",
+		"/{var/a",
+		"/{{var}}",
+		"/a/b/:",
+		"/a/b/*:",
+		"/a/b/**:",
+		"/a/b/{var}:",
+		"/a/{",
+		"/a/{var",
+		"/a/{var.",
+		"/a/{x=var:verb}",
+		"a",
+		"{x}",
+		"{x=/a}",
+		"{x=/a/b}",
+		"a/b",
+		"a/b/{x}",
+		"a/{x}/b",
+		"a/{x}/b:verb",
+		"/a/{var=/b}",
+		"/{var=a/{nested=b}}",
+		"/a{x}",
+		"/{x}a",
+		"/a{x}b",
+		"/{x}a{y}",
+		"/a/b{x}",
+		"/a/{x}b",
+		"/a/b{x}c",
+		"/a/{x}b{y}",
+		"/a/b{x}/s",
+		"/a/{x}b/s",
+		"/a/b{x}c/s",
+		"/a/{x}b{y}/s",
+		// No verb test cases.
+		":",
+		"/:",
+		"/a/:",
+		"/a/*:",
+		"/a/**:",
+		"/a/{b=*}/**:",
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("`%s`", tc), func(t *testing.T) {
+			if Parse(tc) != nil {
+				t.Fatalf("succeed parsing %s but expect to fail", tc)
+			}
+		})
+
+	}
+}


### PR DESCRIPTION
*Description*: import uriTemplate class from [path matcher filter](https://github.com/GoogleCloudPlatform/esp-v2/blob/641ce1d5c177401e424f2b27dd45de1bf797530b/src/api_proxy/path_matcher/http_template.h#L1). It is required to order route match sequence based on path matcher logic.

*Followup*:
- add `SequenceGenerator` under src/go/util/httppattern based on [path_matcher](https://github.com/GoogleCloudPlatform/esp-v2/blob/master/src/api_proxy/path_matcher/path_matcher.h)
- apply the route match ordering in `RouteGenerator`