### PR TITLE
b/172831233: Enable traceparent trace context propagation by default

### DIFF
--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -456,15 +456,21 @@ environment variable or by passing "-k" flag to this script.
         help="An alias to override --tracing_sample_rate to 0")
     parser.add_argument(
         '--tracing_incoming_context',
-        default="",
+        default="traceparent",
         help='''
-        comma separated incoming trace contexts (traceparent|grpc-trace-bin|x-cloud-trace-context)'''
+        Comma separated incoming trace contexts (traceparent|grpc-trace-bin|x-cloud-trace-context).
+        
+        See official documentation for more details:
+        https://cloud.google.com/endpoints/docs/openapi/tracing'''
     )
     parser.add_argument(
         '--tracing_outgoing_context',
-        default="",
+        default="traceparent",
         help='''
-        comma separated outgoing trace contexts (traceparent|grpc-trace-bin|x-cloud-trace-context)'''
+        Comma separated outgoing trace contexts (traceparent|grpc-trace-bin|x-cloud-trace-context).
+        
+        See official documentation for more details:
+        https://cloud.google.com/endpoints/docs/openapi/tracing'''
     )
     parser.add_argument(
         '--cloud_trace_url_override',

--- a/tests/e2e/scripts/cloud-run/deploy.sh
+++ b/tests/e2e/scripts/cloud-run/deploy.sh
@@ -327,9 +327,7 @@ function setup() {
 
   # Redeploy ESPv2 to update the service config. Set flags as follows:
   # - Tracing: Support trace context propagation to the backend and from AppHosting.
-  proxy_args="^++^--tracing_sample_rate=0.05"\
-"++--tracing_outgoing_context=traceparent"\
-"++--tracing_incoming_context=traceparent"
+  proxy_args="^++^--tracing_sample_rate=0.05"
 
   if [[ ${PROXY_PLATFORM} == "cloud-run" ]];
   then

--- a/tests/e2e/scripts/gke/deploy.sh
+++ b/tests/e2e/scripts/gke/deploy.sh
@@ -44,8 +44,6 @@ PROJECT_ID="cloudesf-testing"
 ARGS="$ARGS \"--service=${APIPROXY_SERVICE}\","
 ARGS="$ARGS \"--rollout_strategy=${ROLLOUT_STRATEGY}\","
 ARGS="$ARGS \"--tracing_sample_rate=0.05\","
-ARGS="$ARGS \"--tracing_incoming_context=traceparent\","
-ARGS="$ARGS \"--tracing_outgoing_context=traceparent\","
 ARGS="$ARGS \"--admin_port=8001\""
 case "${BACKEND}" in
   'bookstore')

--- a/tests/endpoints/echo/server/app.go
+++ b/tests/endpoints/echo/server/app.go
@@ -172,7 +172,8 @@ func echoHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(b)
 }
 
-// echoHandler echo received with prefix `Fake-Header-Key` and prefix `X-` after appending `Echo-`
+// echoHeader handler will echo back all headers.
+// Attaches prefix `Echo-` to each header before echoing it back.
 func echoHeaderHandler(w http.ResponseWriter, r *http.Request) {
 	for key, vals := range r.Header {
 		for _, val := range vals {

--- a/tests/endpoints/echo/server/app.go
+++ b/tests/endpoints/echo/server/app.go
@@ -175,10 +175,8 @@ func echoHandler(w http.ResponseWriter, r *http.Request) {
 // echoHandler echo received with prefix `Fake-Header-Key` and prefix `X-` after appending `Echo-`
 func echoHeaderHandler(w http.ResponseWriter, r *http.Request) {
 	for key, vals := range r.Header {
-		if strings.HasPrefix(key, "Fake-Header-Key") || strings.HasPrefix(key, "X-") {
-			for _, val := range vals {
-				w.Header().Add(fmt.Sprintf("Echo-%s", key), val)
-			}
+		for _, val := range vals {
+			w.Header().Add(fmt.Sprintf("Echo-%s", key), val)
 		}
 	}
 

--- a/tests/env/platform/ports.go
+++ b/tests/env/platform/ports.go
@@ -132,6 +132,7 @@ const (
 	TestSimpleCorsWithRegexPreset
 	TestStatistics
 	TestStatisticsServiceControlCallStatus
+	TestTraceContextPropagationHeaders
 	TestTracesDynamicRouting
 	TestTracesFetchingJwks
 	TestTracesServiceControlCheckWithRetry

--- a/tests/env/testdata/fake_echo_service_config_for_dynamic_routing.go
+++ b/tests/env/testdata/fake_echo_service_config_for_dynamic_routing.go
@@ -40,6 +40,9 @@ var (
 						ResponseTypeUrl: "type.googleapis.com/EchoMessage",
 					},
 					{
+						Name: "EchoHeader",
+					},
+					{
 						Name: "dynamic_routing_GetPetById",
 					},
 					{
@@ -124,6 +127,12 @@ var (
 						Post: "/echo",
 					},
 					Body: "message",
+				},
+				{
+					Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.EchoHeader",
+					Pattern: &annotationspb.HttpRule_Get{
+						Get: "/echoHeader",
+					},
 				},
 				{
 					Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_GetPetById",
@@ -333,6 +342,10 @@ var (
 		Usage: &confpb.Usage{
 			Rules: []*confpb.UsageRule{
 				{
+					Selector:               "1.echo_api_endpoints_cloudesf_testing_cloud_goog.EchoHeader",
+					AllowUnregisteredCalls: true,
+				},
+				{
 					Selector:               "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_GetPetById",
 					AllowUnregisteredCalls: true,
 				},
@@ -430,6 +443,11 @@ var (
 					Address:         fmt.Sprintf("https://localhost:%s/echo", platform.WorkingBackendPort),
 					PathTranslation: confpb.BackendRule_CONSTANT_ADDRESS,
 					// No authentication on this rule, essentially the same as `disable_auth`
+				},
+				{
+					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.EchoHeader",
+					Address:         fmt.Sprintf("https://localhost:%s/echoHeader", platform.WorkingBackendPort),
+					PathTranslation: confpb.BackendRule_CONSTANT_ADDRESS,
 				},
 				{
 					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_GetPetById",

--- a/tests/integration_test/generated_header_prefix_test.go
+++ b/tests/integration_test/generated_header_prefix_test.go
@@ -16,7 +16,6 @@ package integration_test
 
 import (
 	"fmt"
-	"net/http"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
@@ -26,17 +25,6 @@ import (
 
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
 )
-
-func checkHeaderExist(headers http.Header, wantHeaderName, wantHeaderVal string) bool {
-	for headerName, headerVals := range headers {
-		if headerName == wantHeaderName {
-			if len(headerVals) > 0 || headerVals[0] == wantHeaderVal {
-				return true
-			}
-		}
-	}
-	return false
-}
 
 func TestGeneratedHeaders(t *testing.T) {
 	t.Parallel()
@@ -106,7 +94,9 @@ func TestGeneratedHeaders(t *testing.T) {
 			}
 
 			for wantHeaderName, wantHeaderVal := range tc.wantRespHeader {
-				if !checkHeaderExist(headers, wantHeaderName, wantHeaderVal) {
+				if !utils.CheckHeaderExist(headers, wantHeaderName, func(gotHeaderVal string) bool {
+					return wantHeaderVal == gotHeaderVal
+				}) {
 					t.Errorf("Test (%s): get headers %v, not find expected header %s:%s,  ", tc.desc, headers, wantHeaderName, wantHeaderVal)
 				}
 			}

--- a/tests/integration_test/opencensus_tracing_test.go
+++ b/tests/integration_test/opencensus_tracing_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -421,5 +422,132 @@ func TestTracesDynamicRouting(t *testing.T) {
 		if err := checkSpanNames(s, tc.wantSpanNames); err != nil {
 			t.Errorf("Test (%s) failed: %v", tc.desc, err)
 		}
+	}
+}
+
+func TestTraceContextPropagationHeaders(t *testing.T) {
+	t.Parallel()
+
+	// Some real-world examples.
+	incomingTraceContexts := map[string]string{
+		"traceparent":           "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+		"X-Cloud-Trace-Context": "105445aa7843bc8bf206b12000100000/1;o=1",
+	}
+
+	testData := []struct {
+		desc          string
+		confArgs      []string
+		requestHeader map[string]string
+		// Headers wanted in the response.
+		wantRespHeaders map[string]string
+		// Headers that should not exist in the response.
+		notWantRespHeaders map[string]string
+	}{
+		{
+			desc: "trace context propagation is disabled",
+			confArgs: append([]string{
+				"--tracing_incoming_context=",
+				"--tracing_outgoing_context=",
+			}, utils.CommonArgs()...),
+			requestHeader: incomingTraceContexts,
+			wantRespHeaders: map[string]string{
+				// All headers are not changed.
+				"Echo-Traceparent":           "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+				"Echo-X-Cloud-Trace-Context": "105445aa7843bc8bf206b12000100000/1;o=1",
+			},
+		},
+		{
+			desc: "traceparent context propagation is enabled, the trace id is preserved",
+			confArgs: append([]string{
+				"--tracing_incoming_context=traceparent",
+				"--tracing_outgoing_context=traceparent",
+			}, utils.CommonArgs()...),
+			requestHeader: incomingTraceContexts,
+			wantRespHeaders: map[string]string{
+				// Trace id is maintained. Span id is changed, so it's not checked.
+				"Echo-Traceparent": "00-0af7651916cd43dd8448eb211c80319c-",
+				// All other headers are not changed.
+				"Echo-X-Cloud-Trace-Context": "105445aa7843bc8bf206b12000100000/1;o=1",
+			},
+			notWantRespHeaders: map[string]string{
+				// The span id should have changed.
+				"Echo-Traceparent": "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+			},
+		},
+		{
+			desc: "x-cloud-trace-context context propagation is enabled, the trace id is preserved",
+			confArgs: append([]string{
+				"--tracing_incoming_context=x-cloud-trace-context",
+				"--tracing_outgoing_context=x-cloud-trace-context",
+			}, utils.CommonArgs()...),
+			requestHeader: incomingTraceContexts,
+			wantRespHeaders: map[string]string{
+				// Trace id is maintained. Span id is changed, so it's not checked.
+				"Echo-X-Cloud-Trace-Context": "105445aa7843bc8bf206b12000100000/",
+				// All other headers are not changed.
+				"Echo-Traceparent": "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+			},
+			notWantRespHeaders: map[string]string{
+				// The span id should have changed.
+				"Echo-X-Cloud-Trace-Context": "105445aa7843bc8bf206b12000100000/1;o=1",
+			},
+		},
+		{
+			desc: "traceparent context propagation is enabled for outgoing only, so the incoming header is fully overwritten",
+			confArgs: append([]string{
+				"--tracing_incoming_context=",
+				"--tracing_outgoing_context=traceparent",
+			}, utils.CommonArgs()...),
+			requestHeader: incomingTraceContexts,
+			wantRespHeaders: map[string]string{
+				// Trace id and span is is changed, so it's not checked.
+				"Echo-Traceparent": "00-",
+				// All other headers are not changed.
+				"Echo-X-Cloud-Trace-Context": "105445aa7843bc8bf206b12000100000/1;o=1",
+			},
+			notWantRespHeaders: map[string]string{
+				// The trace id and span id should have changed.
+				"Echo-Traceparent": "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+			},
+		},
+		// grpc-trace-bin is not tested, it's difficult to test.
+		// We should be safe, opencensus has tests for this.
+	}
+	for _, tc := range testData {
+		t.Run(tc.desc, func(t *testing.T) {
+
+			s := env.NewTestEnv(platform.TestTraceContextPropagationHeaders, platform.EchoRemote)
+			s.SetupFakeTraceServer(1)
+			defer s.TearDown(t)
+			if err := s.Setup(tc.confArgs); err != nil {
+				t.Fatalf("fail to setup test env, %v", err)
+			}
+
+			url := fmt.Sprintf("http://localhost:%v%v%v", s.Ports().ListenerPort, "/echoHeader", "")
+			headers, _, err := utils.DoWithHeaders(url, util.GET, "", tc.requestHeader)
+			if err != nil {
+				t.Fatalf("fail to make call to backend: %v", err)
+			}
+
+			for wantHeaderName, wantHeaderVal := range tc.wantRespHeaders {
+				if !utils.CheckHeaderExist(headers, wantHeaderName, func(gotHeaderVal string) bool {
+					return strings.Contains(gotHeaderVal, wantHeaderVal)
+				}) {
+					t.Errorf("got headers %+q, \ndid not find expected header %s = %s,  ", headers, wantHeaderName, wantHeaderVal)
+				}
+			}
+
+			for notWantHeaderName, notWantHeaderVal := range tc.notWantRespHeaders {
+				if utils.CheckHeaderExist(headers, notWantHeaderName, func(gotHeaderVal string) bool {
+					return strings.Contains(gotHeaderVal, notWantHeaderVal)
+				}) {
+					t.Errorf("got headers %+q, \nfound header %s = %s, but did not want it", headers, notWantHeaderName, notWantHeaderVal)
+				}
+			}
+
+			// Ignore the spans in this test, we do not check the names.
+			time.Sleep(5 * time.Second)
+			_, _ = s.FakeStackdriverServer.RetrieveSpanNames()
+		})
 	}
 }

--- a/tests/integration_test/opencensus_tracing_test.go
+++ b/tests/integration_test/opencensus_tracing_test.go
@@ -444,7 +444,7 @@ func TestTraceContextPropagationHeaders(t *testing.T) {
 		notWantRespHeaders map[string]string
 	}{
 		{
-			desc: "trace context propagation is disabled",
+			desc: "trace context propagation is disabled, all headers are preserved",
 			confArgs: append([]string{
 				"--tracing_incoming_context=",
 				"--tracing_outgoing_context=",

--- a/tests/integration_test/opencensus_tracing_test.go
+++ b/tests/integration_test/opencensus_tracing_test.go
@@ -500,7 +500,7 @@ func TestTraceContextPropagationHeaders(t *testing.T) {
 			}, utils.CommonArgs()...),
 			requestHeader: incomingTraceContexts,
 			wantRespHeaders: map[string]string{
-				// Trace id and span is is changed, so it's not checked.
+				// Trace id and span id are changed, so they not checked.
 				"Echo-Traceparent": "00-",
 				// All other headers are not changed.
 				"Echo-X-Cloud-Trace-Context": "105445aa7843bc8bf206b12000100000/1;o=1",

--- a/tests/start_proxy/start_proxy_test.py
+++ b/tests/start_proxy/start_proxy_test.py
@@ -140,11 +140,11 @@ class TestStartProxy(unittest.TestCase):
               '/etc/endpoint/ssl', '--disable_tracing'
               ]),
             # legacy ssl_port specified
-            (['-R=managed','--ssl_port=9000'],
+            (['-R=managed','--ssl_port=9000', '--disable_tracing'],
              ['bin/configmanager', '--logtostderr', '--rollout_strategy', 'managed',
               '--backend_address', 'http://127.0.0.1:8082', '--v', '0',
               '--ssl_server_cert_path', '/etc/nginx/ssl',
-              '--listener_port', '9000',
+              '--listener_port', '9000', '--disable_tracing',
               ]),
             # ssl_backend_client_cert_path specified
             (['-R=managed','--listener_port=8080',  '--disable_tracing',
@@ -293,24 +293,27 @@ class TestStartProxy(unittest.TestCase):
             # grpc backend with fixed version and tracing
             (['--service=test_bookstore.gloud.run', '--version=2019-11-09r0',
               '--backend=grpc://127.0.0.1:8000', '--http_request_timeout_s=10',
-              '--log_jwt_payloads=aud,exp'],
+              '--log_jwt_payloads=aud,exp', '--disable_tracing'],
              ['bin/configmanager', '--logtostderr', '--rollout_strategy', 'fixed',
               '--backend_address', 'grpc://127.0.0.1:8000', '--v', '0',
               '--log_jwt_payloads', 'aud,exp',
               '--service', 'test_bookstore.gloud.run',
               '--http_request_timeout_s', '10',
               '--service_config_id', '2019-11-09r0',
+              '--disable_tracing',
               ]),
             # json-grpc transcoder json print options
             (['--service=test_bookstore.gloud.run',
               '--backend=grpc://127.0.0.1:8000',
               '--transcoding_always_print_primitive_fields',
               '--transcoding_preserve_proto_field_names',
-              '--transcoding_always_print_enums_as_ints'
+              '--transcoding_always_print_enums_as_ints',
+              '--disable_tracing',
               ],
              ['bin/configmanager', '--logtostderr', '--rollout_strategy', 'fixed',
               '--backend_address', 'grpc://127.0.0.1:8000', '--v', '0',
               '--service', 'test_bookstore.gloud.run',
+              '--disable_tracing',
               '--transcoding_always_print_primitive_fields',
               '--transcoding_always_print_enums_as_ints',
               '--transcoding_preserve_proto_field_names',
@@ -318,47 +321,56 @@ class TestStartProxy(unittest.TestCase):
             # json-grpc transcoder ignore unknown parameters
             (['--service=test_bookstore.gloud.run',
               '--backend=grpc://127.0.0.1:8000',
-              '--transcoding_ignore_query_parameters=foo,bar'
+              '--transcoding_ignore_query_parameters=foo,bar',
+              '--disable_tracing'
               ],
              ['bin/configmanager', '--logtostderr', '--rollout_strategy', 'fixed',
               '--backend_address', 'grpc://127.0.0.1:8000', '--v', '0',
               '--service', 'test_bookstore.gloud.run',
+              '--disable_tracing',
               '--transcoding_ignore_query_parameters', 'foo,bar'
               ]),
             (['--service=test_bookstore.gloud.run',
               '--backend=grpc://127.0.0.1:8000',
-              '--transcoding_ignore_unknown_query_parameters'
+              '--transcoding_ignore_unknown_query_parameters',
+              '--disable_tracing',
               ],
              ['bin/configmanager', '--logtostderr', '--rollout_strategy', 'fixed',
               '--backend_address', 'grpc://127.0.0.1:8000', '--v', '0',
               '--service', 'test_bookstore.gloud.run',
+              '--disable_tracing',
               '--transcoding_ignore_unknown_query_parameters'
               ]),
             # Connection buffer limit bytes
             (['--service=test_bookstore.gloud.run',
               '--backend=grpc://127.0.0.1:8000',
-              '--envoy_connection_buffer_limit_bytes=1024'
+              '--envoy_connection_buffer_limit_bytes=1024',
+              '--disable_tracing',
               ],
              ['bin/configmanager', '--logtostderr', '--rollout_strategy', 'fixed',
               '--backend_address', 'grpc://127.0.0.1:8000', '--v', '0',
               '--service', 'test_bookstore.gloud.run',
+              '--disable_tracing',
               '--connection_buffer_limit_bytes', '1024'
               ]),
             # --enable_debug, with default http schema
             (['--service=test_bookstore.gloud.run',
               '--backend=echo:8000',
               '--enable_debug',
+              '--disable_tracing',
               ],
              ['bin/configmanager', '--logtostderr',
               '--rollout_strategy', 'fixed',
               '--backend_address', 'http://echo:8000',
               '--v', '1',
               '--service', 'test_bookstore.gloud.run',
+              '--disable_tracing',
               '--suppress_envoy_headers=false'
               ]),
             (['--service=test_bookstore.gloud.run',
               '--backend=127.0.0.1:8000',
-              '--access_log=/foo/bar', "--access_log_format=%START_TIME%"
+              '--access_log=/foo/bar', "--access_log_format=%START_TIME%",
+              '--disable_tracing',
               ],
              ['bin/configmanager', '--logtostderr',
               '--rollout_strategy', 'fixed',
@@ -366,7 +378,8 @@ class TestStartProxy(unittest.TestCase):
               '--v', '0',
               '--service', 'test_bookstore.gloud.run',
               '--access_log', '/foo/bar',
-              '--access_log_format', '%START_TIME%'
+              '--access_log_format', '%START_TIME%',
+              '--disable_tracing',
               ]),
             # Tracing disabled on non-gcp
             (['--service=test_bookstore.gloud.run',
@@ -387,6 +400,8 @@ class TestStartProxy(unittest.TestCase):
               '--backend_address', 'http://127.0.0.1', '--v', '0',
               '--service', 'test_bookstore.gloud.run',
               '--tracing_project_id', 'test_project_1234',
+              '--tracing_incoming_context', 'traceparent',
+              '--tracing_outgoing_context', 'traceparent',
               '--service_account_key', '/tmp/service_accout_key', '--non_gcp',
               ]),
             # Tracing params preserved.
@@ -418,43 +433,51 @@ class TestStartProxy(unittest.TestCase):
               '--backend_address', 'grpc://127.0.0.1:8000',
               '--v', '0',
               '--service', 'test_bookstore.gloud.run',
+              '--tracing_incoming_context', 'traceparent',
+              '--tracing_outgoing_context', 'traceparent',
               '--tracing_sample_rate', '0',
               ]),
             # --disable_tracing overrides all other tracing flags
             (['--service=test_bookstore.gloud.run',
               '--backend=grpc://127.0.0.1:8000',
               '--tracing_sample_rate=1',
-              '--disable_tracing'
+              '--disable_tracing',
               ],
              ['bin/configmanager', '--logtostderr',
               '--rollout_strategy', 'fixed',
               '--backend_address', 'grpc://127.0.0.1:8000',
               '--v', '0',
               '--service', 'test_bookstore.gloud.run',
-              '--disable_tracing'
+              '--disable_tracing',
               ]),
             # Service account key does not assume non-gcp
             # and does not disable tracing.
             (['--service=test_bookstore.gloud.run',
               '--backend=http://127.0.0.1',
-              '--service_account_key', '/tmp/service_account_key'],
+              '--service_account_key', '/tmp/service_account_key',
+              '--disable_tracing',
+              ],
              ['bin/configmanager', '--logtostderr',
               '--rollout_strategy', 'fixed',
               '--backend_address', 'http://127.0.0.1',
               '--v', '0',
               '--service', 'test_bookstore.gloud.run',
+              '--disable_tracing',
               '--service_account_key', '/tmp/service_account_key',
               ]),
             # Serverless sets compute platform and xff_num_trusted_hops.
             (['--on_serverless',
               '--http_port=8080',
               '--rollout_strategy=fixed',
-              '--service_json_path=/tmp/service_config.json'],
+              '--service_json_path=/tmp/service_config.json',
+              '--disable_tracing',
+              ],
              ['bin/configmanager',  '--logtostderr', '--rollout_strategy', 'fixed',
               '--backend_address', 'http://127.0.0.1:8082', '--v', '0',
               '--envoy_xff_num_trusted_hops', '0',
               '--listener_port', '8080',
               '--service_json_path', '/tmp/service_config.json',
+              '--disable_tracing',
               '--compute_platform_override', 'Cloud Run(ESPv2)'
               ]),
             # Serverless with override for xff_num_trusted_hops.
@@ -462,20 +485,25 @@ class TestStartProxy(unittest.TestCase):
               '--http_port=8080',
               '--rollout_strategy=fixed',
               '--service_json_path=/tmp/service_config.json',
-              '--envoy_xff_num_trusted_hops=3'],
+              '--envoy_xff_num_trusted_hops=3',
+              '--disable_tracing',
+              ],
              ['bin/configmanager',  '--logtostderr', '--rollout_strategy', 'fixed',
               '--backend_address', 'http://127.0.0.1:8082', '--v', '0',
               '--envoy_xff_num_trusted_hops', '3',
               '--listener_port', '8080',
               '--service_json_path', '/tmp/service_config.json',
+              '--disable_tracing',
               '--compute_platform_override', 'Cloud Run(ESPv2)'
               ]),
         ]
 
+        i = 0
         for flags, wantedArgs in testcases:
             gotArgs = gen_proxy_config(self.parser.parse_args(flags))
             self.assertEqual(gotArgs, wantedArgs,
-                             msg="Fail for input [{}] : got != want".format(', '.join(flags)))
+                             msg="Fail for input #{} [{}] : got != want".format(i, ', '.join(flags)))
+            i += 1
 
     def test_gen_proxy_config_error(self):
         testcases = [

--- a/tests/utils/http.go
+++ b/tests/utils/http.go
@@ -95,3 +95,18 @@ func DoWithHeaders(url, method, message string, headers map[string]string) (http
 	}
 	return resp.Header, bodyBytes, err
 }
+
+type HeaderValueChecker func(gotHeaderVal string) bool
+
+// CheckHeaderExist will check for the given header name in the headers.
+// If a value is provided, it will check the value is contained in the original header value.
+func CheckHeaderExist(headers http.Header, wantHeaderName string, valueChecker HeaderValueChecker) bool {
+	for headerName, headerVals := range headers {
+		if headerName == wantHeaderName {
+			if len(headerVals) > 0 && valueChecker(headerVals[0]) {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Action item number 1 as discussed in #412. 

Testing done:
- Unit tests to ensure default value reaches config manager.
- Added some integration tests to verify how headers are manipulated based on the trace context settings.

Signed-off-by: Teju Nareddy <nareddyt@google.com>