### PR TITLE
Feature: Build from Bazel

### DIFF
--- a/src/envoy/BUILD
+++ b/src/envoy/BUILD
@@ -1,22 +1,48 @@
+package(
+    default_visibility = ["//visibility:public"],
+)
+
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_binary",
 )
 
-package(
-    default_visibility = [
-        "//src/envoy:__subpackages__",
-    ],
+
+alias(
+    name = "backend_auth",
+    actual = "//src/envoy/http/backend_auth:filter_factory",
 )
+
+alias(
+    name = "grpc_metadata_scrubber",
+    actual = "//src/envoy/http/grpc_metadata_scrubber:filter_factory",
+)
+
+alias(
+    name = "path_rewrite",
+    actual = "//src/envoy/http/path_rewrite:filter_factory",
+)
+
+alias(
+    name = "service_control",
+    actual = "//src/envoy/http/service_control:filter_factory",
+)
+
+alias(
+    name = "main",
+    actual = "@envoy//source/exe:envoy_main_entry_lib",
+)
+
 
 envoy_cc_binary(
     name = "envoy",
     repository = "@envoy",
     deps = [
-        "//src/envoy/http/backend_auth:filter_factory",
-        "//src/envoy/http/grpc_metadata_scrubber:filter_factory",
-        "//src/envoy/http/path_rewrite:filter_factory",
-        "//src/envoy/http/service_control:filter_factory",
-        "@envoy//source/exe:envoy_main_entry_lib",
+        ":backend_auth",
+        ":grpc_metadata_scrubber",
+        ":path_rewrite",
+        ":service_control",
+        ":main",
     ],
 )
+


### PR DESCRIPTION
This changeset preps ESPv2 to be able to build externally via Bazel, in projects that are already using Bazel.