### PR TITLE
b/174609312 #2: Handle trailing slashes for exact match paths

### DIFF
--- a/examples/auth/envoy_config.json
+++ b/examples/auth/envoy_config.json
@@ -349,6 +349,38 @@
                           },
                           {
                             "decorator": {
+                              "operation": "ingress ListShelves"
+                            },
+                            "match": {
+                              "headers": [
+                                {
+                                  "exactMatch": "GET",
+                                  "name": ":method"
+                                }
+                              ],
+                              "path": "/shelves/"
+                            },
+                            "route": {
+                              "cluster": "backend-cluster-examples-auth.endpoints.cloudesf-testing.cloud.goog_local",
+                              "retryPolicy": {
+                                "numRetries": 1,
+                                "retryOn": "reset,connect-failure,refused-stream"
+                              },
+                              "timeout": "15s"
+                            },
+                            "typedPerFilterConfig": {
+                              "com.google.espv2.filters.http.service_control": {
+                                "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                                "operationName": "1.examples_auth_endpoints_cloudesf_testing_cloud_goog.ListShelves"
+                              },
+                              "envoy.filters.http.jwt_authn": {
+                                "@type": "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig",
+                                "requirementName": "1.examples_auth_endpoints_cloudesf_testing_cloud_goog.ListShelves"
+                              }
+                            }
+                          },
+                          {
+                            "decorator": {
                               "operation": "ingress CreateShelf"
                             },
                             "match": {
@@ -359,6 +391,38 @@
                                 }
                               ],
                               "path": "/shelves"
+                            },
+                            "route": {
+                              "cluster": "backend-cluster-examples-auth.endpoints.cloudesf-testing.cloud.goog_local",
+                              "retryPolicy": {
+                                "numRetries": 1,
+                                "retryOn": "reset,connect-failure,refused-stream"
+                              },
+                              "timeout": "15s"
+                            },
+                            "typedPerFilterConfig": {
+                              "com.google.espv2.filters.http.service_control": {
+                                "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                                "operationName": "1.examples_auth_endpoints_cloudesf_testing_cloud_goog.CreateShelf"
+                              },
+                              "envoy.filters.http.jwt_authn": {
+                                "@type": "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig",
+                                "requirementName": "1.examples_auth_endpoints_cloudesf_testing_cloud_goog.CreateShelf"
+                              }
+                            }
+                          },
+                          {
+                            "decorator": {
+                              "operation": "ingress CreateShelf"
+                            },
+                            "match": {
+                              "headers": [
+                                {
+                                  "exactMatch": "POST",
+                                  "name": ":method"
+                                }
+                              ],
+                              "path": "/shelves/"
                             },
                             "route": {
                               "cluster": "backend-cluster-examples-auth.endpoints.cloudesf-testing.cloud.goog_local",

--- a/examples/dynamic_routing/envoy_config.json
+++ b/examples/dynamic_routing/envoy_config.json
@@ -291,6 +291,43 @@
                           },
                           {
                             "decorator": {
+                              "operation": "ingress ListShelves"
+                            },
+                            "match": {
+                              "headers": [
+                                {
+                                  "exactMatch": "GET",
+                                  "name": ":method"
+                                }
+                              ],
+                              "path": "/shelves/"
+                            },
+                            "route": {
+                              "cluster": "backend-cluster-http-bookstore-abc123456-uc.a.run.app:443",
+                              "hostRewriteLiteral": "http-bookstore-abc123456-uc.a.run.app",
+                              "retryPolicy": {
+                                "numRetries": 1,
+                                "retryOn": "reset,connect-failure,refused-stream"
+                              },
+                              "timeout": "7s"
+                            },
+                            "typedPerFilterConfig": {
+                              "com.google.espv2.filters.http.backend_auth": {
+                                "@type": "type.googleapis.com/espv2.api.envoy.v9.http.backend_auth.PerRouteFilterConfig",
+                                "jwtAudience": "ESPv2"
+                              },
+                              "com.google.espv2.filters.http.path_rewrite": {
+                                "@type": "type.googleapis.com/espv2.api.envoy.v9.http.path_rewrite.PerRouteFilterConfig",
+                                "pathPrefix": "/shelves"
+                              },
+                              "com.google.espv2.filters.http.service_control": {
+                                "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                                "operationName": "1.examples_dynamic_routing_wd6ufmzfya_uc_a_run_app.ListShelves"
+                              }
+                            }
+                          },
+                          {
+                            "decorator": {
                               "operation": "ingress CreateShelf"
                             },
                             "match": {
@@ -301,6 +338,41 @@
                                 }
                               ],
                               "path": "/shelves"
+                            },
+                            "route": {
+                              "cluster": "backend-cluster-http-bookstore-edf123456-uc.a.run.app:443",
+                              "hostRewriteLiteral": "http-bookstore-edf123456-uc.a.run.app",
+                              "retryPolicy": {
+                                "numRetries": 1,
+                                "retryOn": "reset,connect-failure,refused-stream"
+                              },
+                              "timeout": "23s"
+                            },
+                            "typedPerFilterConfig": {
+                              "com.google.espv2.filters.http.path_rewrite": {
+                                "@type": "type.googleapis.com/espv2.api.envoy.v9.http.path_rewrite.PerRouteFilterConfig",
+                                "constantPath": {
+                                  "path": "/shelves"
+                                }
+                              },
+                              "com.google.espv2.filters.http.service_control": {
+                                "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                                "operationName": "1.examples_dynamic_routing_wd6ufmzfya_uc_a_run_app.CreateShelf"
+                              }
+                            }
+                          },
+                          {
+                            "decorator": {
+                              "operation": "ingress CreateShelf"
+                            },
+                            "match": {
+                              "headers": [
+                                {
+                                  "exactMatch": "POST",
+                                  "name": ":method"
+                                }
+                              ],
+                              "path": "/shelves/"
                             },
                             "route": {
                               "cluster": "backend-cluster-http-bookstore-edf123456-uc.a.run.app:443",

--- a/examples/grpc_dynamic_routing/envoy_config.json
+++ b/examples/grpc_dynamic_routing/envoy_config.json
@@ -927,6 +927,39 @@
                           },
                           {
                             "decorator": {
+                              "operation": "ingress Echo"
+                            },
+                            "match": {
+                              "headers": [
+                                {
+                                  "exactMatch": "POST",
+                                  "name": ":method"
+                                }
+                              ],
+                              "path": "/echo/"
+                            },
+                            "route": {
+                              "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
+                              "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
+                              "retryPolicy": {
+                                "numRetries": 1,
+                                "retryOn": "reset,connect-failure,refused-stream"
+                              },
+                              "timeout": "300s"
+                            },
+                            "typedPerFilterConfig": {
+                              "com.google.espv2.filters.http.backend_auth": {
+                                "@type": "type.googleapis.com/espv2.api.envoy.v9.http.backend_auth.PerRouteFilterConfig",
+                                "jwtAudience": "https://grpc-echo-oxouww7xzq-uc.a.run.app"
+                              },
+                              "com.google.espv2.filters.http.service_control": {
+                                "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                                "operationName": "test.grpc.Test.Echo"
+                              }
+                            }
+                          },
+                          {
+                            "decorator": {
                               "operation": "ingress EchoReport"
                             },
                             "match": {
@@ -937,6 +970,39 @@
                                 }
                               ],
                               "path": "/echoreport"
+                            },
+                            "route": {
+                              "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
+                              "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
+                              "retryPolicy": {
+                                "numRetries": 1,
+                                "retryOn": "reset,connect-failure,refused-stream"
+                              },
+                              "timeout": "300s"
+                            },
+                            "typedPerFilterConfig": {
+                              "com.google.espv2.filters.http.backend_auth": {
+                                "@type": "type.googleapis.com/espv2.api.envoy.v9.http.backend_auth.PerRouteFilterConfig",
+                                "jwtAudience": "https://grpc-echo-oxouww7xzq-uc.a.run.app"
+                              },
+                              "com.google.espv2.filters.http.service_control": {
+                                "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                                "operationName": "test.grpc.Test.EchoReport"
+                              }
+                            }
+                          },
+                          {
+                            "decorator": {
+                              "operation": "ingress EchoReport"
+                            },
+                            "match": {
+                              "headers": [
+                                {
+                                  "exactMatch": "POST",
+                                  "name": ":method"
+                                }
+                              ],
+                              "path": "/echoreport/"
                             },
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
@@ -997,6 +1063,43 @@
                           },
                           {
                             "decorator": {
+                              "operation": "ingress EchoStream"
+                            },
+                            "match": {
+                              "headers": [
+                                {
+                                  "exactMatch": "POST",
+                                  "name": ":method"
+                                }
+                              ],
+                              "path": "/echostream/"
+                            },
+                            "route": {
+                              "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
+                              "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
+                              "retryPolicy": {
+                                "numRetries": 1,
+                                "retryOn": "reset,connect-failure,refused-stream"
+                              },
+                              "timeout": "0s"
+                            },
+                            "typedPerFilterConfig": {
+                              "com.google.espv2.filters.http.backend_auth": {
+                                "@type": "type.googleapis.com/espv2.api.envoy.v9.http.backend_auth.PerRouteFilterConfig",
+                                "jwtAudience": "https://grpc-echo-oxouww7xzq-uc.a.run.app"
+                              },
+                              "com.google.espv2.filters.http.service_control": {
+                                "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                                "operationName": "test.grpc.Test.EchoStream"
+                              },
+                              "envoy.filters.http.jwt_authn": {
+                                "@type": "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig",
+                                "requirementName": "test.grpc.Test.EchoStream"
+                              }
+                            }
+                          },
+                          {
+                            "decorator": {
                               "operation": "ingress Cork"
                             },
                             "match": {
@@ -1007,6 +1110,39 @@
                                 }
                               ],
                               "path": "/test.grpc.Test/Cork"
+                            },
+                            "route": {
+                              "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
+                              "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
+                              "retryPolicy": {
+                                "numRetries": 1,
+                                "retryOn": "reset,connect-failure,refused-stream"
+                              },
+                              "timeout": "0s"
+                            },
+                            "typedPerFilterConfig": {
+                              "com.google.espv2.filters.http.backend_auth": {
+                                "@type": "type.googleapis.com/espv2.api.envoy.v9.http.backend_auth.PerRouteFilterConfig",
+                                "jwtAudience": "https://grpc-echo-oxouww7xzq-uc.a.run.app"
+                              },
+                              "com.google.espv2.filters.http.service_control": {
+                                "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                                "operationName": "test.grpc.Test.Cork"
+                              }
+                            }
+                          },
+                          {
+                            "decorator": {
+                              "operation": "ingress Cork"
+                            },
+                            "match": {
+                              "headers": [
+                                {
+                                  "exactMatch": "POST",
+                                  "name": ":method"
+                                }
+                              ],
+                              "path": "/test.grpc.Test/Cork/"
                             },
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
@@ -1063,6 +1199,39 @@
                           },
                           {
                             "decorator": {
+                              "operation": "ingress Echo"
+                            },
+                            "match": {
+                              "headers": [
+                                {
+                                  "exactMatch": "POST",
+                                  "name": ":method"
+                                }
+                              ],
+                              "path": "/test.grpc.Test/Echo/"
+                            },
+                            "route": {
+                              "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
+                              "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
+                              "retryPolicy": {
+                                "numRetries": 1,
+                                "retryOn": "reset,connect-failure,refused-stream"
+                              },
+                              "timeout": "300s"
+                            },
+                            "typedPerFilterConfig": {
+                              "com.google.espv2.filters.http.backend_auth": {
+                                "@type": "type.googleapis.com/espv2.api.envoy.v9.http.backend_auth.PerRouteFilterConfig",
+                                "jwtAudience": "https://grpc-echo-oxouww7xzq-uc.a.run.app"
+                              },
+                              "com.google.espv2.filters.http.service_control": {
+                                "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                                "operationName": "test.grpc.Test.Echo"
+                              }
+                            }
+                          },
+                          {
+                            "decorator": {
                               "operation": "ingress EchoReport"
                             },
                             "match": {
@@ -1096,6 +1265,39 @@
                           },
                           {
                             "decorator": {
+                              "operation": "ingress EchoReport"
+                            },
+                            "match": {
+                              "headers": [
+                                {
+                                  "exactMatch": "POST",
+                                  "name": ":method"
+                                }
+                              ],
+                              "path": "/test.grpc.Test/EchoReport/"
+                            },
+                            "route": {
+                              "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
+                              "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
+                              "retryPolicy": {
+                                "numRetries": 1,
+                                "retryOn": "reset,connect-failure,refused-stream"
+                              },
+                              "timeout": "300s"
+                            },
+                            "typedPerFilterConfig": {
+                              "com.google.espv2.filters.http.backend_auth": {
+                                "@type": "type.googleapis.com/espv2.api.envoy.v9.http.backend_auth.PerRouteFilterConfig",
+                                "jwtAudience": "https://grpc-echo-oxouww7xzq-uc.a.run.app"
+                              },
+                              "com.google.espv2.filters.http.service_control": {
+                                "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                                "operationName": "test.grpc.Test.EchoReport"
+                              }
+                            }
+                          },
+                          {
+                            "decorator": {
                               "operation": "ingress EchoStream"
                             },
                             "match": {
@@ -1106,6 +1308,43 @@
                                 }
                               ],
                               "path": "/test.grpc.Test/EchoStream"
+                            },
+                            "route": {
+                              "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
+                              "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
+                              "retryPolicy": {
+                                "numRetries": 1,
+                                "retryOn": "reset,connect-failure,refused-stream"
+                              },
+                              "timeout": "0s"
+                            },
+                            "typedPerFilterConfig": {
+                              "com.google.espv2.filters.http.backend_auth": {
+                                "@type": "type.googleapis.com/espv2.api.envoy.v9.http.backend_auth.PerRouteFilterConfig",
+                                "jwtAudience": "https://grpc-echo-oxouww7xzq-uc.a.run.app"
+                              },
+                              "com.google.espv2.filters.http.service_control": {
+                                "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                                "operationName": "test.grpc.Test.EchoStream"
+                              },
+                              "envoy.filters.http.jwt_authn": {
+                                "@type": "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig",
+                                "requirementName": "test.grpc.Test.EchoStream"
+                              }
+                            }
+                          },
+                          {
+                            "decorator": {
+                              "operation": "ingress EchoStream"
+                            },
+                            "match": {
+                              "headers": [
+                                {
+                                  "exactMatch": "POST",
+                                  "name": ":method"
+                                }
+                              ],
+                              "path": "/test.grpc.Test/EchoStream/"
                             },
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",

--- a/examples/service_control/envoy_config.json
+++ b/examples/service_control/envoy_config.json
@@ -763,6 +763,34 @@
                           },
                           {
                             "decorator": {
+                              "operation": "ingress ListShelves"
+                            },
+                            "match": {
+                              "headers": [
+                                {
+                                  "exactMatch": "GET",
+                                  "name": ":method"
+                                }
+                              ],
+                              "path": "/shelves/"
+                            },
+                            "route": {
+                              "cluster": "backend-cluster-examples-service-control.endpoints.cloudesf-testing.cloud.goog_local",
+                              "retryPolicy": {
+                                "numRetries": 1,
+                                "retryOn": "reset,connect-failure,refused-stream"
+                              },
+                              "timeout": "15s"
+                            },
+                            "typedPerFilterConfig": {
+                              "com.google.espv2.filters.http.service_control": {
+                                "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                                "operationName": "1.examples_service_control_endpoints_cloudesf_testing_cloud_goog.ListShelves"
+                              }
+                            }
+                          },
+                          {
+                            "decorator": {
                               "operation": "ingress CreateShelf"
                             },
                             "match": {
@@ -773,6 +801,34 @@
                                 }
                               ],
                               "path": "/shelves"
+                            },
+                            "route": {
+                              "cluster": "backend-cluster-examples-service-control.endpoints.cloudesf-testing.cloud.goog_local",
+                              "retryPolicy": {
+                                "numRetries": 1,
+                                "retryOn": "reset,connect-failure,refused-stream"
+                              },
+                              "timeout": "15s"
+                            },
+                            "typedPerFilterConfig": {
+                              "com.google.espv2.filters.http.service_control": {
+                                "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                                "operationName": "1.examples_service_control_endpoints_cloudesf_testing_cloud_goog.CreateShelf"
+                              }
+                            }
+                          },
+                          {
+                            "decorator": {
+                              "operation": "ingress CreateShelf"
+                            },
+                            "match": {
+                              "headers": [
+                                {
+                                  "exactMatch": "POST",
+                                  "name": ":method"
+                                }
+                              ],
+                              "path": "/shelves/"
                             },
                             "route": {
                               "cluster": "backend-cluster-examples-service-control.endpoints.cloudesf-testing.cloud.goog_local",

--- a/examples/testdata/sidecar_backend/envoy_config.json
+++ b/examples/testdata/sidecar_backend/envoy_config.json
@@ -184,6 +184,34 @@
                           },
                           {
                             "decorator": {
+                              "operation": "ingress ListShelves"
+                            },
+                            "match": {
+                              "headers": [
+                                {
+                                  "exactMatch": "GET",
+                                  "name": ":method"
+                                }
+                              ],
+                              "path": "/shelves/"
+                            },
+                            "route": {
+                              "cluster": "backend-cluster-examples-sidecar-backend.endpoints.cloudesf-testing.cloud.goog_local",
+                              "retryPolicy": {
+                                "numRetries": 1,
+                                "retryOn": "reset,connect-failure,refused-stream"
+                              },
+                              "timeout": "7.500s"
+                            },
+                            "typedPerFilterConfig": {
+                              "com.google.espv2.filters.http.service_control": {
+                                "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                                "operationName": "1.examples_sidecar_backend_endpoints_cloudesf_testing_cloud_goog.ListShelves"
+                              }
+                            }
+                          },
+                          {
+                            "decorator": {
                               "operation": "ingress CreateShelf"
                             },
                             "match": {
@@ -194,6 +222,34 @@
                                 }
                               ],
                               "path": "/shelves"
+                            },
+                            "route": {
+                              "cluster": "backend-cluster-examples-sidecar-backend.endpoints.cloudesf-testing.cloud.goog_local",
+                              "retryPolicy": {
+                                "numRetries": 1,
+                                "retryOn": "reset,connect-failure,refused-stream"
+                              },
+                              "timeout": "25s"
+                            },
+                            "typedPerFilterConfig": {
+                              "com.google.espv2.filters.http.service_control": {
+                                "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                                "operationName": "1.examples_sidecar_backend_endpoints_cloudesf_testing_cloud_goog.CreateShelf"
+                              }
+                            }
+                          },
+                          {
+                            "decorator": {
+                              "operation": "ingress CreateShelf"
+                            },
+                            "match": {
+                              "headers": [
+                                {
+                                  "exactMatch": "POST",
+                                  "name": ":method"
+                                }
+                              ],
+                              "path": "/shelves/"
                             },
                             "route": {
                               "cluster": "backend-cluster-examples-sidecar-backend.endpoints.cloudesf-testing.cloud.goog_local",

--- a/src/go/configgenerator/route_generator_test.go
+++ b/src/go/configgenerator/route_generator_test.go
@@ -111,6 +111,42 @@ func TestMakeRouteConfig(t *testing.T) {
               "operationName": "endpoints.examples.bookstore.Bookstore.Echo"
             }
           }
+        },
+        {
+          "decorator": {
+            "operation": "ingress Echo"
+          },
+          "match": {
+            "headers": [
+              {
+                "exactMatch": "GET",
+                "name": ":method"
+              }
+            ],
+            "path": "/echo/"
+          },
+          "responseHeadersToAdd": [
+            {
+              "header": {
+                "key": "Strict-Transport-Security",
+                "value": "max-age=31536000; includeSubdomains"
+              }
+            }
+          ],
+          "route": {
+            "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "retryPolicy": {
+              "numRetries": 1,
+              "retryOn": "reset,connect-failure,refused-stream"
+            },
+            "timeout": "15s"
+          },
+          "typedPerFilterConfig": {
+            "com.google.espv2.filters.http.service_control": {
+              "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+              "operationName": "endpoints.examples.bookstore.Bookstore.Echo"
+            }
+          }
         }
       ]
     }
@@ -173,6 +209,53 @@ func TestMakeRouteConfig(t *testing.T) {
               }
             ],
             "path": "/foo"
+          },
+          "responseHeadersToAdd": [
+            {
+              "header": {
+                "key": "Strict-Transport-Security",
+                "value": "max-age=31536000; includeSubdomains"
+              }
+            }
+          ],
+          "route": {
+            "cluster": "backend-cluster-testapipb.com:443",
+            "hostRewriteLiteral": "testapipb.com",
+            "retryPolicy": {
+              "numRetries": 1,
+              "retryOn": "reset,connect-failure,refused-stream"
+            },
+            "timeout": "15s"
+          },
+          "typedPerFilterConfig": {
+            "com.google.espv2.filters.http.backend_auth": {
+              "@type": "type.googleapis.com/espv2.api.envoy.v9.http.backend_auth.PerRouteFilterConfig",
+              "jwtAudience": "bar.com"
+            },
+            "com.google.espv2.filters.http.path_rewrite": {
+              "@type": "type.googleapis.com/espv2.api.envoy.v9.http.path_rewrite.PerRouteFilterConfig",
+              "constantPath": {
+                "path": "/foo"
+              }
+            },
+            "com.google.espv2.filters.http.service_control": {
+              "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+              "operationName": "endpoints.examples.bookstore.Bookstore.Foo"
+            }
+          }
+        },
+        {
+          "decorator": {
+            "operation": "ingress Foo"
+          },
+          "match": {
+            "headers": [
+              {
+                "exactMatch": "GET",
+                "name": ":method"
+              }
+            ],
+            "path": "/foo/"
           },
           "responseHeadersToAdd": [
             {
@@ -556,6 +639,43 @@ func TestMakeRouteConfig(t *testing.T) {
         },
         {
           "decorator": {
+            "operation": "ingress bar"
+          },
+          "match": {
+            "headers": [
+              {
+                "exactMatch": "GET",
+                "name": ":method"
+              }
+            ],
+            "path": "/bar/"
+          },
+          "route": {
+            "cluster": "backend-cluster-testapipb.com:443",
+            "hostRewriteLiteral": "testapipb.com",
+            "retryPolicy": {
+              "numRetries": 1,
+              "retryOn": "reset,connect-failure,refused-stream"
+            },
+            "timeout": "15s"
+          },
+          "typedPerFilterConfig": {
+            "com.google.espv2.filters.http.backend_auth": {
+              "@type": "type.googleapis.com/espv2.api.envoy.v9.http.backend_auth.PerRouteFilterConfig",
+              "jwtAudience": "bar.com"
+            },
+            "com.google.espv2.filters.http.path_rewrite": {
+              "@type": "type.googleapis.com/espv2.api.envoy.v9.http.path_rewrite.PerRouteFilterConfig",
+              "pathPrefix": "/foo"
+            },
+            "com.google.espv2.filters.http.service_control": {
+              "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+              "operationName": "testapi.bar"
+            }
+          }
+        },
+        {
+          "decorator": {
             "operation": "ingress foo"
           },
           "match": {
@@ -566,6 +686,45 @@ func TestMakeRouteConfig(t *testing.T) {
               }
             ],
             "path": "/foo"
+          },
+          "route": {
+            "cluster": "backend-cluster-testapipb.com:443",
+            "hostRewriteLiteral": "testapipb.com",
+            "retryPolicy": {
+              "numRetries": 1,
+              "retryOn": "reset,connect-failure,refused-stream"
+            },
+            "timeout": "15s"
+          },
+          "typedPerFilterConfig": {
+            "com.google.espv2.filters.http.backend_auth": {
+              "@type": "type.googleapis.com/espv2.api.envoy.v9.http.backend_auth.PerRouteFilterConfig",
+              "jwtAudience": "foo.com"
+            },
+            "com.google.espv2.filters.http.path_rewrite": {
+              "@type": "type.googleapis.com/espv2.api.envoy.v9.http.path_rewrite.PerRouteFilterConfig",
+              "constantPath": {
+                "path": "/foo"
+              }
+            },
+            "com.google.espv2.filters.http.service_control": {
+              "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+              "operationName": "testapi.foo"
+            }
+          }
+        },
+        {
+          "decorator": {
+            "operation": "ingress foo"
+          },
+          "match": {
+            "headers": [
+              {
+                "exactMatch": "GET",
+                "name": ":method"
+              }
+            ],
+            "path": "/foo/"
           },
           "route": {
             "cluster": "backend-cluster-testapipb.com:443",
@@ -708,6 +867,43 @@ func TestMakeRouteConfig(t *testing.T) {
         },
         {
           "decorator": {
+            "operation": "ingress bar"
+          },
+          "match": {
+            "headers": [
+              {
+                "exactMatch": "GET",
+                "name": ":method"
+              }
+            ],
+            "path": "/bar/"
+          },
+          "route": {
+            "cluster": "backend-cluster-testapipb.com:443",
+            "hostRewriteLiteral": "testapipb.com",
+            "retryPolicy": {
+              "numRetries": 1,
+              "retryOn": "reset,connect-failure,refused-stream"
+            },
+            "timeout": "15s"
+          },
+          "typedPerFilterConfig": {
+            "com.google.espv2.filters.http.backend_auth": {
+              "@type": "type.googleapis.com/espv2.api.envoy.v9.http.backend_auth.PerRouteFilterConfig",
+              "jwtAudience": "bar.com"
+            },
+            "com.google.espv2.filters.http.path_rewrite": {
+              "@type": "type.googleapis.com/espv2.api.envoy.v9.http.path_rewrite.PerRouteFilterConfig",
+              "pathPrefix": "/bar"
+            },
+            "com.google.espv2.filters.http.service_control": {
+              "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+              "operationName": "testapi.bar"
+            }
+          }
+        },
+        {
+          "decorator": {
             "operation": "ingress ESPv2_Autogenerated_CORS_bar"
           },
           "match": {
@@ -718,6 +914,43 @@ func TestMakeRouteConfig(t *testing.T) {
               }
             ],
             "path": "/bar"
+          },
+          "route": {
+            "cluster": "backend-cluster-testapipb.com:443",
+            "hostRewriteLiteral": "testapipb.com",
+            "retryPolicy": {
+              "numRetries": 1,
+              "retryOn": "reset,connect-failure,refused-stream"
+            },
+            "timeout": "15s"
+          },
+          "typedPerFilterConfig": {
+            "com.google.espv2.filters.http.backend_auth": {
+              "@type": "type.googleapis.com/espv2.api.envoy.v9.http.backend_auth.PerRouteFilterConfig",
+              "jwtAudience": "bar.com"
+            },
+            "com.google.espv2.filters.http.path_rewrite": {
+              "@type": "type.googleapis.com/espv2.api.envoy.v9.http.path_rewrite.PerRouteFilterConfig",
+              "pathPrefix": "/bar"
+            },
+            "com.google.espv2.filters.http.service_control": {
+              "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+              "operationName": "testapi.ESPv2_Autogenerated_CORS_bar"
+            }
+          }
+        },
+        {
+          "decorator": {
+            "operation": "ingress ESPv2_Autogenerated_CORS_bar"
+          },
+          "match": {
+            "headers": [
+              {
+                "exactMatch": "OPTIONS",
+                "name": ":method"
+              }
+            ],
+            "path": "/bar/"
           },
           "route": {
             "cluster": "backend-cluster-testapipb.com:443",
@@ -927,6 +1160,39 @@ func TestMakeRouteConfig(t *testing.T) {
         },
         {
           "decorator": {
+            "operation": "ingress bar"
+          },
+          "match": {
+            "headers": [
+              {
+                "exactMatch": "GET",
+                "name": ":method"
+              }
+            ],
+            "path": "/bar/"
+          },
+          "route": {
+            "cluster": "backend-cluster-testapipb.com:443",
+            "hostRewriteLiteral": "testapipb.com",
+            "retryPolicy": {
+              "numRetries": 1,
+              "retryOn": "reset,connect-failure,refused-stream"
+            },
+            "timeout": "15s"
+          },
+          "typedPerFilterConfig": {
+            "com.google.espv2.filters.http.backend_auth": {
+              "@type": "type.googleapis.com/espv2.api.envoy.v9.http.backend_auth.PerRouteFilterConfig",
+              "jwtAudience": "https://testapipb.com"
+            },
+            "com.google.espv2.filters.http.service_control": {
+              "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+              "operationName": "testapi.bar"
+            }
+          }
+        },
+        {
+          "decorator": {
             "operation": "ingress foo"
           },
           "match": {
@@ -937,6 +1203,39 @@ func TestMakeRouteConfig(t *testing.T) {
               }
             ],
             "path": "/foo"
+          },
+          "route": {
+            "cluster": "backend-cluster-testapipb.com:443",
+            "hostRewriteLiteral": "testapipb.com",
+            "retryPolicy": {
+              "numRetries": 1,
+              "retryOn": "reset,connect-failure,refused-stream"
+            },
+            "timeout": "15s"
+          },
+          "typedPerFilterConfig": {
+            "com.google.espv2.filters.http.backend_auth": {
+              "@type": "type.googleapis.com/espv2.api.envoy.v9.http.backend_auth.PerRouteFilterConfig",
+              "jwtAudience": "https://testapipb.com"
+            },
+            "com.google.espv2.filters.http.service_control": {
+              "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+              "operationName": "testapi.foo"
+            }
+          }
+        },
+        {
+          "decorator": {
+            "operation": "ingress foo"
+          },
+          "match": {
+            "headers": [
+              {
+                "exactMatch": "GET",
+                "name": ":method"
+              }
+            ],
+            "path": "/foo/"
           },
           "route": {
             "cluster": "backend-cluster-testapipb.com:443",
@@ -1063,6 +1362,45 @@ func TestMakeRouteConfig(t *testing.T) {
         },
         {
           "decorator": {
+            "operation": "ingress bar"
+          },
+          "match": {
+            "headers": [
+              {
+                "exactMatch": "GET",
+                "name": ":method"
+              }
+            ],
+            "path": "/bar/"
+          },
+          "route": {
+            "cluster": "backend-cluster-testapipb.com:443",
+            "hostRewriteLiteral": "testapipb.com",
+            "retryPolicy": {
+              "numRetries": 1,
+              "retryOn": "reset,connect-failure,refused-stream"
+            },
+            "timeout": "15s"
+          },
+          "typedPerFilterConfig": {
+            "com.google.espv2.filters.http.backend_auth": {
+              "@type": "type.googleapis.com/espv2.api.envoy.v9.http.backend_auth.PerRouteFilterConfig",
+              "jwtAudience": "https://testapipb.com"
+            },
+            "com.google.espv2.filters.http.path_rewrite": {
+              "@type": "type.googleapis.com/espv2.api.envoy.v9.http.path_rewrite.PerRouteFilterConfig",
+              "constantPath": {
+                "path": "/"
+              }
+            },
+            "com.google.espv2.filters.http.service_control": {
+              "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+              "operationName": "testapi.bar"
+            }
+          }
+        },
+        {
+          "decorator": {
             "operation": "ingress foo"
           },
           "match": {
@@ -1073,6 +1411,45 @@ func TestMakeRouteConfig(t *testing.T) {
               }
             ],
             "path": "/foo"
+          },
+          "route": {
+            "cluster": "backend-cluster-testapipb.com:443",
+            "hostRewriteLiteral": "testapipb.com",
+            "retryPolicy": {
+              "numRetries": 1,
+              "retryOn": "reset,connect-failure,refused-stream"
+            },
+            "timeout": "15s"
+          },
+          "typedPerFilterConfig": {
+            "com.google.espv2.filters.http.backend_auth": {
+              "@type": "type.googleapis.com/espv2.api.envoy.v9.http.backend_auth.PerRouteFilterConfig",
+              "jwtAudience": "https://testapipb.com"
+            },
+            "com.google.espv2.filters.http.path_rewrite": {
+              "@type": "type.googleapis.com/espv2.api.envoy.v9.http.path_rewrite.PerRouteFilterConfig",
+              "constantPath": {
+                "path": "/"
+              }
+            },
+            "com.google.espv2.filters.http.service_control": {
+              "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+              "operationName": "testapi.foo"
+            }
+          }
+        },
+        {
+          "decorator": {
+            "operation": "ingress foo"
+          },
+          "match": {
+            "headers": [
+              {
+                "exactMatch": "GET",
+                "name": ":method"
+              }
+            ],
+            "path": "/foo/"
           },
           "route": {
             "cluster": "backend-cluster-testapipb.com:443",
@@ -1459,7 +1836,73 @@ func TestMakeRouteConfig(t *testing.T) {
             "operation": "ingress Bar"
           },
           "match": {
+            "headers": [
+              {
+                "exactMatch": "GET",
+                "name": ":method"
+              }
+            ],
+            "path": "/foo/bar/"
+          },
+          "responseHeadersToAdd": [
+            {
+              "header": {
+                "key": "Strict-Transport-Security",
+                "value": "max-age=31536000; includeSubdomains"
+              }
+            }
+          ],
+          "route": {
+            "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "retryPolicy": {
+              "numRetries": 1,
+              "retryOn": "reset,connect-failure,refused-stream"
+            },
+            "timeout": "15s"
+          },
+          "typedPerFilterConfig": {
+            "com.google.espv2.filters.http.service_control": {
+              "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+              "operationName": "endpoints.examples.bookstore.Bookstore.Bar"
+            }
+          }
+        },
+        {
+          "decorator": {
+            "operation": "ingress Bar"
+          },
+          "match": {
             "path": "/foo/bar"
+          },
+          "responseHeadersToAdd": [
+            {
+              "header": {
+                "key": "Strict-Transport-Security",
+                "value": "max-age=31536000; includeSubdomains"
+              }
+            }
+          ],
+          "route": {
+            "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "retryPolicy": {
+              "numRetries": 1,
+              "retryOn": "reset,connect-failure,refused-stream"
+            },
+            "timeout": "15s"
+          },
+          "typedPerFilterConfig": {
+            "com.google.espv2.filters.http.service_control": {
+              "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+              "operationName": "endpoints.examples.bookstore.Bookstore.Bar"
+            }
+          }
+        },
+        {
+          "decorator": {
+            "operation": "ingress Bar"
+          },
+          "match": {
+            "path": "/foo/bar/"
           },
           "responseHeadersToAdd": [
             {

--- a/src/go/configinfo/service_info_test.go
+++ b/src/go/configinfo/service_info_test.go
@@ -2921,7 +2921,7 @@ func TestProcessTypes(t *testing.T) {
 		}
 
 		for operation, wantUrlTemplate := range tc.wantUrlTemplateByOperation {
-			getUrlTemplate := serviceInfo.Methods[operation].HttpRule[0].UriTemplate.String()
+			getUrlTemplate := serviceInfo.Methods[operation].HttpRule[0].UriTemplate.ExactMatchString(false)
 			if getUrlTemplate != wantUrlTemplate {
 				t.Errorf("Test(%v): For operation (%v), expected urlTemplate (%v), got urlTemplate(%v)", tc.desc, operation, wantUrlTemplate, getUrlTemplate)
 			}

--- a/src/go/configmanager/testdata/test_fetch_listeners.go
+++ b/src/go/configmanager/testdata/test_fetch_listeners.go
@@ -155,6 +155,31 @@ var (
                                        "operationName":"endpoints.examples.bookstore.Bookstore.CreateShelf"
                                     }
                                  }
+                              },
+                              {
+                                 "decorator":{
+                                    "operation":"ingress CreateShelf"
+                                 },
+                                 "match":{
+                                    "headers":[
+                                       {
+                                          "exactMatch":"POST",
+                                          "name":":method"
+                                       }
+                                    ],
+                                    "path":"/endpoints.examples.bookstore.Bookstore/CreateShelf/"
+                                 },
+                                 "route":{
+                                    "cluster":"%s",
+                                    "retryPolicy":{"numRetries":1,"retryOn":"reset,connect-failure,refused-stream"},
+                                    "timeout":"15s"
+                                 },
+                                 "typedPerFilterConfig":{
+                                    "com.google.espv2.filters.http.service_control":{
+                                       "@type":"type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                                       "operationName":"endpoints.examples.bookstore.Bookstore.CreateShelf"
+                                    }
+                                 }
                               }
                            ]
                         }
@@ -177,7 +202,7 @@ var (
    "name":"ingress_listener"
 }
 `,
-		fakeProtoDescriptor, TestFetchListenersEndpointName, testBackendClusterName, localReplyConfig)
+		fakeProtoDescriptor, TestFetchListenersEndpointName, testBackendClusterName, testBackendClusterName, localReplyConfig)
 
 	FakeServiceConfigForGrpcWithJwtFilterWithAuds = fmt.Sprintf(`{
                 "name":"bookstore.endpoints.project123.cloud.goog",
@@ -336,6 +361,35 @@ var (
                                        "requirementName": "endpoints.examples.bookstore.Bookstore.CreateShelf"
                                     }
                                  }
+                              },
+                              {
+                                 "decorator":{
+                                    "operation":"ingress CreateShelf"
+                                 },
+                                 "match":{
+                                    "headers":[
+                                       {
+                                          "exactMatch":"POST",
+                                          "name":":method"
+                                       }
+                                    ],
+                                    "path":"/endpoints.examples.bookstore.Bookstore/CreateShelf/"
+                                 },
+                                 "route":{
+                                    "cluster":"%s",
+                                    "retryPolicy":{"numRetries":1,"retryOn":"reset,connect-failure,refused-stream"},
+                                    "timeout":"15s"
+                                 },
+                                 "typedPerFilterConfig":{
+                                    "com.google.espv2.filters.http.service_control":{
+                                       "@type":"type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                                       "operationName":"endpoints.examples.bookstore.Bookstore.CreateShelf"
+                                    },
+                                    "envoy.filters.http.jwt_authn": {
+                                       "@type": "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig",
+                                       "requirementName": "endpoints.examples.bookstore.Bookstore.CreateShelf"
+                                    }
+                                 }
                               }
                            ]
                         }
@@ -354,7 +408,7 @@ var (
       }
    ]
 }
-              `, testBackendClusterName, localReplyConfig)
+              `, testBackendClusterName, testBackendClusterName, localReplyConfig)
 
 	FakeServiceConfigForGrpcWithJwtFilterWithoutAuds = fmt.Sprintf(`{
                 "name":"bookstore.endpoints.project123.cloud.goog",
@@ -530,6 +584,35 @@ var (
                               },
                               {
                                  "decorator":{
+                                    "operation":"ingress CreateShelf"
+                                 },
+                                 "match":{
+                                    "headers":[
+                                       {
+                                          "exactMatch":"POST",
+                                          "name":":method"
+                                       }
+                                    ],
+                                    "path":"/endpoints.examples.bookstore.Bookstore/CreateShelf/"
+                                 },
+                                 "route":{
+                                    "cluster":"backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                                    "retryPolicy":{"numRetries":1,"retryOn":"reset,connect-failure,refused-stream"},
+                                    "timeout":"15s"
+                                 },
+                                 "typedPerFilterConfig":{
+                                    "com.google.espv2.filters.http.service_control":{
+                                       "@type":"type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                                       "operationName":"endpoints.examples.bookstore.Bookstore.CreateShelf"
+                                    },
+                                    "envoy.filters.http.jwt_authn": {
+                                       "@type": "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig",
+                                       "requirementName": "endpoints.examples.bookstore.Bookstore.CreateShelf"
+                                    }
+                                 }
+                              },
+                              {
+                                 "decorator":{
                                     "operation":"ingress ListShelves"
                                  },
                                  "match":{
@@ -564,11 +647,69 @@ var (
                                  "match":{
                                     "headers":[
                                        {
+                                          "exactMatch":"POST",
+                                          "name":":method"
+                                       }
+                                    ],
+                                    "path":"/endpoints.examples.bookstore.Bookstore/ListShelves/"
+                                 },
+                                 "route":{
+                                    "cluster":"backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                                    "retryPolicy":{"numRetries":1,"retryOn":"reset,connect-failure,refused-stream"},
+                                    "timeout":"15s"
+                                 },
+                                 "typedPerFilterConfig":{
+                                    "com.google.espv2.filters.http.service_control":{
+                                       "@type":"type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                                       "operationName":"endpoints.examples.bookstore.Bookstore.ListShelves"
+                                    },
+                                    "envoy.filters.http.jwt_authn": {
+                                       "@type": "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig",
+                                       "requirementName": "endpoints.examples.bookstore.Bookstore.ListShelves"
+                                    }
+                                 }
+                              },
+                              {
+                                 "decorator":{
+                                    "operation":"ingress ListShelves"
+                                 },
+                                 "match":{
+                                    "headers":[
+                                       {
                                           "exactMatch":"GET",
                                           "name":":method"
                                        }
                                     ],
                                     "path":"/v1/shelves"
+                                 },
+                                 "route":{
+                                    "cluster":"backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                                    "retryPolicy":{"numRetries":1,"retryOn":"reset,connect-failure,refused-stream"},
+                                    "timeout":"15s"
+                                 },
+                                 "typedPerFilterConfig":{
+                                    "com.google.espv2.filters.http.service_control":{
+                                       "@type":"type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                                       "operationName":"endpoints.examples.bookstore.Bookstore.ListShelves"
+                                    },
+                                    "envoy.filters.http.jwt_authn": {
+                                       "@type": "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig",
+                                       "requirementName": "endpoints.examples.bookstore.Bookstore.ListShelves"
+                                    }
+                                 }
+                              },
+                              {
+                                 "decorator":{
+                                    "operation":"ingress ListShelves"
+                                 },
+                                 "match":{
+                                    "headers":[
+                                       {
+                                          "exactMatch":"GET",
+                                          "name":":method"
+                                       }
+                                    ],
+                                    "path":"/v1/shelves/"
                                  },
                                  "route":{
                                     "cluster":"backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
@@ -845,6 +986,31 @@ var (
                               },
                               {
                                  "decorator":{
+                                    "operation":"ingress DeleteBook"
+                                 },
+                                 "match":{
+                                    "headers":[
+                                       {
+                                          "exactMatch":"POST",
+                                          "name":":method"
+                                       }
+                                    ],
+                                    "path":"/endpoints.examples.bookstore.Bookstore/DeleteBook/"
+                                 },
+                                 "route":{
+                                    "cluster":"backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                                    "retryPolicy":{"numRetries":1,"retryOn":"reset,connect-failure,refused-stream"},
+                                    "timeout":"15s"
+                                 },
+                                 "typedPerFilterConfig":{
+                                    "com.google.espv2.filters.http.service_control":{
+                                       "@type":"type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                                       "operationName":"endpoints.examples.bookstore.Bookstore.DeleteBook"
+                                    }
+                                 }
+                              },
+                              {
+                                 "decorator":{
                                     "operation":"ingress GetBook"
                                  },
                                  "match":{
@@ -855,6 +1021,35 @@ var (
                                        }
                                     ],
                                     "path":"/endpoints.examples.bookstore.Bookstore/GetBook"
+                                 },
+                                 "route":{
+                                    "cluster":"backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                                    "retryPolicy":{"numRetries":1,"retryOn":"reset,connect-failure,refused-stream"},
+                                    "timeout":"15s"
+                                 },
+                                 "typedPerFilterConfig":{
+                                    "com.google.espv2.filters.http.service_control":{
+                                       "@type":"type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                                       "operationName":"endpoints.examples.bookstore.Bookstore.GetBook"
+                                    },
+                                    "envoy.filters.http.jwt_authn": {
+                                       "@type": "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig",
+                                       "requirementName": "endpoints.examples.bookstore.Bookstore.GetBook"
+                                    }
+                                 }
+                              },
+                              {
+                                 "decorator":{
+                                    "operation":"ingress GetBook"
+                                 },
+                                 "match":{
+                                    "headers":[
+                                       {
+                                          "exactMatch":"POST",
+                                          "name":":method"
+                                       }
+                                    ],
+                                    "path":"/endpoints.examples.bookstore.Bookstore/GetBook/"
                                  },
                                  "route":{
                                     "cluster":"backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
@@ -1140,6 +1335,31 @@ var (
                               },
                               {
                                  "decorator":{
+                                    "operation":"ingress CreateShelf"
+                                 },
+                                 "match":{
+                                    "headers":[
+                                       {
+                                          "exactMatch":"POST",
+                                          "name":":method"
+                                       }
+                                    ],
+                                    "path":"/endpoints.examples.bookstore.Bookstore/CreateShelf/"
+                                 },
+                                 "route":{
+                                    "cluster":"backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                                    "retryPolicy":{"numRetries":1,"retryOn":"reset,connect-failure,refused-stream"},
+                                    "timeout":"15s"
+                                 },
+                                 "typedPerFilterConfig":{
+                                    "com.google.espv2.filters.http.service_control":{
+                                       "@type":"type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                                       "operationName":"endpoints.examples.bookstore.Bookstore.CreateShelf"
+                                    }
+                                 }
+                              },
+                              {
+                                 "decorator":{
                                     "operation":"ingress ListShelves"
                                  },
                                  "match":{
@@ -1150,6 +1370,31 @@ var (
                                        }
                                     ],
                                     "path":"/endpoints.examples.bookstore.Bookstore/ListShelves"
+                                 },
+                                 "route":{
+                                    "cluster":"backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                                    "retryPolicy":{"numRetries":1,"retryOn":"reset,connect-failure,refused-stream"},
+                                    "timeout":"15s"
+                                 },
+                                 "typedPerFilterConfig":{
+                                    "com.google.espv2.filters.http.service_control":{
+                                       "@type":"type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                                       "operationName":"endpoints.examples.bookstore.Bookstore.ListShelves"
+                                    }
+                                 }
+                              },
+                              {
+                                 "decorator":{
+                                    "operation":"ingress ListShelves"
+                                 },
+                                 "match":{
+                                    "headers":[
+                                       {
+                                          "exactMatch":"POST",
+                                          "name":":method"
+                                       }
+                                    ],
+                                    "path":"/endpoints.examples.bookstore.Bookstore/ListShelves/"
                                  },
                                  "route":{
                                     "cluster":"backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
@@ -1190,6 +1435,31 @@ var (
                               },
                               {
                                  "decorator":{
+                                    "operation":"ingress ListShelves"
+                                 },
+                                 "match":{
+                                    "headers":[
+                                       {
+                                          "exactMatch":"GET",
+                                          "name":":method"
+                                       }
+                                    ],
+                                    "path":"/v1/shelves/"
+                                 },
+                                 "route":{
+                                    "cluster":"backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+"retryPolicy":{"numRetries":1,"retryOn":"reset,connect-failure,refused-stream"},
+                                    "timeout":"15s"
+                                 },
+                                 "typedPerFilterConfig":{
+                                    "com.google.espv2.filters.http.service_control":{
+                                       "@type":"type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                                       "operationName":"endpoints.examples.bookstore.Bookstore.ListShelves"
+                                    }
+                                 }
+                              },
+                              {
+                                 "decorator":{
                                     "operation":"ingress CreateShelf"
                                  },
                                  "match":{
@@ -1200,6 +1470,31 @@ var (
                                        }
                                     ],
                                     "path":"/v1/shelves"
+                                 },
+                                 "route":{
+                                    "cluster":"backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                                    "retryPolicy":{"numRetries":1,"retryOn":"reset,connect-failure,refused-stream"},
+                                    "timeout":"15s"
+                                 },
+                                 "typedPerFilterConfig":{
+                                    "com.google.espv2.filters.http.service_control":{
+                                       "@type":"type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                                       "operationName":"endpoints.examples.bookstore.Bookstore.CreateShelf"
+                                    }
+                                 }
+                              },
+                              {
+                                 "decorator":{
+                                    "operation":"ingress CreateShelf"
+                                 },
+                                 "match":{
+                                    "headers":[
+                                       {
+                                          "exactMatch":"POST",
+                                          "name":":method"
+                                       }
+                                    ],
+                                    "path":"/v1/shelves/"
                                  },
                                  "route":{
                                     "cluster":"backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
@@ -1403,6 +1698,35 @@ var (
                               },
                               {
                                  "decorator":{
+                                    "operation":"ingress Echo_Auth_Jwt"
+                                 },
+                                 "match":{
+                                    "headers":[
+                                       {
+                                          "exactMatch":"GET",
+                                          "name":":method"
+                                       }
+                                    ],
+                                    "path":"/auth/info/googlejwt/"
+                                 },
+                                 "route":{
+                                    "cluster":"backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                                    "retryPolicy":{"numRetries":1,"retryOn":"reset,connect-failure,refused-stream"},
+                                    "timeout":"15s"
+                                 },
+                                 "typedPerFilterConfig":{
+                                    "com.google.espv2.filters.http.service_control":{
+                                       "@type":"type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                                       "operationName":"1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo_Auth_Jwt"
+                                    },
+                                    "envoy.filters.http.jwt_authn": {
+                                       "@type": "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig",
+                                       "requirementName": "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo_Auth_Jwt"
+                                    }
+                                 }
+                              },
+                              {
+                                 "decorator":{
                                     "operation":"ingress Echo"
                                  },
                                  "match":{
@@ -1413,6 +1737,31 @@ var (
                                        }
                                     ],
                                     "path":"/echo"
+                                 },
+                                 "route":{
+                                    "cluster":"backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                                    "retryPolicy":{"numRetries":1,"retryOn":"reset,connect-failure,refused-stream"},
+                                    "timeout":"15s"
+                                 },
+                                 "typedPerFilterConfig":{
+                                    "com.google.espv2.filters.http.service_control":{
+                                       "@type":"type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                                       "operationName":"1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo"
+                                    }
+                                 }
+                              },
+                              {
+                                 "decorator":{
+                                    "operation":"ingress Echo"
+                                 },
+                                 "match":{
+                                    "headers":[
+                                       {
+                                          "exactMatch":"POST",
+                                          "name":":method"
+                                       }
+                                    ],
+                                    "path":"/echo/"
                                  },
                                  "route":{
                                     "cluster":"backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
@@ -1590,6 +1939,31 @@ var (
                               },
                               {
                                  "decorator":{
+                                    "operation":"ingress Simplegetcors"
+                                 },
+                                 "match":{
+                                    "headers":[
+                                       {
+                                          "exactMatch":"GET",
+                                          "name":":method"
+                                       }
+                                    ],
+                                    "path":"/simplegetcors/"
+                                 },
+                                 "route":{
+                                    "cluster":"backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                                    "retryPolicy":{"numRetries":1,"retryOn":"reset,connect-failure,refused-stream"},
+                                    "timeout":"15s"
+                                 },
+                                 "typedPerFilterConfig":{
+                                    "com.google.espv2.filters.http.service_control":{
+                                       "@type":"type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                                       "operationName":"1.echo_api_endpoints_cloudesf_testing_cloud_goog.Simplegetcors"
+                                    }
+                                 }
+                              },
+                              {
+                                 "decorator":{
                                     "operation":"ingress ESPv2_Autogenerated_CORS_Simplegetcors"
                                  },
                                  "match":{
@@ -1600,6 +1974,31 @@ var (
                                        }
                                     ],
                                     "path":"/simplegetcors"
+                                 },
+                                 "route":{
+                                    "cluster":"backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                                    "retryPolicy":{"numRetries":1,"retryOn":"reset,connect-failure,refused-stream"},
+                                    "timeout":"15s"
+                                 },
+                                 "typedPerFilterConfig":{
+                                    "com.google.espv2.filters.http.service_control":{
+                                       "@type":"type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                                       "operationName":"1.echo_api_endpoints_cloudesf_testing_cloud_goog.ESPv2_Autogenerated_CORS_simplegetcors"
+                                    }
+                                 }
+                              },
+                              {
+                                 "decorator":{
+                                    "operation":"ingress ESPv2_Autogenerated_CORS_Simplegetcors"
+                                 },
+                                 "match":{
+                                    "headers":[
+                                       {
+                                          "exactMatch":"OPTIONS",
+                                          "name":":method"
+                                       }
+                                    ],
+                                    "path":"/simplegetcors/"
                                  },
                                  "route":{
                                     "cluster":"backend-cluster-bookstore.endpoints.project123.cloud.goog_local",

--- a/src/go/configmanager/testdata/test_fixed_mode_dynamic_routing.go
+++ b/src/go/configmanager/testdata/test_fixed_mode_dynamic_routing.go
@@ -323,6 +323,31 @@ var (
                     },
                     {
                       "decorator": {
+                        "operation": "ingress Echo"
+                      },
+                      "match": {
+                        "headers": [
+                          {
+                            "exactMatch": "POST",
+                            "name": ":method"
+                          }
+                        ],
+                        "path": "/echo/"
+                      },
+                      "route": {
+                        "cluster": "backend-cluster-echo-api.endpoints.cloudesf-testing.cloud.goog_local",
+                        "retryPolicy":{"numRetries":1,"retryOn":"reset,connect-failure,refused-stream"},
+                        "timeout": "15s"
+                      },
+                      "typedPerFilterConfig": {
+                        "com.google.espv2.filters.http.service_control": {
+                          "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                          "operationName": "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo"
+                        }
+                      }
+                    },
+                    {
+                      "decorator": {
                         "operation": "ingress dynamic_routing_Hello"
                       },
                       "match": {
@@ -357,6 +382,40 @@ var (
                     },
                     {
                       "decorator": {
+                        "operation": "ingress dynamic_routing_Hello"
+                      },
+                      "match": {
+                        "headers": [
+                          {
+                            "exactMatch": "GET",
+                            "name": ":method"
+                          }
+                        ],
+                        "path": "/hello/"
+                      },
+                      "route": {
+                        "cluster": "backend-cluster-us-central1-cloud-esf.cloudfunctions.net:443",
+                        "hostRewriteLiteral": "us-central1-cloud-esf.cloudfunctions.net",
+                        "retryPolicy":{"numRetries":1,"retryOn":"reset,connect-failure,refused-stream"},
+                        "timeout": "15s"
+                      },
+                      "typedPerFilterConfig": {
+                        "com.google.espv2.filters.http.backend_auth": {
+                          "@type": "type.googleapis.com/espv2.api.envoy.v9.http.backend_auth.PerRouteFilterConfig",
+                          "jwtAudience": "https://us-central1-cloud-esf.cloudfunctions.net/hello"
+                        },
+                        "com.google.espv2.filters.http.path_rewrite": {
+                          "@type": "type.googleapis.com/espv2.api.envoy.v9.http.path_rewrite.PerRouteFilterConfig",
+                          "pathPrefix": "/hello"
+                        },
+                        "com.google.espv2.filters.http.service_control": {
+                          "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                          "operationName": "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_Hello"
+                        }
+                      }
+                    },
+                    {
+                      "decorator": {
                         "operation": "ingress dynamic_routing_AddPet"
                       },
                       "match": {
@@ -367,6 +426,40 @@ var (
                           }
                         ],
                         "path": "/pet"
+                      },
+                      "route": {
+                        "cluster": "backend-cluster-pets.appspot.com:443",
+                        "hostRewriteLiteral": "pets.appspot.com",
+                        "retryPolicy":{"numRetries":1,"retryOn":"reset,connect-failure,refused-stream"},
+                        "timeout": "15s"
+                      },
+                      "typedPerFilterConfig": {
+                        "com.google.espv2.filters.http.backend_auth": {
+                          "@type": "type.googleapis.com/espv2.api.envoy.v9.http.backend_auth.PerRouteFilterConfig",
+                          "jwtAudience": "1083071298623-e...t.apps.googleusercontent.com"
+                        },
+                        "com.google.espv2.filters.http.path_rewrite": {
+                          "@type": "type.googleapis.com/espv2.api.envoy.v9.http.path_rewrite.PerRouteFilterConfig",
+                          "pathPrefix": "/api"
+                        },
+                        "com.google.espv2.filters.http.service_control": {
+                          "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                          "operationName": "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_AddPet"
+                        }
+                      }
+                    },
+                    {
+                      "decorator": {
+                        "operation": "ingress dynamic_routing_AddPet"
+                      },
+                      "match": {
+                        "headers": [
+                          {
+                            "exactMatch": "POST",
+                            "name": ":method"
+                          }
+                        ],
+                        "path": "/pet/"
                       },
                       "route": {
                         "cluster": "backend-cluster-pets.appspot.com:443",
@@ -462,6 +555,40 @@ var (
                     },
                     {
                       "decorator": {
+                        "operation": "ingress dynamic_routing_ListPets"
+                      },
+                      "match": {
+                        "headers": [
+                          {
+                            "exactMatch": "GET",
+                            "name": ":method"
+                          }
+                        ],
+                        "path": "/pets/"
+                      },
+                      "route": {
+                        "cluster": "backend-cluster-pets.appspot.com:443",
+                        "hostRewriteLiteral": "pets.appspot.com",
+                        "retryPolicy":{"numRetries":1,"retryOn":"reset,connect-failure,refused-stream"},
+                        "timeout": "15s"
+                      },
+                      "typedPerFilterConfig": {
+                        "com.google.espv2.filters.http.backend_auth": {
+                          "@type": "type.googleapis.com/espv2.api.envoy.v9.http.backend_auth.PerRouteFilterConfig",
+                          "jwtAudience": "1083071298623-e...t.apps.googleusercontent.com"
+                        },
+                        "com.google.espv2.filters.http.path_rewrite": {
+                          "@type": "type.googleapis.com/espv2.api.envoy.v9.http.path_rewrite.PerRouteFilterConfig",
+                          "pathPrefix": "/api"
+                        },
+                        "com.google.espv2.filters.http.service_control": {
+                          "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                          "operationName": "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_ListPets"
+                        }
+                      }
+                    },
+                    {
+                      "decorator": {
                         "operation": "ingress dynamic_routing_Search"
                       },
                       "match": {
@@ -472,6 +599,42 @@ var (
                           }
                         ],
                         "path": "/search"
+                      },
+                      "route": {
+                        "cluster": "backend-cluster-us-west2-cloud-esf.cloudfunctions.net:443",
+                        "hostRewriteLiteral": "us-west2-cloud-esf.cloudfunctions.net",
+                        "retryPolicy":{"numRetries":1,"retryOn":"reset,connect-failure,refused-stream"},
+                        "timeout": "15s"
+                      },
+                      "typedPerFilterConfig": {
+                        "com.google.espv2.filters.http.backend_auth": {
+                          "@type": "type.googleapis.com/espv2.api.envoy.v9.http.backend_auth.PerRouteFilterConfig",
+                          "jwtAudience": "https://us-west2-cloud-esf.cloudfunctions.net/search"
+                        },
+                        "com.google.espv2.filters.http.path_rewrite": {
+                          "@type": "type.googleapis.com/espv2.api.envoy.v9.http.path_rewrite.PerRouteFilterConfig",
+                          "constantPath": {
+                            "path": "/search"
+                          }
+                        },
+                        "com.google.espv2.filters.http.service_control": {
+                          "@type": "type.googleapis.com/espv2.api.envoy.v9.http.service_control.PerRouteFilterConfig",
+                          "operationName": "1.echo_api_endpoints_cloudesf_testing_cloud_goog.dynamic_routing_Search"
+                        }
+                      }
+                    },
+                    {
+                      "decorator": {
+                        "operation": "ingress dynamic_routing_Search"
+                      },
+                      "match": {
+                        "headers": [
+                          {
+                            "exactMatch": "GET",
+                            "name": ":method"
+                          }
+                        ],
+                        "path": "/search/"
                       },
                       "route": {
                         "cluster": "backend-cluster-us-west2-cloud-esf.cloudfunctions.net:443",

--- a/src/go/util/httppattern/sort_test.go
+++ b/src/go/util/httppattern/sort_test.go
@@ -254,7 +254,7 @@ func TestSort(t *testing.T) {
 			}
 
 			for idx, r := range *methods {
-				if getHttpPattern := fmt.Sprintf("%s %s", r.HttpMethod, r.UriTemplate); getHttpPattern != tc.sortedHttpPattern[idx] {
+				if getHttpPattern := fmt.Sprintf("%s %s", r.HttpMethod, r.UriTemplate.ExactMatchString(false)); getHttpPattern != tc.sortedHttpPattern[idx] {
 					t.Errorf("expect http pattern: % s, get http pattern: %s", tc.sortedHttpPattern[idx], getHttpPattern)
 				}
 			}

--- a/src/go/util/httppattern/uri_template.go
+++ b/src/go/util/httppattern/uri_template.go
@@ -112,6 +112,11 @@ func (u *UriTemplate) ExactMatchString(acceptTrailingBackslash bool) string {
 	return buff.String()
 }
 
+// Output the string representation with defaults.
+func (u *UriTemplate) String() string {
+	return u.ExactMatchString(false)
+}
+
 // Check if two uriTemplates are equal. Ignore `Origin`
 func (u *UriTemplate) Equal(v *UriTemplate) bool {
 	return cmp.Equal(u.Segments, v.Segments) && cmp.Equal(u.Variables, v.Variables) && cmp.Equal(u.Verb, v.Verb)

--- a/src/go/util/httppattern/uri_template.go
+++ b/src/go/util/httppattern/uri_template.go
@@ -62,7 +62,7 @@ type variable struct {
 	HasDoubleWildCard bool
 }
 
-func (u *UriTemplate) String() string {
+func (u *UriTemplate) ExactMatchString(acceptTrailingBackslash bool) string {
 	if len(u.Segments) == 0 {
 		return "/"
 	}
@@ -99,6 +99,10 @@ func (u *UriTemplate) String() string {
 
 		// Add path field.
 		buff.WriteString(fmt.Sprintf("/%s", seg))
+	}
+
+	if acceptTrailingBackslash {
+		buff.WriteString("/")
 	}
 
 	if u.Verb != "" {

--- a/src/go/util/httppattern/uri_template_test.go
+++ b/src/go/util/httppattern/uri_template_test.go
@@ -79,6 +79,59 @@ func TestReplaceVariableFieldInUriTemplateRebuild(t *testing.T) {
 	}
 }
 
+func compareExactMatchString(t *testing.T, uriTemplate *UriTemplate, trailingBackslash bool, wantUriTemplates map[bool]string) {
+	got := uriTemplate.ExactMatchString(trailingBackslash)
+	want := wantUriTemplates[trailingBackslash]
+	if got != want {
+		t.Errorf("Want trailing backslash = (%v), got (%v), expected (%v)", trailingBackslash, got, want)
+	}
+}
+
+func TestTrailingBackSlash(t *testing.T) {
+	testCases := []struct {
+		desc                                string
+		uriTemplate                         string
+		wantUriTemplatesByTrailingBackslash map[bool]string
+	}{
+		{
+			desc:        "Exact path match outputs in different format",
+			uriTemplate: "/book",
+			wantUriTemplatesByTrailingBackslash: map[bool]string{
+				false: "/book",
+				true:  "/book/",
+			},
+		},
+		{
+			desc:        "Exact path with variable bindings outputs in different format",
+			uriTemplate: "/shelves/{shelf}/books/{book}",
+			wantUriTemplatesByTrailingBackslash: map[bool]string{
+				false: "/shelves/{shelf=*}/books/{book=*}",
+				true:  "/shelves/{shelf=*}/books/{book=*}/",
+			},
+		},
+		{
+			desc:        "Root path outputs in same format",
+			uriTemplate: "/",
+			wantUriTemplatesByTrailingBackslash: map[bool]string{
+				false: "/",
+				true:  "/",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			uriTemplate, err := ParseUriTemplate(tc.uriTemplate)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			compareExactMatchString(t, uriTemplate, false, tc.wantUriTemplatesByTrailingBackslash)
+			compareExactMatchString(t, uriTemplate, true, tc.wantUriTemplatesByTrailingBackslash)
+		})
+	}
+}
+
 func TestReplaceVariableFieldInUriTemplate(t *testing.T) {
 	testCases := []struct {
 		desc                   string
@@ -160,7 +213,6 @@ func TestReplaceVariableFieldInUriTemplate(t *testing.T) {
 				t.Errorf("fail to replace variable field, wante uriTemplate: %s, get uriTemplate: %s", tc.wantUriTemplate, getUriTemplate)
 			}
 		})
-
 	}
 }
 

--- a/src/go/util/httppattern/uri_template_test.go
+++ b/src/go/util/httppattern/uri_template_test.go
@@ -111,7 +111,7 @@ func TestTrailingBackSlash(t *testing.T) {
 		},
 		{
 			desc:        "Exact path with verb outputs in different format",
-			uriTemplate: "/book",
+			uriTemplate: "/book:read",
 			wantUriTemplatesByTrailingBackslash: map[bool]string{
 				false: "/book:read",
 				true:  "/book/:read",

--- a/src/go/util/httppattern/uri_template_test.go
+++ b/src/go/util/httppattern/uri_template_test.go
@@ -94,7 +94,7 @@ func TestTrailingBackSlash(t *testing.T) {
 		wantUriTemplatesByTrailingBackslash map[bool]string
 	}{
 		{
-			desc:        "Exact path match outputs in different format",
+			desc:        "Exact path outputs in different format",
 			uriTemplate: "/book",
 			wantUriTemplatesByTrailingBackslash: map[bool]string{
 				false: "/book",
@@ -107,6 +107,14 @@ func TestTrailingBackSlash(t *testing.T) {
 			wantUriTemplatesByTrailingBackslash: map[bool]string{
 				false: "/shelves/{shelf=*}/books/{book=*}",
 				true:  "/shelves/{shelf=*}/books/{book=*}/",
+			},
+		},
+		{
+			desc:        "Exact path with verb outputs in different format",
+			uriTemplate: "/book",
+			wantUriTemplatesByTrailingBackslash: map[bool]string{
+				false: "/book:read",
+				true:  "/book/:read",
 			},
 		},
 		{

--- a/tests/integration_test/dynamic_routing_integration_test.go
+++ b/tests/integration_test/dynamic_routing_integration_test.go
@@ -65,6 +65,12 @@ func TestDynamicRouting(t *testing.T) {
 			wantResp: `{"RequestURI":"/dynamicrouting/getpetbyid?pet_id=123&number=987"}`,
 		},
 		{
+			desc:     "Succeed, CONSTANT_ADDRESS path translation is correct with trailing slash",
+			path:     "/pet/123/num/987/",
+			method:   "GET",
+			wantResp: `{"RequestURI":"/dynamicrouting/getpetbyid?pet_id=123&number=987"}`,
+		},
+		{
 			desc:     "Succeed, CONSTANT_ADDRESS path translation is correct with escaped path segment",
 			path:     "/pet/a%20b/num/9%3B8",
 			method:   "GET",
@@ -75,6 +81,18 @@ func TestDynamicRouting(t *testing.T) {
 			path:     "/empty_path",
 			method:   "POST",
 			wantResp: `{"RequestURI":"/"}`,
+		},
+		{
+			desc:     "Succeed, CONSTANT_ADDRESS path translation with empty path and trailing slash",
+			path:     "/empty_path/",
+			method:   "POST",
+			wantResp: `{"RequestURI":"/"}`,
+		},
+		{
+			desc:          "Succeed, CONSTANT_ADDRESS path translation with empty path and multiple trailing slash",
+			path:          "/empty_path//",
+			method:        "POST",
+			httpCallError: fmt.Errorf("http response status is not 200 OK: 404 Not Found"),
 		},
 		{
 			desc:     "Succeed, CONSTANT_ADDRESS path translation is correct, original URL has query parameters, original query parameters should appear first and query parameters converted from path parameters appear later",
@@ -143,6 +161,12 @@ func TestDynamicRouting(t *testing.T) {
 			wantResp: `{"RequestURI":"/dynamicrouting/searchpet/searchpet?timezone=PST&lang=US"}`,
 		},
 		{
+			desc:     "Succeed, APPEND_PATH_TO_ADDRESS path translation with query parameter and trailing slash is correct, appends original URL to backend address (https://domain/base/path)",
+			path:     "/searchpet/?timezone=PST&lang=US",
+			method:   "GET",
+			wantResp: `{"RequestURI":"/dynamicrouting/searchpet/searchpet/?timezone=PST&lang=US"}`,
+		},
+		{
 			desc:     "Succeed, APPEND_PATH_TO_ADDRESS path translation is correct, appends original URL to backend address that ends with slash (https://domain/base/path/)",
 			path:     "/searchdog",
 			method:   "GET",
@@ -165,6 +189,12 @@ func TestDynamicRouting(t *testing.T) {
 			path:     "/pets/cat/year/2018",
 			method:   "GET",
 			wantResp: `{"RequestURI":"/dynamicrouting/listpet/pets/cat/year/2018"}`,
+		},
+		{
+			desc:     "Succeed, APPEND_PATH_TO_ADDRESS path translation is correct, original URL has path parameters and trailing slash (preserved)",
+			path:     "/pets/cat/year/2018/",
+			method:   "GET",
+			wantResp: `{"RequestURI":"/dynamicrouting/listpet/pets/cat/year/2018/"}`,
 		},
 		{
 			desc:     "Succeed, APPEND_PATH_TO_ADDRESS path translation is correct, original URL has path parameters and escaped characters",


### PR DESCRIPTION
Follow-up on #435 to accept trailing slash for all remaining paths. The trailing slash will **not** be stripped from the request unless `CONSTANT_ADDRESS` path rewrite is configured.

This is implemented by creating a duplicate route, where the only difference is the exact match path.

Testing done:
- Updated config manager unit tests
- Added new integration tests