### PR TITLE
b/171326338: Add extra validation to filter config

### DIFF
--- a/api/envoy/v9/http/backend_auth/config.proto
+++ b/api/envoy/v9/http/backend_auth/config.proto
@@ -28,8 +28,9 @@ message PerRouteFilterConfig {
   // It has to be in the `jwt_audience_list`.
   string jwt_audience = 1 [(validate.rules).string = {
     min_bytes: 1,
-    well_known_regex: HTTP_HEADER_VALUE,
-    strict: false
+    // Does not contain query params ('?'), fragments ('#'), or invalid
+    // HTTP_HEADER_VALUE ('\r', '\n', '\0') characters.
+    pattern: '^[^?#\\r\\n\\0]+$',
   }];
 }
 
@@ -38,7 +39,14 @@ message FilterConfig {
   // The tokens from this list will be prefetched.
   repeated string jwt_audience_list = 1 [(validate.rules).repeated = {
     min_items: 1
-    items { string { well_known_regex: HTTP_HEADER_VALUE strict: false } }
+    items {
+      string {
+        min_len: 1,
+        // Does not contain query params ('?', '&'), fragments ('#'), or invalid
+        // HTTP_HEADER_VALUE ('\r', '\n', '\0') characters.
+        pattern: '^[^?&#\\r\\n\\0]+$',
+      }
+    }
   }];
 
   oneof id_token_info {

--- a/api/envoy/v9/http/backend_auth/config.proto
+++ b/api/envoy/v9/http/backend_auth/config.proto
@@ -28,9 +28,9 @@ message PerRouteFilterConfig {
   // It has to be in the `jwt_audience_list`.
   string jwt_audience = 1 [(validate.rules).string = {
     min_bytes: 1,
-    // Does not contain query params ('?'), fragments ('#'), or invalid
+    // Does not contain query params ('?', '&'), fragments ('#'), or invalid
     // HTTP_HEADER_VALUE ('\r', '\n', '\0') characters.
-    pattern: '^[^?#\\r\\n\\0]+$',
+    pattern: '^[^?&#\\r\\n\\0]+$',
   }];
 }
 

--- a/api/envoy/v9/http/common/base.proto
+++ b/api/envoy/v9/http/common/base.proto
@@ -38,8 +38,11 @@ message Pattern {
   //     /search{?q*,lang}
   //
   string uri_template = 1 [(validate.rules).string = {
-    well_known_regex: HTTP_HEADER_VALUE,
-    strict: false
+    // Must not be empty, at a minimum must be "/".
+    min_len: 1,
+    // Does not contain query params ('?', '&'), fragments ('#'), or invalid
+    // HTTP_HEADER_VALUE ('\r', '\n', '\0') characters.
+    pattern: '^[^?&#\\r\\n\\0]+$',
   }];
 
   // HTTP request method to match against as defined by
@@ -52,6 +55,7 @@ message Pattern {
 message HttpUri {
   // The uri string including the domain and path.
   string uri = 1 [(validate.rules).string = {
+    // Must not be empty, at a minimum must be "/".
     min_bytes: 1,
     well_known_regex: HTTP_HEADER_VALUE,
     strict: false

--- a/api/envoy/v9/http/path_rewrite/config.proto
+++ b/api/envoy/v9/http/path_rewrite/config.proto
@@ -51,11 +51,11 @@ message ConstantPath {
   // This is the final path. All incoming request paths will be
   // translated to this final path.
   string path = 1 [(validate.rules).string = {
-    // Must not be empty. At minimu it should have "/".
+    // Must not be empty. At minimum it should have "/".
     min_len: 1,
-    // Does not contain query params ('?'), fragments ('#'), or invalid
+    // Does not contain query params ('?', '&'), fragments ('#'), or invalid
     // HTTP_HEADER_VALUE ('\r', '\n', '\0') characters.
-    pattern: '^[^?#\\r\\n\\0]+$',
+    pattern: '^[^?&#\\r\\n\\0]+$',
   }];
 
   // If not empty, specify the url template with variable names.
@@ -73,9 +73,9 @@ message PerRouteFilterConfig {
     string path_prefix = 1 [(validate.rules).string = {
       // Must be more than "/".
       min_len: 2,
-      // Does not contain query params ('?'), fragments ('#'), or invalid
+      // Does not contain query params ('?', '&'), fragments ('#'), or invalid
       // HTTP_HEADER_VALUE ('\r', '\n', '\0') characters.
-      pattern: '^[^?#\\r\\n\\0]+$',
+      pattern: '^[^?&#\\r\\n\\0]+$',
     }];
 
     // Translate to a constant path.

--- a/api/envoy/v9/http/service_control/requirement.proto
+++ b/api/envoy/v9/http/service_control/requirement.proto
@@ -35,8 +35,10 @@ message ApiKeyLocation {
     //     GET /something?api_key=abcdef12345
     //
     string query = 1 [(validate.rules).string = {
-      well_known_regex: HTTP_HEADER_VALUE,
-      strict: false
+      min_bytes: 1,
+      // Does not contain query params ('?', '&'), fragments ('#'), or invalid
+      // HTTP_HEADER_VALUE ('\r', '\n', '\0') characters.
+      pattern: '^[^?&#\\r\\n\\0]+$',
     }];
 
     // API key is sent in a request header. `header` represents the
@@ -48,8 +50,10 @@ message ApiKeyLocation {
     //     GET /something HTTP/1.1
     //     X-API-Key: abcdef12345
     //
-    string header = 2
-        [(validate.rules).string = { well_known_regex: HTTP_HEADER_NAME }];
+    string header = 2 [(validate.rules).string = {
+      min_bytes: 1,
+      well_known_regex: HTTP_HEADER_NAME
+    }];
 
     // API key is sent in a
     // [cookie](https://swagger.io/docs/specification/authentication/cookie-authentication),
@@ -60,8 +64,10 @@ message ApiKeyLocation {
     //     GET /something HTTP/1.1
     //     Cookie: API-KEY=abcdef12345
     //
-    string cookie = 3
-        [(validate.rules).string = { well_known_regex: HTTP_HEADER_VALUE }];
+    string cookie = 3 [(validate.rules).string = {
+      min_bytes: 1,
+      well_known_regex: HTTP_HEADER_VALUE
+    }];
   }
 }
 


### PR DESCRIPTION
One customer issue that came up is due to query params being included in the backend auth JWT audience. I went through our filter configs and added more validation, especially for URI-related fields.

Follow-up PRs:
- For Cloud API Gateway usability, we also need to duplicate this validation logic into config generator. Ideally we should have the same validation reject the service config before Envoy ever sees it. As Jason suggested, the first iteration of this could include running protoc-gen-validate on the Envoy config that is outputted.

Signed-off-by: Teju Nareddy <nareddyt@google.com>