### PR TITLE
b/176165002: Align behavior of `X-Forwarded-Authorization` and `X-Endpoint-API-UserInfo` headers

### DIFF
--- a/src/envoy/http/backend_auth/filter.cc
+++ b/src/envoy/http/backend_auth/filter.cc
@@ -95,6 +95,10 @@ FilterHeadersStatus Filter::decodeHeaders(RequestHeaderMap& headers, bool) {
   const Envoy::Http::HeaderEntry* existAuthToken =
       headers.getInline(authorization_handle.handle());
   if (existAuthToken != nullptr) {
+    // b/176165002: Clear out pre-existing header to prevent backends from
+    // unintentionally using the wrong value.
+    headers.remove(kXForwardedAuthorization);
+
     headers.addCopy(kXForwardedAuthorization,
                     existAuthToken->value().getStringView());
   }

--- a/tests/integration_test/backend_auth_disable_auth_test.go
+++ b/tests/integration_test/backend_auth_disable_auth_test.go
@@ -81,6 +81,13 @@ func TestBackendAuthDisableAuth(t *testing.T) {
 			wantResp: `{"Authorization": "Bearer ya29.DefaultAuth", "RequestURI": "/bearertoken/constant?foo=disableauthsettofalse", "X-Forwarded-Authorization":"Bearer origin-token"}`,
 		},
 		{
+			desc:     "With disable_auth=false and X-Forwarded-Authorization is already provided, it is overridden by the Authorization header.",
+			method:   "GET",
+			path:     "/disableauthsettofalse/constant/disableauthsettofalse",
+			headers:  map[string]string{"Authorization": "Bearer origin-token", "X-Forwarded-Authorization": "Bearer untrusted-token"},
+			wantResp: `{"Authorization": "Bearer ya29.DefaultAuth", "RequestURI": "/bearertoken/constant?foo=disableauthsettofalse", "X-Forwarded-Authorization":"Bearer origin-token"}`,
+		},
+		{
 			desc:     "Authentication is not set so JwtAudience is set with the backend address",
 			method:   "GET",
 			path:     "/authenticationnotset/constant/authenticationnotset",

--- a/tests/integration_test/jwt_auth_integration_test.go
+++ b/tests/integration_test/jwt_auth_integration_test.go
@@ -411,6 +411,20 @@ func TestFrontendAndBackendAuthHeaders(t *testing.T) {
 			},
 		},
 		{
+			desc: "Frontend auth preserves `Authorization` and overrides `X-Endpoint-API-UserInfo`." +
+				"Backend auth is disabled, so no further header modifications.",
+			method: "GET",
+			path:   "/disableauthsettotrue/constant/disableauthsettotrue",
+			headers: map[string]string{
+				"Authorization":           "Bearer " + testdata.Es256Token,
+				"X-Endpoint-API-UserInfo": "untrusted-payload",
+			},
+			wantHeaders: map[string]string{
+				"Authorization":           "Bearer " + testdata.Es256Token,
+				"X-Endpoint-API-UserInfo": testdata.Es256TokenPayloadBase64,
+			},
+		},
+		{
 			desc: "Frontend auth preserves `Authorization` and creates `X-Endpoint-API-UserInfo`." +
 				"Backend auth then modifies `Authorization` and creates `X-Forwarded-Authorization`.",
 			method: "GET",


### PR DESCRIPTION
**Background**: Aligning behavior based on user confusion on when to use these two headers. `X-Endpoint-API-UserInfo` is overridden if provided by the client, so we should follow the same behavior for `X-Forwarded-Authorization`. 

This will prevent backends from unintentionally using the original, client-provided value for the header. Additionally, the public `x-google-backend` [documentation](https://cloud.google.com/endpoints/docs/openapi/openapi-extensions#jwt_audience) will be updated to:

> Therefore, if an API client sets the Authorization header, a backend running behind ESPv2 should use the `X-Forwarded-Authorization` header to retrieve the entire JWT. The backend must verify the JWT in this header, as ESPv2 will not perform verification when authentication methods are not configured. **Note:** If ESPv2 is configured with authentication, prefer to use the `X-Endpoint-API-UserInfo` header to retrieve the verified JWT payload. See Receiving authenticated results in your API for more details.

**Prod Risk**: This is technically a breaking change, but @qiwzhang mentioned it should be safe. `X-Forwarded-Authorization` is not a standard header, only we set it. And backends expect it to be set by ESPv2, not by clients.

**Testing Done**: Unit test + integration tests for overriding both headers.