### PR TITLE
b/172671425: work around tsan false alarm on atomic race

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,8 @@ integration-debug: build build-envoy-debug build-grpc-interop build-grpc-echo
 
 integration-test-asan: build-msan build-envoy-asan build-grpc-interop build-grpc-echo integration-test-run-sequential
 
+# next line is to work around issue: https://github.com/google/sanitizers/issues/953
+integration-test-tsan: export TSAN_OPTIONS=report_atomic_races=0
 integration-test-tsan: build-race build-envoy-tsan build-grpc-interop build-grpc-echo integration-test-run-sequential
 
 


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

Our tsan log has a log of false "data race".  It is due to https://github.com/google/sanitizers/issues/953