### PR TITLE
b/174609312 #1: Handle trailing backslash for regex-match paths

### DIFF
--- a/examples/testdata/route_match/envoy_config.json
+++ b/examples/testdata/route_match/envoy_config.json
@@ -262,7 +262,7 @@
                               ],
                               "safeRegex": {
                                 "googleRe2": {},
-                                "regex": "^/libraries/[^\\/]+/shelves/[^\\/]+$"
+                                "regex": "^/libraries/[^\\/]+/shelves/[^\\/]+\\/?$"
                               }
                             },
                             "route": {
@@ -301,7 +301,7 @@
                               ],
                               "safeRegex": {
                                 "googleRe2": {},
-                                "regex": "^/libraries/[^\\/]+/shelves/[^\\/]+$"
+                                "regex": "^/libraries/[^\\/]+/shelves/[^\\/]+\\/?$"
                               }
                             },
                             "route": {
@@ -340,7 +340,7 @@
                               ],
                               "safeRegex": {
                                 "googleRe2": {},
-                                "regex": "^/.*$"
+                                "regex": "^/.*\\/?$"
                               }
                             },
                             "route": {
@@ -372,7 +372,7 @@
                               ],
                               "safeRegex": {
                                 "googleRe2": {},
-                                "regex": "^/.*$"
+                                "regex": "^/.*\\/?$"
                               }
                             },
                             "route": {
@@ -404,7 +404,7 @@
                               ],
                               "safeRegex": {
                                 "googleRe2": {},
-                                "regex": "^/.*$"
+                                "regex": "^/.*\\/?$"
                               }
                             },
                             "route": {
@@ -436,7 +436,7 @@
                               ],
                               "safeRegex": {
                                 "googleRe2": {},
-                                "regex": "^/.*$"
+                                "regex": "^/.*\\/?$"
                               }
                             },
                             "route": {
@@ -468,7 +468,7 @@
                               ],
                               "safeRegex": {
                                 "googleRe2": {},
-                                "regex": "^/.*$"
+                                "regex": "^/.*\\/?$"
                               }
                             },
                             "route": {
@@ -500,7 +500,7 @@
                               ],
                               "safeRegex": {
                                 "googleRe2": {},
-                                "regex": "^/.*$"
+                                "regex": "^/.*\\/?$"
                               }
                             },
                             "route": {

--- a/src/envoy/BUILD
+++ b/src/envoy/BUILD
@@ -7,7 +7,6 @@ load(
     "envoy_cc_binary",
 )
 
-
 alias(
     name = "backend_auth",
     actual = "//src/envoy/http/backend_auth:filter_factory",
@@ -33,16 +32,14 @@ alias(
     actual = "@envoy//source/exe:envoy_main_entry_lib",
 )
 
-
 envoy_cc_binary(
     name = "envoy",
     repository = "@envoy",
     deps = [
         ":backend_auth",
         ":grpc_metadata_scrubber",
+        ":main",
         ":path_rewrite",
         ":service_control",
-        ":main",
     ],
 )
-

--- a/src/go/configgenerator/route_generator.go
+++ b/src/go/configgenerator/route_generator.go
@@ -245,8 +245,6 @@ func makeRouteTable(serviceInfo *configinfo.ServiceInfo) ([]*routepb.Route, erro
 			HttpMethod:  httpPatternMethod.HttpMethod,
 		}
 
-		var routeMatcher *routepb.RouteMatch
-
 		// Response timeouts are not compatible with streaming methods (documented in Envoy).
 		// If this method is non-unary gRPC, explicitly set 0s to disable the timeout.
 		// This even applies for routes with gRPC-JSON transcoding where only the upstream is streaming.
@@ -257,6 +255,7 @@ func makeRouteTable(serviceInfo *configinfo.ServiceInfo) ([]*routepb.Route, erro
 			respTimeout = method.BackendInfo.Deadline
 		}
 
+		var routeMatcher *routepb.RouteMatch
 		var err error
 		if routeMatcher, err = makeHttpRouteMatcher(httpRule); err != nil {
 			return nil, fmt.Errorf("error making HTTP route matcher for selector (%v): %v", operation, err)

--- a/src/go/configgenerator/route_generator_test.go
+++ b/src/go/configgenerator/route_generator_test.go
@@ -257,7 +257,7 @@ func TestMakeRouteConfig(t *testing.T) {
           "match":{
             "safeRegex":{
               "googleRe2":{},
-              "regex":"^/v1/[^\\/]+/test/.*$"
+              "regex":"^/v1/[^\\/]+/test/.*\\/?$"
             }
           },
           "route":{
@@ -364,7 +364,7 @@ func TestMakeRouteConfig(t *testing.T) {
             ],
             "safeRegex": {
               "googleRe2": {},
-              "regex": "^/v1/shelves/[^\\/]+$"
+              "regex": "^/v1/shelves/[^\\/]+\\/?$"
             }
           },
           "route": {
@@ -400,7 +400,7 @@ func TestMakeRouteConfig(t *testing.T) {
             ],
             "safeRegex": {
               "googleRe2": {},
-              "regex": "^/v1/shelves/[^\\/]+$"
+              "regex": "^/v1/shelves/[^\\/]+\\/?$"
             }
           },
           "route": {
@@ -717,7 +717,7 @@ func TestMakeRouteConfig(t *testing.T) {
             ],
             "safeRegex": {
               "googleRe2": {},
-              "regex": "^/foo/[^\\/]+$"
+              "regex": "^/foo/[^\\/]+\\/?$"
             }
           },
           "route": {
@@ -756,7 +756,7 @@ func TestMakeRouteConfig(t *testing.T) {
             ],
             "safeRegex": {
               "googleRe2": {},
-              "regex": "^/foo/[^\\/]+$"
+              "regex": "^/foo/[^\\/]+\\/?$"
             }
           },
           "route": {
@@ -1226,7 +1226,7 @@ func TestMakeRouteConfig(t *testing.T) {
             ],
             "safeRegex": {
               "googleRe2": {},
-              "regex": "^/foo/[^\\/]+$"
+              "regex": "^/foo/[^\\/]+\\/?$"
             }
           },
           "route": {
@@ -1416,7 +1416,7 @@ func TestMakeRouteConfig(t *testing.T) {
                      "googleRe2":{
                         
                      },
-                     "regex":"^/foo/[^\\/]+$"
+                     "regex":"^/foo/[^\\/]+\\/?$"
                   }
                },
                "responseHeadersToAdd":[
@@ -1453,7 +1453,7 @@ func TestMakeRouteConfig(t *testing.T) {
                      "googleRe2":{
                         
                      },
-                     "regex":"^/foo/[^\\/]+/bar$"
+                     "regex":"^/foo/[^\\/]+/bar\\/?$"
                   }
                },
                "responseHeadersToAdd":[
@@ -1490,7 +1490,7 @@ func TestMakeRouteConfig(t *testing.T) {
                      "googleRe2":{
                         
                      },
-                     "regex":"^/foo/.*/bar$"
+                     "regex":"^/foo/.*/bar\\/?$"
                   }
                },
                "responseHeadersToAdd":[
@@ -1527,7 +1527,7 @@ func TestMakeRouteConfig(t *testing.T) {
                      "googleRe2":{
                         
                      },
-                     "regex":"^/foo/.*:verb$"
+                     "regex":"^/foo/.*\\/?:verb$"
                   }
                },
                "responseHeadersToAdd":[
@@ -1564,7 +1564,7 @@ func TestMakeRouteConfig(t *testing.T) {
                      "googleRe2":{
                         
                      },
-                     "regex":"^/foo/.*$"
+                     "regex":"^/foo/.*\\/?$"
                   }
                },
                "responseHeadersToAdd":[
@@ -1676,7 +1676,7 @@ func TestMakeRouteConfigForCors(t *testing.T) {
 		},
 		{
 			desc:        "Incorrect configured basic Cors",
-			params:      []string{"basic", "", `^https?://.+\\.example\\.com$`, "", "", ""},
+			params:      []string{"basic", "", `^https?://.+\\.example\\.com\/?$`, "", "", ""},
 			wantedError: "cors_allow_origin cannot be empty when cors_preset=basic",
 		},
 		{
@@ -1686,7 +1686,7 @@ func TestMakeRouteConfigForCors(t *testing.T) {
 		},
 		{
 			desc:        "Incorrect configured regex Cors",
-			params:      []string{"cors_with_regexs", "", `^https?://.+\\.example\\.com$`, "", "", ""},
+			params:      []string{"cors_with_regexs", "", `^https?://.+\\.example\\.com\/?$`, "", "", ""},
 			wantedError: `cors_preset must be either "basic" or "cors_with_regex"`,
 		},
 		{
@@ -1711,7 +1711,7 @@ func TestMakeRouteConfigForCors(t *testing.T) {
 		},
 		{
 			desc:   "Correct configured regex Cors, with allow headers",
-			params: []string{"cors_with_regex", "", `^https?://.+\\.example\\.com$`, "", "Origin,Content-Type,Accept", ""},
+			params: []string{"cors_with_regex", "", `^https?://.+\\.example\\.com\/?$`, "", "Origin,Content-Type,Accept", ""},
 			wantCorsPolicy: &routepb.CorsPolicy{
 				AllowOriginStringMatch: []*matcher.StringMatcher{
 					{
@@ -1720,7 +1720,7 @@ func TestMakeRouteConfigForCors(t *testing.T) {
 								EngineType: &matcher.RegexMatcher_GoogleRe2{
 									GoogleRe2: &matcher.RegexMatcher_GoogleRE2{},
 								},
-								Regex: `^https?://.+\\.example\\.com$`,
+								Regex: `^https?://.+\\.example\\.com\/?$`,
 							},
 						},
 					},
@@ -1731,7 +1731,7 @@ func TestMakeRouteConfigForCors(t *testing.T) {
 		},
 		{
 			desc:             "Correct configured regex Cors, with expose headers",
-			params:           []string{"cors_with_regex", "", `^https?://.+\\.example\\.com$`, "", "", "Content-Length"},
+			params:           []string{"cors_with_regex", "", `^https?://.+\\.example\\.com\/?$`, "", "", "Content-Length"},
 			allowCredentials: true,
 			wantCorsPolicy: &routepb.CorsPolicy{
 				AllowOriginStringMatch: []*matcher.StringMatcher{
@@ -1741,7 +1741,7 @@ func TestMakeRouteConfigForCors(t *testing.T) {
 								EngineType: &matcher.RegexMatcher_GoogleRe2{
 									GoogleRe2: &matcher.RegexMatcher_GoogleRE2{},
 								},
-								Regex: `^https?://.+\\.example\\.com$`,
+								Regex: `^https?://.+\\.example\\.com\/?$`,
 							},
 						},
 					},

--- a/src/go/configmanager/testdata/test_fetch_listeners.go
+++ b/src/go/configmanager/testdata/test_fetch_listeners.go
@@ -596,7 +596,7 @@ var (
                                        "googleRe2":{
                                           
                                        },
-                                       "regex":"^/v1/shelves/[^\\/]+$"
+                                       "regex":"^/v1/shelves/[^\\/]+\\/?$"
                                     }
                                  },
                                  "route":{
@@ -879,7 +879,7 @@ var (
                                        "googleRe2":{
                                           
                                        },
-                                       "regex":"^/v1/shelves/[^\\/]+/books/[^\\/]+$"
+                                       "regex":"^/v1/shelves/[^\\/]+/books/[^\\/]+\\/?$"
                                     }
                                  },
                                  "route":{
@@ -908,7 +908,7 @@ var (
                                        "googleRe2":{
                                           
                                        },
-                                       "regex":"^/v1/shelves/[^\\/]+/books/[^\\/]+$"
+                                       "regex":"^/v1/shelves/[^\\/]+/books/[^\\/]+\\/?$"
                                     }
                                  },
                                  "route":{

--- a/src/go/configmanager/testdata/test_fixed_mode_dynamic_routing.go
+++ b/src/go/configmanager/testdata/test_fixed_mode_dynamic_routing.go
@@ -399,7 +399,7 @@ var (
                         ],
                         "safeRegex": {
                           "googleRe2": {},
-                          "regex": "^/pet/[^\\/]+$"
+                          "regex": "^/pet/[^\\/]+\\/?$"
                         }
                       },
                       "route": {

--- a/src/go/util/httppattern/uri_template.go
+++ b/src/go/util/httppattern/uri_template.go
@@ -152,6 +152,7 @@ func (u *UriTemplate) Regex() string {
 			regex.WriteString(segment)
 		}
 	}
+	regex.WriteString(optionalTrailingSlashRegex)
 
 	if u.Verb != "" {
 		regex.WriteString(":" + u.Verb)

--- a/src/go/util/httppattern/uri_template_test.go
+++ b/src/go/util/httppattern/uri_template_test.go
@@ -154,47 +154,47 @@ func TestUriTemplateRegex(t *testing.T) {
 		{
 			desc:        "No path params",
 			uri:         "/shelves",
-			wantMatcher: `^/shelves$`,
+			wantMatcher: `^/shelves\/?$`,
 		},
 		{
 			desc:        "Path params with fieldpath-only bindings",
 			uri:         "/shelves/{shelf_id}/books/{book.id}",
-			wantMatcher: `^/shelves/[^\/]+/books/[^\/]+$`,
+			wantMatcher: `^/shelves/[^\/]+/books/[^\/]+\/?$`,
 		},
 		{
 			desc:        "Path params with fieldpath-only bindings and verb",
 			uri:         "/shelves/{shelf_id}/books/{book.id}:checkout",
-			wantMatcher: `^/shelves/[^\/]+/books/[^\/]+:checkout$`,
+			wantMatcher: `^/shelves/[^\/]+/books/[^\/]+\/?:checkout$`,
 		},
 		{
 			desc:        "Path param with wildcard segments",
 			uri:         "/test/*/test/**",
-			wantMatcher: `^/test/[^\/]+/test/.*$`,
+			wantMatcher: `^/test/[^\/]+/test/.*\/?$`,
 		},
 		{
 			desc:        "Path param with wildcard segments and verb",
 			uri:         "/test/*/test/**:upload",
-			wantMatcher: `^/test/[^\/]+/test/.*:upload$`,
+			wantMatcher: `^/test/[^\/]+/test/.*\/?:upload$`,
 		},
 		{
 			desc:        "Path param with wildcard in segment binding",
 			uri:         "/test/{x=*}/test/{y=**}",
-			wantMatcher: `^/test/[^\/]+/test/.*$`,
+			wantMatcher: `^/test/[^\/]+/test/.*\/?$`,
 		},
 		{
 			desc:        "Path param with mixed wildcards",
 			uri:         "/test/{name=*}/test/**",
-			wantMatcher: `^/test/[^\/]+/test/.*$`,
+			wantMatcher: `^/test/[^\/]+/test/.*\/?$`,
 		},
 		{
 			desc:        "Path params with full segment binding",
 			uri:         "/v1/{name=books/*}",
-			wantMatcher: `^/v1/books/[^\/]+$`,
+			wantMatcher: `^/v1/books/[^\/]+\/?$`,
 		},
 		{
 			desc:        "Path params with multiple field path segment bindings",
 			uri:         "/v1/{test=a/b/*}/route/{resource_id=shelves/*/books/**}:upload",
-			wantMatcher: `^/v1/a/b/[^\/]+/route/shelves/[^\/]+/books/.*:upload$`,
+			wantMatcher: `^/v1/a/b/[^\/]+/route/shelves/[^\/]+/books/.*\/?:upload$`,
 		},
 	}
 

--- a/src/go/util/httppattern/util.go
+++ b/src/go/util/httppattern/util.go
@@ -12,4 +12,6 @@ const (
 	singleWildcardReplacementRegex = `[^\/]+`
 	// Matches any character or no characters at all.
 	doubleWildcardReplacementRegex = `.*`
+	// Matches a trailing slash at the end of a path.
+	optionalTrailingSlashRegex = `\/?`
 )

--- a/tests/endpoints/echo/server/app.go
+++ b/tests/endpoints/echo/server/app.go
@@ -55,6 +55,7 @@ func main() {
 		HandlerFunc(echoHeaderHandler)
 	r.PathPrefix("/echoMethod").Methods("GET", "POST", "PUT", "DELETE", "PATCH").
 		HandlerFunc(echoMethodHandler)
+	r.Path("/prefix/echo/{variable}/path").Methods("GET").HandlerFunc(dynamicRoutingHandler)
 
 	r.Path("/websocketecho").HandlerFunc(websocketEchoHandler)
 	r.Path("/echo/nokey").Methods("POST").

--- a/tests/env/testdata/fake_echo_service_config_for_dynamic_routing.go
+++ b/tests/env/testdata/fake_echo_service_config_for_dynamic_routing.go
@@ -43,6 +43,9 @@ var (
 						Name: "EchoHeader",
 					},
 					{
+						Name: "EchoAppendPath",
+					},
+					{
 						Name: "dynamic_routing_GetPetById",
 					},
 					{
@@ -132,6 +135,12 @@ var (
 					Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.EchoHeader",
 					Pattern: &annotationspb.HttpRule_Get{
 						Get: "/echoHeader",
+					},
+				},
+				{
+					Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.EchoAppendPath",
+					Pattern: &annotationspb.HttpRule_Get{
+						Get: "/echo/{variable}/path",
 					},
 				},
 				{
@@ -346,6 +355,10 @@ var (
 					AllowUnregisteredCalls: true,
 				},
 				{
+					Selector:               "1.echo_api_endpoints_cloudesf_testing_cloud_goog.EchoAppendPath",
+					AllowUnregisteredCalls: true,
+				},
+				{
 					Selector:               "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_GetPetById",
 					AllowUnregisteredCalls: true,
 				},
@@ -448,6 +461,11 @@ var (
 					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.EchoHeader",
 					Address:         fmt.Sprintf("https://localhost:%s/echoHeader", platform.WorkingBackendPort),
 					PathTranslation: confpb.BackendRule_CONSTANT_ADDRESS,
+				},
+				{
+					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.EchoAppendPath",
+					Address:         fmt.Sprintf("https://localhost:%s/prefix", platform.WorkingBackendPort),
+					PathTranslation: confpb.BackendRule_APPEND_PATH_TO_ADDRESS,
 				},
 				{
 					Selector:        "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_GetPetById",

--- a/tests/integration_test/dynamic_routing_integration_test.go
+++ b/tests/integration_test/dynamic_routing_integration_test.go
@@ -251,6 +251,12 @@ func TestDynamicRouting(t *testing.T) {
 			wantResp: `{"RequestURI":"/dynamicrouting/const_wildcard?s_1=a/1/b/2&s_2=x/9/8/7"}`,
 		},
 		{
+			desc:     "Succeed, CONSTANT_ADDRESS with query params for variable bindings with multiple segments and trailing slash",
+			path:     "/field_path/a/1/b/2/x/9/8/7/:upload",
+			method:   "GET",
+			wantResp: `{"RequestURI":"/dynamicrouting/const_wildcard?s_1=a/1/b/2&s_2=x/9/8/7/"}`,
+		},
+		{
 			desc:          "Fail, CONSTANT_ADDRESS but verb is incorrect",
 			path:          "/field_path/a/1/b/2/x/9/8/7:incorrect_verb",
 			method:        "GET",

--- a/tests/integration_test/dynamic_routing_integration_test.go
+++ b/tests/integration_test/dynamic_routing_integration_test.go
@@ -95,6 +95,18 @@ func TestDynamicRouting(t *testing.T) {
 			wantResp: `{"RequestURI":"/dynamicrouting/bookinfo?SHELF=123&BOOK=987"}`,
 		},
 		{
+			desc:     "Succeed, CONSTANT_ADDRESS path translation with trailing slash works",
+			path:     "/shelves/123/books/info/987/",
+			method:   "GET",
+			wantResp: `{"RequestURI":"/dynamicrouting/bookinfo?SHELF=123&BOOK=987"}`,
+		},
+		{
+			desc:          "Succeed, CONSTANT_ADDRESS path translation with multiple trailing slashes fails",
+			path:          "/shelves/123/books/info/987//",
+			method:        "GET",
+			httpCallError: fmt.Errorf("http response status is not 200 OK: 404 Not Found"),
+		},
+		{
 			desc:     "Succeed, CONSTANT_ADDRESS path translation with snake case is correct, supports {foo.bar} style path, if corresponding jsonName not found, origin snake case path is used.",
 			path:     "/shelves/221/books/id/2019",
 			method:   "GET",
@@ -269,6 +281,46 @@ func TestDynamicRouting(t *testing.T) {
 		{
 			desc:     "Route match ordering - Match http pattern `POST /allow-all/{double_wildcard=**}`",
 			path:     "/allow-all/should-match/double-wildcard",
+			method:   "POST",
+			message:  "hello",
+			wantResp: `{"RequestURI":"/dynamicrouting/const_wildcard?double_wildcard=should-match/double-wildcard"}`,
+		},
+		// Test regex route match with trailing slashes.
+		{
+			desc:     "APPEND_PATH_TO_ADDRESS should work with variable binding",
+			path:     "/echo/123/path",
+			method:   "GET",
+			wantResp: `{"RequestURI":"/prefix/echo/123/path"}`,
+		},
+		{
+			desc:     "APPEND_PATH_TO_ADDRESS should work with variable binding and trailing slash (preserved)",
+			path:     "/echo/123/path/",
+			method:   "GET",
+			wantResp: `{"RequestURI":"/prefix/echo/123/path/"}`,
+		},
+		{
+			desc:          "APPEND_PATH_TO_ADDRESS fails with multiple trailing slashes",
+			path:          "/echo/123/path//",
+			method:        "GET",
+			httpCallError: fmt.Errorf("http response status is not 200 OK: 404 Not Found"),
+		},
+		{
+			desc:     "Allow all with single wildcard works with trailing slash",
+			path:     "/allow-all/should-match-single-wildcard/",
+			method:   "POST",
+			message:  "hello",
+			wantResp: `{"RequestURI":"/dynamicrouting/const_wildcard?single_wildcard=should-match-single-wildcard"}`,
+		},
+		{
+			desc:     "Allow all with double wildcard works with trailing slash",
+			path:     "/allow-all/should-match/double-wildcard/",
+			method:   "POST",
+			message:  "hello",
+			wantResp: `{"RequestURI":"/dynamicrouting/const_wildcard?double_wildcard=should-match/double-wildcard"}`,
+		},
+		{
+			desc:     "Multiple trailing slashes are accepted by allow all with double wildcard, they are treated as empty segments",
+			path:     "/allow-all/should-match/double-wildcard///",
 			method:   "POST",
 			message:  "hello",
 			wantResp: `{"RequestURI":"/dynamicrouting/const_wildcard?double_wildcard=should-match/double-wildcard"}`,


### PR DESCRIPTION
Currently, ESPv2 only matches paths when they are not followed by a trailing slash. This matches the path template syntax, but is problematic for some clients. Transition ESPv2 to match paths with trailing slashes. This PR only changes regex-based paths - it is trivial and will minimize the diff of the following PR.

The trailing slash will **not** be stripped from the request unless `CONSTANT_ADDRESS` path rewrite is configured.

Testing done:
- Updated config manager unit tests
- Added new integration tests