### PR TITLE
b/171074292: Switch ads to unix domain socket

### DIFF
--- a/src/go/bootstrap/ads/bootstrap_test.go
+++ b/src/go/bootstrap/ads/bootstrap_test.go
@@ -46,7 +46,7 @@ func TestCreateBootstrapConfig(t *testing.T) {
          "grpcServices":[
             {
                "envoyGrpc":{
-                  "clusterName":"ads_cluster"
+                  "clusterName":"@espv2-ads-cluster"
                }
             }
          ],
@@ -87,16 +87,15 @@ func TestCreateBootstrapConfig(t *testing.T) {
                
             },
             "loadAssignment":{
-               "clusterName":"127.0.0.1",
+               "clusterName":"@espv2-ads-cluster",
                "endpoints":[
                   {
                      "lbEndpoints":[
                         {
                            "endpoint":{
                               "address":{
-                                 "socketAddress":{
-                                    "address":"127.0.0.1",
-                                    "portValue":8790
+                                 "pipe":{
+                                    "path":"@espv2-ads-cluster"
                                  }
                               }
                            }
@@ -105,12 +104,13 @@ func TestCreateBootstrapConfig(t *testing.T) {
                   }
                ]
             },
-            "name":"ads_cluster",
-            "type":"STRICT_DNS"
+            "name":"@espv2-ads-cluster",
+            "type":"STATIC"
          }
       ]
    }
-}`,
+}
+`,
 		},
 		{
 			desc: "bootstrap with options",
@@ -137,7 +137,7 @@ func TestCreateBootstrapConfig(t *testing.T) {
          "grpcServices":[
             {
                "envoyGrpc":{
-                  "clusterName":"ads_cluster"
+                  "clusterName":"@espv2-ads-cluster"
                }
             }
          ],
@@ -178,16 +178,15 @@ func TestCreateBootstrapConfig(t *testing.T) {
                
             },
             "loadAssignment":{
-               "clusterName":"127.0.0.1",
+               "clusterName":"@espv2-ads-cluster",
                "endpoints":[
                   {
                      "lbEndpoints":[
                         {
                            "endpoint":{
                               "address":{
-                                 "socketAddress":{
-                                    "address":"127.0.0.1",
-                                    "portValue":8790
+                                 "pipe":{
+                                    "path":"@espv2-ads-cluster"
                                  }
                               }
                            }
@@ -196,8 +195,8 @@ func TestCreateBootstrapConfig(t *testing.T) {
                   }
                ]
             },
-            "name":"ads_cluster",
-            "type":"STRICT_DNS"
+            "name":"@espv2-ads-cluster",
+            "type":"STATIC"
          }
       ]
    }

--- a/src/go/bootstrap/ads/flags/flags.go
+++ b/src/go/bootstrap/ads/flags/flags.go
@@ -16,12 +16,10 @@ package flags
 
 import (
 	"flag"
-	"fmt"
 	"time"
 
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/commonflags"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/options"
-	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	"github.com/golang/glog"
 )
 
@@ -34,7 +32,6 @@ func DefaultBootstrapperOptionsFromFlags() options.AdsBootstrapperOptions {
 	opts := options.AdsBootstrapperOptions{
 		CommonOptions:     common_option,
 		AdsConnectTimeout: *AdsConnectTimeout,
-		DiscoveryAddress:  fmt.Sprintf("%s:%d", util.LoopbackIPv4Addr, common_option.DiscoveryPort),
 	}
 
 	glog.Infof("ADS Bootstrapper options: %+v", opts)

--- a/src/go/commonflags/flags.go
+++ b/src/go/commonflags/flags.go
@@ -28,7 +28,7 @@ var (
 	// These flags are kept in sync with options.CommonOptions.
 	// When adding or changing default values, update options.DefaultCommonOptions.
 	AdminAddress               = flag.String("admin_address", "0.0.0.0", "Address that envoy should serve the admin page on. Supports both ipv4 and ipv6 addresses.")
-	DiscoveryPort              = flag.Int("discovery_port", 8790, "Port that envoy should use to contact ADS. Defaults to config manager's port.")
+	AdsNamedPipe               = flag.String("ads_named_pipe", "@espv2-ads-cluster", "Unix domain socket to use internally for xDs between config manager and envoy.")
 	DisableTracing             = flag.Bool("disable_tracing", false, `Disable stackdriver tracing`)
 	AdminPort                  = flag.Int("admin_port", 8001, "Enables envoy's admin interface on this port if it is not 0. Not recommended for production use-cases, as the admin port is unauthenticated.")
 	HttpRequestTimeoutS        = flag.Int("http_request_timeout_s", 30, `Set the timeout in second for all requests. Must be > 0 and the default is 30 seconds if not set.`)
@@ -66,8 +66,8 @@ func DefaultCommonOptionsFromFlags() options.CommonOptions {
 	opts := options.CommonOptions{
 		AdminAddress:               *AdminAddress,
 		AdminPort:                  *AdminPort,
+		AdsNamedPipe:               *AdsNamedPipe,
 		DisableTracing:             *DisableTracing,
-		DiscoveryPort:              *DiscoveryPort,
 		HttpRequestTimeout:         time.Duration(*HttpRequestTimeoutS) * time.Second,
 		Node:                       *Node,
 		NonGCP:                     *NonGCP,

--- a/src/go/configmanager/main/server.go
+++ b/src/go/configmanager/main/server.go
@@ -28,7 +28,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/configmanager/flags"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/metadata"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/tokengenerator"
-	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	"github.com/golang/glog"
 	"google.golang.org/grpc"
 
@@ -56,7 +55,7 @@ func main() {
 	}
 	server := xds.NewServer(ctx, m.Cache(), nil)
 	grpcServer := grpc.NewServer()
-	lis, err := net.Listen("tcp", fmt.Sprintf("%s:%d", util.LoopbackIPv4Addr, opts.DiscoveryPort))
+	lis, err := net.Listen("unix", opts.AdsNamedPipe)
 	if err != nil {
 		glog.Exitf("Server failed to listen: %v", err)
 	}
@@ -64,7 +63,7 @@ func main() {
 	// Register Envoy discovery services.
 	discoverygrpc.RegisterAggregatedDiscoveryServiceServer(grpcServer, server)
 
-	fmt.Printf("config manager server is running at %s .......\n", lis.Addr())
+	glog.Infof("config manager server is running at %s .......\n", lis.Addr())
 
 	// Handle signals gracefully
 	signalChan := make(chan os.Signal, 1)

--- a/src/go/options/adsbootstrapper.go
+++ b/src/go/options/adsbootstrapper.go
@@ -15,10 +15,7 @@
 package options
 
 import (
-	"fmt"
 	"time"
-
-	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 )
 
 // AdsBootstrapperOptions describes the possible overrides used by the ADS bootstrapper to create the envoy bootstrap config.
@@ -27,7 +24,6 @@ type AdsBootstrapperOptions struct {
 
 	// Flags for ADS
 	AdsConnectTimeout time.Duration
-	DiscoveryAddress  string
 }
 
 // DefaultAdsBootstrapperOptions returns AdsBootstrapperOptions with default values.
@@ -37,6 +33,5 @@ func DefaultAdsBootstrapperOptions() AdsBootstrapperOptions {
 	return AdsBootstrapperOptions{
 		CommonOptions:     DefaultCommonOptions(),
 		AdsConnectTimeout: 10 * time.Second,
-		DiscoveryAddress:  fmt.Sprintf("%s:8790", util.LoopbackIPv4Addr),
 	}
 }

--- a/src/go/options/common.go
+++ b/src/go/options/common.go
@@ -24,7 +24,7 @@ type CommonOptions struct {
 	// Flags for envoy
 	AdminAddress          string
 	AdminPort             int
-	DiscoveryPort         int
+	AdsNamedPipe          string
 	Node                  string
 	GeneratedHeaderPrefix string
 
@@ -77,9 +77,9 @@ type IAMCredentialsOptions struct {
 // The default values are expected to match the default values from the flags.
 func DefaultCommonOptions() CommonOptions {
 	return CommonOptions{
-		AdminAddress:  "0.0.0.0",
-		AdminPort:     8001,
-		DiscoveryPort: 8790,
+		AdminAddress: "0.0.0.0",
+		AdminPort:    8001,
+		AdsNamedPipe: "@espv2-ads-cluster",
 
 		// b/148454048: This should be at least 20s due to IMDS latency issues with k8s workload identities.
 		HttpRequestTimeout: 30 * time.Second,

--- a/src/go/util/load_assignment.go
+++ b/src/go/util/load_assignment.go
@@ -19,7 +19,7 @@ import (
 	endpointpb "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 )
 
-// CreateLoadAssignment creates a ClusterLoadAssignment
+// CreateLoadAssignment creates a cluster for a TCP/IP port.
 func CreateLoadAssignment(hostname string, port uint32) *endpointpb.ClusterLoadAssignment {
 	return &endpointpb.ClusterLoadAssignment{
 		ClusterName: hostname,
@@ -36,6 +36,32 @@ func CreateLoadAssignment(hostname string, port uint32) *endpointpb.ClusterLoadA
 											PortSpecifier: &corepb.SocketAddress_PortValue{
 												PortValue: port,
 											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// CreateUdsLoadAssignment creates a cluster for a unix domain socket.
+func CreateUdsLoadAssignment(clusterName string) *endpointpb.ClusterLoadAssignment {
+	return &endpointpb.ClusterLoadAssignment{
+		ClusterName: clusterName,
+		Endpoints: []*endpointpb.LocalityLbEndpoints{
+			{
+				LbEndpoints: []*endpointpb.LbEndpoint{
+					{
+						HostIdentifier: &endpointpb.LbEndpoint_Endpoint{
+							Endpoint: &endpointpb.Endpoint{
+								Address: &corepb.Address{
+									Address: &corepb.Address_Pipe{
+										Pipe: &corepb.Pipe{
+											Path: clusterName,
 										},
 									},
 								},

--- a/src/go/util/xds_name.go
+++ b/src/go/util/xds_name.go
@@ -67,6 +67,9 @@ const (
 	// The service control server cluster name.
 	ServiceControlClusterName = "service-control-cluster"
 
+	// The ADS cluster name.
+	AdsClusterName = "ads-cluster"
+
 	IngressListenerName  = "ingress_listener"
 	LoopbackListenerName = "loopback_listener"
 )

--- a/src/go/util/xds_name.go
+++ b/src/go/util/xds_name.go
@@ -67,9 +67,6 @@ const (
 	// The service control server cluster name.
 	ServiceControlClusterName = "service-control-cluster"
 
-	// The ADS cluster name.
-	AdsClusterName = "ads-cluster"
-
 	IngressListenerName  = "ingress_listener"
 	LoopbackListenerName = "loopback_listener"
 )

--- a/tests/env/components/config_manager.go
+++ b/tests/env/components/config_manager.go
@@ -15,7 +15,6 @@
 package components
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 
@@ -25,7 +24,6 @@ import (
 
 type ConfigManagerServer struct {
 	*Cmd
-	grpcPort uint16
 }
 
 func NewConfigManagerServer(debugMode bool, ports *platform.Ports, args []string) (*ConfigManagerServer, error) {
@@ -48,16 +46,9 @@ func NewConfigManagerServer(debugMode bool, ports *platform.Ports, args []string
 			name: "ConfigManager",
 			Cmd:  cmd,
 		},
-		grpcPort: ports.DiscoveryPort,
 	}, nil
 }
 
 func (s ConfigManagerServer) String() string {
 	return "Config Manager gRPC Server"
-}
-
-func (s ConfigManagerServer) CheckHealth() error {
-	opts := NewHealthCheckOptions()
-	addr := fmt.Sprintf("%v:%v", platform.GetLoopbackAddress(), s.grpcPort)
-	return GrpcConnectionCheck(addr, opts)
 }

--- a/tests/env/components/envoy.go
+++ b/tests/env/components/envoy.go
@@ -35,7 +35,7 @@ func createEnvoyConf(configPath string, bootstrapArgs []string, ports *platform.
 
 	glog.Infof("Outputting envoy bootstrap config to: %v", configPath)
 
-	bootstrapArgs = append(bootstrapArgs, fmt.Sprintf("--discovery_port=%v", ports.DiscoveryPort))
+	bootstrapArgs = append(bootstrapArgs, fmt.Sprintf("--ads_named_pipe=@espv2-ads-cluster-integ-test-%v", ports.TestId))
 	bootstrapArgs = append(bootstrapArgs, fmt.Sprintf("--admin_port=%v", ports.AdminPort))
 	bootstrapArgs = append(bootstrapArgs, "--admin_address", platform.GetAnyAddress())
 	bootstrapArgs = append(bootstrapArgs, configPath)
@@ -49,7 +49,7 @@ func createEnvoyConf(configPath string, bootstrapArgs []string, ports *platform.
 }
 
 // NewEnvoy creates a new Envoy struct and starts envoy.
-func NewEnvoy(args []string, bootstrapArgs []string, confPath string, ports *platform.Ports, testId uint16) (*Envoy, error) {
+func NewEnvoy(args []string, bootstrapArgs []string, confPath string, ports *platform.Ports) (*Envoy, error) {
 
 	if err := createEnvoyConf(confPath, bootstrapArgs, ports); err != nil {
 		return nil, err
@@ -62,7 +62,7 @@ func NewEnvoy(args []string, bootstrapArgs []string, confPath string, ports *pla
 		// Allows multiple envoys to run on a single machine. If one test fails to stop envoy, this ID
 		// will allow other tests to run afterwords without conflicting.
 		// See: https://www.envoyproxy.io/docs/envoy/latest/operations/cli#cmdoption-base-id
-		"--base-id", strconv.Itoa(int(testId)),
+		"--base-id", strconv.Itoa(int(ports.TestId)),
 	)
 
 	glog.Infof("Calling envoy at %v with args: %v", platform.GetFilePath(platform.Envoy), args)

--- a/tests/env/env.go
+++ b/tests/env/env.go
@@ -350,7 +350,6 @@ func (e *TestEnv) Setup(confArgs []string) error {
 	}
 
 	confArgs = append(confArgs, fmt.Sprintf("--listener_port=%v", e.ports.ListenerPort))
-	confArgs = append(confArgs, fmt.Sprintf("--ads_named_pipe=@espv2-ads-cluster-integ-test-%v", e.ports.TestId))
 	confArgs = append(confArgs, fmt.Sprintf("--service=%v", e.fakeServiceConfig.Name))
 
 	// Tracing configuration.
@@ -390,7 +389,7 @@ func (e *TestEnv) Setup(confArgs []string) error {
 	if err = e.configMgr.StartAndWait(); err != nil {
 		return err
 	}
-	// e.healthRegistry.RegisterHealthChecker(e.configMgr)
+	e.healthRegistry.RegisterHealthChecker(e.configMgr)
 
 	// Starts envoy.
 	envoyConfPath := fmt.Sprintf("/tmp/apiproxy-testdata-bootstrap-%v.yaml", e.ports.TestId)

--- a/tests/env/env.go
+++ b/tests/env/env.go
@@ -40,11 +40,10 @@ const (
 )
 
 var (
-	debugComponents = flag.String("debug_components", "", `display debug logs for components, can be "all", "envoy", "configmanager"`)
+	debugComponents = flag.String("debug_components", "", `display debug logs for components, can be "all", "envoy", "configmanager", "bootstrap"`)
 )
 
 type TestEnv struct {
-	testId  uint16
 	backend platform.Backend
 
 	mockMetadata                    bool
@@ -94,7 +93,6 @@ func NewTestEnv(testId uint16, backend platform.Backend) *TestEnv {
 	fakeServiceConfig := testdata.SetupServiceConfig(backend)
 
 	return &TestEnv{
-		testId:                      testId,
 		backend:                     backend,
 		mockMetadata:                true,
 		MockServiceManagementServer: components.NewMockServiceMrg(fakeServiceConfig.GetName(), initRolloutId, fakeServiceConfig),
@@ -352,7 +350,7 @@ func (e *TestEnv) Setup(confArgs []string) error {
 	}
 
 	confArgs = append(confArgs, fmt.Sprintf("--listener_port=%v", e.ports.ListenerPort))
-	confArgs = append(confArgs, fmt.Sprintf("--discovery_port=%v", e.ports.DiscoveryPort))
+	confArgs = append(confArgs, fmt.Sprintf("--ads_named_pipe=@espv2-ads-cluster-integ-test-%v", e.ports.TestId))
 	confArgs = append(confArgs, fmt.Sprintf("--service=%v", e.fakeServiceConfig.Name))
 
 	// Tracing configuration.
@@ -367,6 +365,10 @@ func (e *TestEnv) Setup(confArgs []string) error {
 	// Starts XDS.
 	var err error
 	debugConfigMgr := *debugComponents == "all" || *debugComponents == "configmanager"
+
+	if *debugComponents == "all" || *debugComponents == "bootstrap" {
+		bootstrapperArgs = append(bootstrapperArgs, "--logtostderr", "--v=1")
+	}
 
 	// Set backend flag (for sidecar)
 	if e.backendAddress == "" {
@@ -388,10 +390,10 @@ func (e *TestEnv) Setup(confArgs []string) error {
 	if err = e.configMgr.StartAndWait(); err != nil {
 		return err
 	}
-	e.healthRegistry.RegisterHealthChecker(e.configMgr)
+	// e.healthRegistry.RegisterHealthChecker(e.configMgr)
 
 	// Starts envoy.
-	envoyConfPath := fmt.Sprintf("/tmp/apiproxy-testdata-bootstrap-%v.yaml", e.testId)
+	envoyConfPath := fmt.Sprintf("/tmp/apiproxy-testdata-bootstrap-%v.yaml", e.ports.TestId)
 	if *debugComponents == "all" || *debugComponents == "envoy" {
 		envoyArgs = append(envoyArgs, "--log-level", "debug")
 		if e.envoyDrainTimeInSec == 0 {
@@ -402,7 +404,7 @@ func (e *TestEnv) Setup(confArgs []string) error {
 		envoyArgs = append(envoyArgs, "--drain-time-s", strconv.Itoa(e.envoyDrainTimeInSec))
 	}
 
-	e.envoy, err = components.NewEnvoy(envoyArgs, bootstrapperArgs, envoyConfPath, e.ports, e.testId)
+	e.envoy, err = components.NewEnvoy(envoyArgs, bootstrapperArgs, envoyConfPath, e.ports)
 	if err != nil {
 		glog.Errorf("unable to create Envoy %v", err)
 		return err

--- a/tests/env/platform/ports.go
+++ b/tests/env/platform/ports.go
@@ -152,7 +152,7 @@ const (
 	portBase uint16 = 20000
 
 	// Maximum number of ports used by non-jwt components.
-	portNum uint16 = 7
+	portNum uint16 = 6
 )
 
 const (
@@ -179,11 +179,11 @@ type Ports struct {
 	BackendServerPort         uint16
 	DynamicRoutingBackendPort uint16
 	ListenerPort              uint16
-	DiscoveryPort             uint16
 	AdminPort                 uint16
 	FakeStackdriverPort       uint16
 	DnsResolverPort           uint16
 	JwtRangeBase              uint16
+	TestId                    uint16
 }
 
 func allocPortBase(testId uint16) uint16 {
@@ -241,11 +241,11 @@ func NewPorts(testId uint16) *Ports {
 		BackendServerPort:         base,
 		DynamicRoutingBackendPort: base + 1,
 		ListenerPort:              base + 2,
-		DiscoveryPort:             base + 3,
 		AdminPort:                 base + 4,
 		FakeStackdriverPort:       base + 5,
 		DnsResolverPort:           base + 6,
 		JwtRangeBase:              base + 7,
+		TestId:                    testId,
 	}
 	glog.Infof(fmt.Sprintf("Ports generated for test(%v) are: %+v", testId, ports))
 	return ports


### PR DESCRIPTION
**Problem**: In k8s, the network stack is shared across containers in a single pod. This can result in port conflicts, especially when ESPv2's internal ports are hardcoded. #363 is an example where a port conflict occurred due to the internal ADS port.

**Solution**: Switch ESPv2 to use a unix domain socket for ADS instead of a TCP/IP port. This will prevent port conflicts and allows the ADS traffic to be internal to the ESPv2 docker container (filesystem is not shared across containers by default).

**Implementation detail**: Use an [abstract namespace](https://utcc.utoronto.ca/~cks/space/blog/linux/SocketAbstractNamespace) so we don't have to manage the underlying inode. Switch ADS cluster to be `static`, no DNS required.

**Testing done**:
- Fix ads bootstrapper unit tests.
- Switch integration test framework to generate separate (but deterministic) pipe names for each test. Verify all tests still function.

**Follow-up PRs**: This will fix all port conflicts in the majority of cases. However, when ESPv2 is deployed with a customer service account, we will reserve TCP/IP port `8791` for the local token agent server. I need to look into the feasibility of switching this to a unix domain socket. Worst case, i'll just expose a flag to configure this. Most people don't use this, so it's not a big issue.

Signed-off-by: Teju Nareddy <nareddyt@google.com>