### PR TITLE
b/171326666 #2: Envoy changes to use DependencyErrorBehavior in TokenSubscriber

### DIFF
--- a/src/envoy/http/backend_auth/config_parser_impl_test.cc
+++ b/src/envoy/http/backend_auth/config_parser_impl_test.cc
@@ -28,6 +28,8 @@ namespace envoy {
 namespace http_filters {
 namespace backend_auth {
 
+using ::espv2::api::envoy::v9::http::common::DependencyErrorBehavior;
+
 class ConfigParserImplTest : public ::testing::Test {
  protected:
   void setUp(absl::string_view filter_config) {
@@ -63,9 +65,10 @@ imds_token {
               createImdsTokenSubscriber(
                   token::TokenType::IdentityToken, "this-is-cluster",
                   "this-is-uri?format=standard&audience=audience-foo",
-                  std::chrono::seconds(20), _))
+                  std::chrono::seconds(20), _, _))
       .WillOnce(Invoke([&token_foo](const token::TokenType&, const std::string&,
                                     const std::string&, std::chrono::seconds,
+                                    const DependencyErrorBehavior,
                                     token::UpdateTokenCallback callback)
                            -> token::TokenSubscriberPtr {
         callback(token_foo);
@@ -75,9 +78,10 @@ imds_token {
               createImdsTokenSubscriber(
                   token::TokenType::IdentityToken, "this-is-cluster",
                   "this-is-uri?format=standard&audience=audience-bar",
-                  std::chrono::seconds(20), _))
+                  std::chrono::seconds(20), _, _))
       .WillOnce(Invoke([&token_bar](const token::TokenType&, const std::string&,
                                     const std::string&, std::chrono::seconds,
+                                    const DependencyErrorBehavior,
                                     token::UpdateTokenCallback callback)
                            -> token::TokenSubscriberPtr {
         callback(token_bar);
@@ -121,10 +125,11 @@ iam_token {
   EXPECT_CALL(mock_token_subscriber_factory_,
               createImdsTokenSubscriber(
                   token::TokenType::AccessToken, "this-is-imds-cluster",
-                  "this-is-imds-uri", std::chrono::seconds(20), _))
+                  "this-is-imds-uri", std::chrono::seconds(20), _, _))
       .WillOnce(
           Invoke([&access_token](const token::TokenType&, const std::string&,
                                  const std::string&, std::chrono::seconds,
+                                 const DependencyErrorBehavior,
                                  token::UpdateTokenCallback callback)
                      -> token::TokenSubscriberPtr {
             callback(access_token);
@@ -134,11 +139,12 @@ iam_token {
   EXPECT_CALL(mock_token_subscriber_factory_,
               createIamTokenSubscriber(_, "this-is-iam-cluster",
                                        "this-is-iam-uri?audience=audience-foo",
-                                       std::chrono::seconds(4), _, _, _, _))
+                                       std::chrono::seconds(4), _, _, _, _, _))
       .WillOnce(
           Invoke([&id_token_foo](
                      token::TokenType, const std::string&, const std::string&,
-                     std::chrono::seconds, token::UpdateTokenCallback callback,
+                     std::chrono::seconds, const DependencyErrorBehavior,
+                     token::UpdateTokenCallback callback,
                      const ::google::protobuf::RepeatedPtrField<std::string>&,
                      const ::google::protobuf::RepeatedPtrField<std::string>&,
                      token::GetTokenFunc access_token_fn)
@@ -150,11 +156,12 @@ iam_token {
   EXPECT_CALL(mock_token_subscriber_factory_,
               createIamTokenSubscriber(_, "this-is-iam-cluster",
                                        "this-is-iam-uri?audience=audience-bar",
-                                       std::chrono::seconds(4), _, _, _, _))
+                                       std::chrono::seconds(4), _, _, _, _, _))
       .WillOnce(
           Invoke([&id_token_bar](
                      token::TokenType, const std::string&, const std::string&,
-                     std::chrono::seconds, token::UpdateTokenCallback callback,
+                     std::chrono::seconds, const DependencyErrorBehavior,
+                     token::UpdateTokenCallback callback,
                      const ::google::protobuf::RepeatedPtrField<std::string>&,
                      const ::google::protobuf::RepeatedPtrField<std::string>&,
                      token::GetTokenFunc access_token_fn)

--- a/src/envoy/http/backend_auth/config_parser_impl_test.cc
+++ b/src/envoy/http/backend_auth/config_parser_impl_test.cc
@@ -68,7 +68,7 @@ imds_token {
                   std::chrono::seconds(20), _, _))
       .WillOnce(Invoke([&token_foo](const token::TokenType&, const std::string&,
                                     const std::string&, std::chrono::seconds,
-                                    const DependencyErrorBehavior,
+                                    DependencyErrorBehavior,
                                     token::UpdateTokenCallback callback)
                            -> token::TokenSubscriberPtr {
         callback(token_foo);
@@ -81,7 +81,7 @@ imds_token {
                   std::chrono::seconds(20), _, _))
       .WillOnce(Invoke([&token_bar](const token::TokenType&, const std::string&,
                                     const std::string&, std::chrono::seconds,
-                                    const DependencyErrorBehavior,
+                                    DependencyErrorBehavior,
                                     token::UpdateTokenCallback callback)
                            -> token::TokenSubscriberPtr {
         callback(token_bar);
@@ -129,7 +129,7 @@ iam_token {
       .WillOnce(
           Invoke([&access_token](const token::TokenType&, const std::string&,
                                  const std::string&, std::chrono::seconds,
-                                 const DependencyErrorBehavior,
+                                 DependencyErrorBehavior,
                                  token::UpdateTokenCallback callback)
                      -> token::TokenSubscriberPtr {
             callback(access_token);
@@ -143,7 +143,7 @@ iam_token {
       .WillOnce(
           Invoke([&id_token_foo](
                      token::TokenType, const std::string&, const std::string&,
-                     std::chrono::seconds, const DependencyErrorBehavior,
+                     std::chrono::seconds, DependencyErrorBehavior,
                      token::UpdateTokenCallback callback,
                      const ::google::protobuf::RepeatedPtrField<std::string>&,
                      const ::google::protobuf::RepeatedPtrField<std::string>&,
@@ -160,7 +160,7 @@ iam_token {
       .WillOnce(
           Invoke([&id_token_bar](
                      token::TokenType, const std::string&, const std::string&,
-                     std::chrono::seconds, const DependencyErrorBehavior,
+                     std::chrono::seconds, DependencyErrorBehavior,
                      token::UpdateTokenCallback callback,
                      const ::google::protobuf::RepeatedPtrField<std::string>&,
                      const ::google::protobuf::RepeatedPtrField<std::string>&,

--- a/src/envoy/token/BUILD
+++ b/src/envoy/token/BUILD
@@ -48,6 +48,7 @@ envoy_cc_library(
     repository = "@envoy",
     deps = [
         ":token_info_lib",
+        "//api/envoy/v9/http/common:base_proto_cc_proto",
         "@envoy//include/envoy/common:time_interface",
         "@envoy//include/envoy/event:dispatcher_interface",
         "@envoy//include/envoy/server:filter_config_interface",
@@ -78,6 +79,7 @@ envoy_cc_library(
         ":iam_token_info_lib",
         ":imds_token_info_lib",
         ":token_subscriber_lib",
+        "//api/envoy/v9/http/common:base_proto_cc_proto",
     ],
 )
 
@@ -88,6 +90,7 @@ envoy_cc_library(
     deps = [
         ":token_info_lib",
         ":token_subscriber_factory_interface",
+        "//api/envoy/v9/http/common:base_proto_cc_proto",
     ],
 )
 
@@ -100,6 +103,7 @@ envoy_cc_library(
         ":imds_token_info_lib",
         ":token_subscriber_factory_interface",
         ":token_subscriber_lib",
+        "//api/envoy/v9/http/common:base_proto_cc_proto",
     ],
 )
 
@@ -156,6 +160,7 @@ envoy_cc_test(
     deps = [
         ":mocks_lib",
         ":token_subscriber_lib",
+        "//api/envoy/v9/http/common:base_proto_cc_proto",
         "@envoy//test/mocks/init:init_mocks",
         "@envoy//test/mocks/server:server_mocks",
         "@envoy//test/test_common:utility_lib",

--- a/src/envoy/token/mocks.h
+++ b/src/envoy/token/mocks.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #pragma once
+#include "api/envoy/v9/http/common/base.pb.h"
 #include "gmock/gmock.h"
 #include "src/envoy/token/token_info.h"
 #include "src/envoy/token/token_subscriber_factory.h"
@@ -29,6 +30,8 @@ class MockTokenSubscriberFactory : public TokenSubscriberFactory {
   MOCK_METHOD(TokenSubscriberPtr, createImdsTokenSubscriber,
               (const TokenType& token_type, const std::string& token_cluster,
                const std::string& token_url, std::chrono::seconds fetch_timeout,
+               const api::envoy::v9::http::common::DependencyErrorBehavior
+                   error_behavior,
                UpdateTokenCallback callback),
               (const));
 
@@ -36,6 +39,8 @@ class MockTokenSubscriberFactory : public TokenSubscriberFactory {
       TokenSubscriberPtr, createIamTokenSubscriber,
       (const TokenType& token_type, const std::string& token_cluster,
        const std::string& token_url, std::chrono::seconds fetch_timeout,
+       const api::envoy::v9::http::common::DependencyErrorBehavior
+           error_behavior,
        UpdateTokenCallback callback,
        const ::google::protobuf::RepeatedPtrField<std::string>& delegates,
        const ::google::protobuf::RepeatedPtrField<std::string>& scopes,

--- a/src/envoy/token/mocks.h
+++ b/src/envoy/token/mocks.h
@@ -30,7 +30,7 @@ class MockTokenSubscriberFactory : public TokenSubscriberFactory {
   MOCK_METHOD(TokenSubscriberPtr, createImdsTokenSubscriber,
               (const TokenType& token_type, const std::string& token_cluster,
                const std::string& token_url, std::chrono::seconds fetch_timeout,
-               const api::envoy::v9::http::common::DependencyErrorBehavior
+               ::espv2::api::envoy::v9::http::common::DependencyErrorBehavior
                    error_behavior,
                UpdateTokenCallback callback),
               (const));
@@ -39,7 +39,7 @@ class MockTokenSubscriberFactory : public TokenSubscriberFactory {
       TokenSubscriberPtr, createIamTokenSubscriber,
       (const TokenType& token_type, const std::string& token_cluster,
        const std::string& token_url, std::chrono::seconds fetch_timeout,
-       const api::envoy::v9::http::common::DependencyErrorBehavior
+       ::espv2::api::envoy::v9::http::common::DependencyErrorBehavior
            error_behavior,
        UpdateTokenCallback callback,
        const ::google::protobuf::RepeatedPtrField<std::string>& delegates,

--- a/src/envoy/token/token_subscriber.cc
+++ b/src/envoy/token/token_subscriber.cc
@@ -39,7 +39,7 @@ TokenSubscriber::TokenSubscriber(
     Envoy::Server::Configuration::FactoryContext& context,
     const TokenType& token_type, const std::string& token_cluster,
     const std::string& token_url, std::chrono::seconds fetch_timeout,
-    const DependencyErrorBehavior error_behavior, UpdateTokenCallback callback,
+    DependencyErrorBehavior error_behavior, UpdateTokenCallback callback,
     TokenInfoPtr token_info)
     : context_(context),
       token_type_(token_type),

--- a/src/envoy/token/token_subscriber.h
+++ b/src/envoy/token/token_subscriber.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "api/envoy/v9/http/common/base.pb.h"
 #include "common/common/logger.h"
 #include "common/init/target_impl.h"
 #include "envoy/common/time.h"
@@ -44,6 +45,8 @@ class TokenSubscriber
                   const TokenType& token_type, const std::string& token_cluster,
                   const std::string& token_url,
                   std::chrono::seconds fetch_timeout,
+                  const api::envoy::v9::http::common::DependencyErrorBehavior
+                      error_behavior,
                   UpdateTokenCallback callback, TokenInfoPtr token_info);
   void init();
 
@@ -70,6 +73,7 @@ class TokenSubscriber
   const std::string token_cluster_;
   const std::string token_url_;
   const std::chrono::seconds fetch_timeout_;
+  const api::envoy::v9::http::common::DependencyErrorBehavior error_behavior_;
   const UpdateTokenCallback callback_;
   TokenInfoPtr token_info_;
 

--- a/src/envoy/token/token_subscriber.h
+++ b/src/envoy/token/token_subscriber.h
@@ -45,7 +45,7 @@ class TokenSubscriber
                   const TokenType& token_type, const std::string& token_cluster,
                   const std::string& token_url,
                   std::chrono::seconds fetch_timeout,
-                  const api::envoy::v9::http::common::DependencyErrorBehavior
+                  ::espv2::api::envoy::v9::http::common::DependencyErrorBehavior
                       error_behavior,
                   UpdateTokenCallback callback, TokenInfoPtr token_info);
   void init();

--- a/src/envoy/token/token_subscriber_factory.h
+++ b/src/envoy/token/token_subscriber_factory.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "api/envoy/v9/http/common/base.pb.h"
 #include "src/envoy/token/iam_token_info.h"
 #include "src/envoy/token/imds_token_info.h"
 #include "src/envoy/token/token_subscriber.h"
@@ -29,11 +30,15 @@ class TokenSubscriberFactory {
   virtual TokenSubscriberPtr createImdsTokenSubscriber(
       const TokenType& token_type, const std::string& token_cluster,
       const std::string& token_url, std::chrono::seconds fetch_timeout,
+      const api::envoy::v9::http::common::DependencyErrorBehavior
+          error_behavior,
       UpdateTokenCallback callback) const PURE;
 
   virtual TokenSubscriberPtr createIamTokenSubscriber(
       const TokenType& token_type, const std::string& token_cluster,
       const std::string& token_url, std::chrono::seconds fetch_timeout,
+      const api::envoy::v9::http::common::DependencyErrorBehavior
+          error_behavior,
       UpdateTokenCallback callback,
       const ::google::protobuf::RepeatedPtrField<std::string>& delegates,
       const ::google::protobuf::RepeatedPtrField<std::string>& scopes,

--- a/src/envoy/token/token_subscriber_factory.h
+++ b/src/envoy/token/token_subscriber_factory.h
@@ -30,14 +30,14 @@ class TokenSubscriberFactory {
   virtual TokenSubscriberPtr createImdsTokenSubscriber(
       const TokenType& token_type, const std::string& token_cluster,
       const std::string& token_url, std::chrono::seconds fetch_timeout,
-      const api::envoy::v9::http::common::DependencyErrorBehavior
+      ::espv2::api::envoy::v9::http::common::DependencyErrorBehavior
           error_behavior,
       UpdateTokenCallback callback) const PURE;
 
   virtual TokenSubscriberPtr createIamTokenSubscriber(
       const TokenType& token_type, const std::string& token_cluster,
       const std::string& token_url, std::chrono::seconds fetch_timeout,
-      const api::envoy::v9::http::common::DependencyErrorBehavior
+      ::espv2::api::envoy::v9::http::common::DependencyErrorBehavior
           error_behavior,
       UpdateTokenCallback callback,
       const ::google::protobuf::RepeatedPtrField<std::string>& delegates,

--- a/src/envoy/token/token_subscriber_factory_impl.h
+++ b/src/envoy/token/token_subscriber_factory_impl.h
@@ -33,7 +33,7 @@ class TokenSubscriberFactoryImpl : public TokenSubscriberFactory {
   TokenSubscriberPtr createImdsTokenSubscriber(
       const TokenType& token_type, const std::string& token_cluster,
       const std::string& token_url, std::chrono::seconds fetch_timeout,
-      const api::envoy::v9::http::common::DependencyErrorBehavior
+      ::espv2::api::envoy::v9::http::common::DependencyErrorBehavior
           error_behavior,
       UpdateTokenCallback callback) const override {
     TokenInfoPtr info = std::make_unique<ImdsTokenInfo>();
@@ -47,7 +47,7 @@ class TokenSubscriberFactoryImpl : public TokenSubscriberFactory {
   TokenSubscriberPtr createIamTokenSubscriber(
       const TokenType& token_type, const std::string& token_cluster,
       const std::string& token_url, std::chrono::seconds fetch_timeout,
-      const api::envoy::v9::http::common::DependencyErrorBehavior
+      ::espv2::api::envoy::v9::http::common::DependencyErrorBehavior
           error_behavior,
       UpdateTokenCallback callback,
       const ::google::protobuf::RepeatedPtrField<std::string>& delegates,

--- a/src/envoy/token/token_subscriber_factory_impl.h
+++ b/src/envoy/token/token_subscriber_factory_impl.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "api/envoy/v9/http/common/base.pb.h"
 #include "src/envoy/token/iam_token_info.h"
 #include "src/envoy/token/imds_token_info.h"
 #include "src/envoy/token/token_subscriber.h"
@@ -32,11 +33,13 @@ class TokenSubscriberFactoryImpl : public TokenSubscriberFactory {
   TokenSubscriberPtr createImdsTokenSubscriber(
       const TokenType& token_type, const std::string& token_cluster,
       const std::string& token_url, std::chrono::seconds fetch_timeout,
+      const api::envoy::v9::http::common::DependencyErrorBehavior
+          error_behavior,
       UpdateTokenCallback callback) const override {
     TokenInfoPtr info = std::make_unique<ImdsTokenInfo>();
     TokenSubscriberPtr subscriber = std::make_unique<TokenSubscriber>(
-        context_, token_type, token_cluster, token_url, fetch_timeout, callback,
-        std::move(info));
+        context_, token_type, token_cluster, token_url, fetch_timeout,
+        error_behavior, callback, std::move(info));
     subscriber->init();
     return subscriber;
   }
@@ -44,6 +47,8 @@ class TokenSubscriberFactoryImpl : public TokenSubscriberFactory {
   TokenSubscriberPtr createIamTokenSubscriber(
       const TokenType& token_type, const std::string& token_cluster,
       const std::string& token_url, std::chrono::seconds fetch_timeout,
+      const api::envoy::v9::http::common::DependencyErrorBehavior
+          error_behavior,
       UpdateTokenCallback callback,
       const ::google::protobuf::RepeatedPtrField<std::string>& delegates,
       const ::google::protobuf::RepeatedPtrField<std::string>& scopes,
@@ -51,8 +56,8 @@ class TokenSubscriberFactoryImpl : public TokenSubscriberFactory {
     TokenInfoPtr info = std::make_unique<IamTokenInfo>(
         delegates, scopes, token_type == IdentityToken, access_token_fn);
     TokenSubscriberPtr subscriber = std::make_unique<TokenSubscriber>(
-        context_, token_type, token_cluster, token_url, fetch_timeout, callback,
-        std::move(info));
+        context_, token_type, token_cluster, token_url, fetch_timeout,
+        error_behavior, callback, std::move(info));
     subscriber->init();
     return subscriber;
   }

--- a/src/envoy/token/token_subscriber_test.cc
+++ b/src/envoy/token/token_subscriber_test.cc
@@ -49,8 +49,7 @@ class TokenSubscriberTest : public testing::Test {
     mock_timer_ = new Envoy::Event::MockTimer{};
   }
 
-  void setUp(const TokenType& token_type,
-             const DependencyErrorBehavior error_behavior) {
+  void setUp(TokenType token_type, DependencyErrorBehavior error_behavior) {
     EXPECT_CALL(context_.init_manager_, add(_))
         .WillOnce(Invoke([this](const Envoy::Init::Target& target) {
           init_target_handle_ = target.createHandle("test");


### PR DESCRIPTION
Follow-up on PR #402 to plumb the filter config changes into TokenSubscriber, allowing the proxy startup behavior to be configured.

Testing:
- Unit tests in TokenSubscriber
- Integration tests for Envoy startup. Unrelated, but these new tests are detecting pre-existing race conditions (b/172671425).

Follow-up PR to improve the error message API clients see when the failure occurs. The current message is not actionable:
```
{"code":500,"message":"Token not found for audience: https://localhost/bearertoken/constant"}
```

Signed-off-by: Teju Nareddy <nareddyt@google.com>