### PR TITLE
[WIP] Run protoc-gen-validate on generated envoy config

### DIFF
--- a/api/envoy/v9/http/backend_auth/BUILD
+++ b/api/envoy/v9/http/backend_auth/BUILD
@@ -16,10 +16,15 @@ api_cc_py_proto_library(
 
 go_proto_library(
     name = "config_go_proto",
+    compilers = [
+        "@io_bazel_rules_go//proto:go_proto",
+        "@envoy_api//bazel:pgv_plugin_go",
+    ],
     importpath = "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/v9/http/backend_auth",
-    proto = ":config_proto",
+    protos = [":config_proto"],
     deps = [
         "//api/envoy/v9/http/common:base_go_proto",
         "@com_envoyproxy_protoc_gen_validate//validate:go_default_library",
+        "@com_github_golang_protobuf//ptypes:go_default_library",
     ],
 )

--- a/api/envoy/v9/http/backend_auth/BUILD
+++ b/api/envoy/v9/http/backend_auth/BUILD
@@ -21,7 +21,7 @@ go_proto_library(
         "@envoy_api//bazel:pgv_plugin_go",
     ],
     importpath = "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/v9/http/backend_auth",
-    protos = [":config_proto"],
+    proto = ":config_proto",
     deps = [
         "//api/envoy/v9/http/common:base_go_proto",
         "@com_envoyproxy_protoc_gen_validate//validate:go_default_library",

--- a/api/envoy/v9/http/common/BUILD
+++ b/api/envoy/v9/http/common/BUILD
@@ -13,9 +13,14 @@ api_cc_py_proto_library(
 
 go_proto_library(
     name = "base_go_proto",
+    compilers = [
+        "@io_bazel_rules_go//proto:go_proto",
+        "@envoy_api//bazel:pgv_plugin_go",
+    ],
     importpath = "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/v9/http/common",
     proto = ":base_proto",
     deps = [
         "@com_envoyproxy_protoc_gen_validate//validate:go_default_library",
+        "@com_github_golang_protobuf//ptypes:go_default_library",
     ],
 )

--- a/api/envoy/v9/http/grpc_metadata_scrubber/BUILD
+++ b/api/envoy/v9/http/grpc_metadata_scrubber/BUILD
@@ -13,6 +13,14 @@ api_cc_py_proto_library(
 
 go_proto_library(
     name = "config_go_proto",
+    compilers = [
+        "@io_bazel_rules_go//proto:go_proto",
+        "@envoy_api//bazel:pgv_plugin_go",
+    ],
     importpath = "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/v9/http/grpc_metadata_scrubber",
     proto = ":config_proto",
+    deps = [
+        "@com_envoyproxy_protoc_gen_validate//validate:go_default_library",
+        "@com_github_golang_protobuf//ptypes:go_default_library",
+    ],
 )

--- a/api/envoy/v9/http/path_matcher/BUILD
+++ b/api/envoy/v9/http/path_matcher/BUILD
@@ -16,10 +16,15 @@ api_cc_py_proto_library(
 
 go_proto_library(
     name = "config_go_proto",
+    compilers = [
+        "@io_bazel_rules_go//proto:go_proto",
+        "@envoy_api//bazel:pgv_plugin_go",
+    ],
     importpath = "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/v9/http/path_matcher",
     proto = ":config_proto",
     deps = [
         "//api/envoy/v9/http/common:base_go_proto",
         "@com_envoyproxy_protoc_gen_validate//validate:go_default_library",
+        "@com_github_golang_protobuf//ptypes:go_default_library",
     ],
 )

--- a/api/envoy/v9/http/path_rewrite/BUILD
+++ b/api/envoy/v9/http/path_rewrite/BUILD
@@ -13,9 +13,14 @@ api_cc_py_proto_library(
 
 go_proto_library(
     name = "config_go_proto",
+    compilers = [
+        "@io_bazel_rules_go//proto:go_proto",
+        "@envoy_api//bazel:pgv_plugin_go",
+    ],
     importpath = "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/v9/http/path_rewrite",
     proto = ":config_proto",
     deps = [
         "@com_envoyproxy_protoc_gen_validate//validate:go_default_library",
+        "@com_github_golang_protobuf//ptypes:go_default_library",
     ],
 )

--- a/api/envoy/v9/http/service_control/BUILD
+++ b/api/envoy/v9/http/service_control/BUILD
@@ -18,11 +18,16 @@ api_cc_py_proto_library(
 
 go_proto_library(
     name = "config_go_proto",
+    compilers = [
+        "@io_bazel_rules_go//proto:go_proto",
+        "@envoy_api//bazel:pgv_plugin_go",
+    ],
     importpath = "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/v9/http/service_control",
     proto = ":config_proto",
     deps = [
         "//api/envoy/v9/http/common:base_go_proto",
         "@com_envoyproxy_protoc_gen_validate//validate:go_default_library",
+        "@com_github_golang_protobuf//ptypes:go_default_library",
         "@com_github_googleapis_googleapis//google/api:serviceconfig_go_proto",
     ],
 )

--- a/src/go/configgenerator/cluster_generator.go
+++ b/src/go/configgenerator/cluster_generator.go
@@ -103,6 +103,13 @@ func MakeClusters(serviceInfo *sc.ServiceInfo) ([]*clusterpb.Cluster, error) {
 	}
 
 	glog.Infof("generate clusters: %v", clusters)
+
+	for _, cluster := range clusters {
+		if err := cluster.Validate(); err != nil {
+			return nil, fmt.Errorf("validation error for cluster: %v", err)
+		}
+	}
+
 	return clusters, nil
 }
 

--- a/src/go/configgenerator/listener_generator.go
+++ b/src/go/configgenerator/listener_generator.go
@@ -58,6 +58,11 @@ func MakeListeners(serviceInfo *sc.ServiceInfo) ([]*listenerpb.Listener, error) 
 	if err != nil {
 		return nil, err
 	}
+
+	if err := listener.Validate(); err != nil {
+		return nil, fmt.Errorf("validation error for listener: %v", err)
+	}
+
 	return []*listenerpb.Listener{listener}, nil
 }
 


### PR DESCRIPTION
TODO: Decide what the best way to test this is. Some new unit tests that run on a full config with random errors.

TODO: When synced into google3, we need to modify the BUILD rules to depend on the generated google3 validate protos. 

Signed-off-by: Teju Nareddy <nareddyt@google.com>