### PR TITLE
b/173810289: fix request header size

### DIFF
--- a/src/envoy/http/service_control/handler_impl.cc
+++ b/src/envoy/http/service_control/handler_impl.cc
@@ -69,6 +69,7 @@ ServiceControlHandlerImpl::ServiceControlHandlerImpl(
       stream_info_(stream_info),
       time_source_(time_source),
       uuid_(uuid),
+      request_header_size_(headers.byteSize()),
       consumer_type_header_(cfg_parser_.config().generated_header_prefix() +
                             kConsumerTypeHeaderSuffix),
       consumer_number_header_(cfg_parser_.config().generated_header_prefix() +
@@ -338,18 +339,16 @@ void ServiceControlHandlerImpl::callReport(
   info.backend_protocol =
       getBackendProtocol(require_ctx_->service_ctx().config());
 
-  uint64_t request_header_size = 0;
   if (request_headers) {
     info.referer = std::string(utils::readHeaderEntry(
         request_headers->getInline(referer_handle.handle())));
-    request_header_size = request_headers->byteSize();
   }
 
   fillLatency(stream_info_, info.latency, filter_stats_);
 
   info.response_code = stream_info_.responseCode().value_or(500);
 
-  info.request_size = stream_info_.bytesReceived() + request_header_size;
+  info.request_size = stream_info_.bytesReceived() + request_header_size_;
 
   uint64_t response_header_size = 0;
   if (response_headers) {

--- a/src/envoy/http/service_control/handler_impl.h
+++ b/src/envoy/http/service_control/handler_impl.h
@@ -117,7 +117,9 @@ class ServiceControlHandlerImpl
   std::string uuid_;
   std::string api_key_;
 
-  // The size of request headers.
+  // Considering the request headers can be modified, the original downstream
+  // header should be used as request_header_size. This variable is used to
+  // remember the downstream header size when HandlerImpl object is created.
   int request_header_size_;
 
   // The name of headers to send consumer info

--- a/src/envoy/http/service_control/handler_impl.h
+++ b/src/envoy/http/service_control/handler_impl.h
@@ -117,6 +117,9 @@ class ServiceControlHandlerImpl
   std::string uuid_;
   std::string api_key_;
 
+  // The size of request headers.
+  int request_header_size_;
+
   // The name of headers to send consumer info
   const Envoy::Http::LowerCaseString consumer_type_header_;
   const Envoy::Http::LowerCaseString consumer_number_header_;


### PR DESCRIPTION
Right now, the service control filter report the size of request headers passed from upstream. It is incorrect behavior as we need the size of request headers from client and they can be modified by upstream filter like the backend auth filter.

**Fix**: use the size of request headers from downstream 

**Follow-up**: add integration tests for request/response header size

