### PR TITLE
b/176433373: Cleanup usages of `getOrCreateMethod`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,4 +22,5 @@ require (
 	google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d
 	google.golang.org/grpc v1.27.0
 	google.golang.org/protobuf v1.24.0
+	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 )

--- a/src/go/configgenerator/cluster_generator_test.go
+++ b/src/go/configgenerator/cluster_generator_test.go
@@ -15,6 +15,7 @@
 package configgenerator
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -87,12 +88,17 @@ func TestMakeServiceControlCluster(t *testing.T) {
 				Apis: []*apipb.Api{
 					{
 						Name: testApiName,
+						Methods: []*apipb.Method{
+							{
+								Name: "ListShelves",
+							},
+						},
 					},
 				},
 				Http: &annotationspb.Http{
 					Rules: []*annotationspb.HttpRule{
 						{
-							Selector: "endpoints.examples.bookstore.Bookstore.ListShelves",
+							Selector: fmt.Sprintf("%s.ListShelves", testApiName),
 							Pattern: &annotationspb.HttpRule_Get{
 								Get: "/v1/shelves",
 							},
@@ -115,21 +121,23 @@ func TestMakeServiceControlCluster(t *testing.T) {
 	}
 
 	for i, tc := range testData {
-		opts := options.DefaultConfigGeneratorOptions()
-		opts.BackendAddress = tc.BackendAddress
-		fakeServiceInfo, err := configinfo.NewServiceInfoFromServiceConfig(tc.fakeServiceConfig, testConfigID, opts)
-		if err != nil {
-			t.Fatal(err)
-		}
+		t.Run(tc.desc, func(t *testing.T) {
+			opts := options.DefaultConfigGeneratorOptions()
+			opts.BackendAddress = tc.BackendAddress
+			fakeServiceInfo, err := configinfo.NewServiceInfoFromServiceConfig(tc.fakeServiceConfig, testConfigID, opts)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		cluster, err := makeServiceControlCluster(fakeServiceInfo)
-		if err != nil {
-			t.Fatal(err)
-		}
+			cluster, err := makeServiceControlCluster(fakeServiceInfo)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		if !proto.Equal(cluster, &tc.wantedCluster) {
-			t.Errorf("Test Desc(%d): %s, makeServiceControlCluster\ngot Clusters: %v,\nwant: %v", i, tc.desc, cluster, tc.wantedCluster)
-		}
+			if !proto.Equal(cluster, &tc.wantedCluster) {
+				t.Errorf("Test Desc(%d): %s, makeServiceControlCluster\ngot Clusters: %v,\nwant: %v", i, tc.desc, cluster, tc.wantedCluster)
+			}
+		})
 	}
 }
 
@@ -156,16 +164,6 @@ func TestMakeBackendRoutingCluster(t *testing.T) {
 							},
 							{
 								Name: "Bar",
-							},
-						},
-					},
-				},
-				Http: &annotationspb.Http{
-					Rules: []*annotationspb.HttpRule{
-						{
-							Selector: "endpoints.examples.bookstore.Bookstore.ListShelves",
-							Pattern: &annotationspb.HttpRule_Get{
-								Get: "/v1/shelves",
 							},
 						},
 					},
@@ -216,16 +214,6 @@ func TestMakeBackendRoutingCluster(t *testing.T) {
 						},
 					},
 				},
-				Http: &annotationspb.Http{
-					Rules: []*annotationspb.HttpRule{
-						{
-							Selector: "endpoints.examples.bookstore.Bookstore.ListShelves",
-							Pattern: &annotationspb.HttpRule_Get{
-								Get: "/v1/shelves",
-							},
-						},
-					},
-				},
 				Backend: &confpb.Backend{
 					Rules: []*confpb.BackendRule{
 						{
@@ -262,16 +250,6 @@ func TestMakeBackendRoutingCluster(t *testing.T) {
 							},
 							{
 								Name: "Bar",
-							},
-						},
-					},
-				},
-				Http: &annotationspb.Http{
-					Rules: []*annotationspb.HttpRule{
-						{
-							Selector: "endpoints.examples.bookstore.Bookstore.ListShelves",
-							Pattern: &annotationspb.HttpRule_Get{
-								Get: "/v1/shelves",
 							},
 						},
 					},
@@ -323,16 +301,6 @@ func TestMakeBackendRoutingCluster(t *testing.T) {
 						},
 					},
 				},
-				Http: &annotationspb.Http{
-					Rules: []*annotationspb.HttpRule{
-						{
-							Selector: "endpoints.examples.bookstore.Bookstore.ListShelves",
-							Pattern: &annotationspb.HttpRule_Get{
-								Get: "/v1/shelves",
-							},
-						},
-					},
-				},
 				Backend: &confpb.Backend{
 					Rules: []*confpb.BackendRule{
 						{
@@ -372,16 +340,6 @@ func TestMakeBackendRoutingCluster(t *testing.T) {
 						},
 					},
 				},
-				Http: &annotationspb.Http{
-					Rules: []*annotationspb.HttpRule{
-						{
-							Selector: "endpoints.examples.bookstore.Bookstore.ListShelves",
-							Pattern: &annotationspb.HttpRule_Get{
-								Get: "/v1/shelves",
-							},
-						},
-					},
-				},
 				Backend: &confpb.Backend{
 					Rules: []*confpb.BackendRule{
 						{
@@ -415,16 +373,6 @@ func TestMakeBackendRoutingCluster(t *testing.T) {
 							},
 							{
 								Name: "Bar",
-							},
-						},
-					},
-				},
-				Http: &annotationspb.Http{
-					Rules: []*annotationspb.HttpRule{
-						{
-							Selector: "endpoints.examples.bookstore.Bookstore.ListShelves",
-							Pattern: &annotationspb.HttpRule_Get{
-								Get: "/v1/shelves",
 							},
 						},
 					},
@@ -468,20 +416,10 @@ func TestMakeBackendRoutingCluster(t *testing.T) {
 				Name: testProjectName,
 				Apis: []*apipb.Api{
 					{
-						Name: "1.cloudesf_testing_cloud_goog.run.app",
+						Name: "1.cloudesf_testing_cloud_goog",
 						Methods: []*apipb.Method{
 							{
 								Name: "Foo",
-							},
-						},
-					},
-				},
-				Http: &annotationspb.Http{
-					Rules: []*annotationspb.HttpRule{
-						{
-							Selector: "endpoints.examples.bookstore.Bookstore.ListShelves",
-							Pattern: &annotationspb.HttpRule_Get{
-								Get: "/v1/shelves",
 							},
 						},
 					},
@@ -518,20 +456,10 @@ func TestMakeBackendRoutingCluster(t *testing.T) {
 				Name: testProjectName,
 				Apis: []*apipb.Api{
 					{
-						Name: "1.cloudesf_testing_cloud_goog.run.app",
+						Name: "1.cloudesf_testing_cloud_goog",
 						Methods: []*apipb.Method{
 							{
 								Name: "Foo",
-							},
-						},
-					},
-				},
-				Http: &annotationspb.Http{
-					Rules: []*annotationspb.HttpRule{
-						{
-							Selector: "endpoints.examples.bookstore.Bookstore.ListShelves",
-							Pattern: &annotationspb.HttpRule_Get{
-								Get: "/v1/shelves",
 							},
 						},
 					},
@@ -555,27 +483,29 @@ func TestMakeBackendRoutingCluster(t *testing.T) {
 	}
 
 	for i, tc := range testData {
-		opts := options.DefaultConfigGeneratorOptions()
-		opts.BackendAddress = tc.BackendAddress
-		if tc.backendDnsLookupFamily != "" {
-			opts.BackendDnsLookupFamily = tc.backendDnsLookupFamily
-		}
-		fakeServiceInfo, err := configinfo.NewServiceInfoFromServiceConfig(tc.fakeServiceConfig, testConfigID, opts)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		clusters, err := makeRemoteBackendClusters(fakeServiceInfo)
-		if err != nil {
-			if tc.wantedError == "" || !strings.Contains(err.Error(), tc.wantedError) {
-				t.Fatal(err)
-
+		t.Run(tc.desc, func(t *testing.T) {
+			opts := options.DefaultConfigGeneratorOptions()
+			opts.BackendAddress = tc.BackendAddress
+			if tc.backendDnsLookupFamily != "" {
+				opts.BackendDnsLookupFamily = tc.backendDnsLookupFamily
 			}
-		}
+			fakeServiceInfo, err := configinfo.NewServiceInfoFromServiceConfig(tc.fakeServiceConfig, testConfigID, opts)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		if tc.wantedClusters != nil && !cmp.Equal(clusters, tc.wantedClusters, cmp.Comparer(proto.Equal)) {
-			t.Errorf("Test Desc(%d): %s, makeRemoteBackendClusters\ngot: %v,\nwant: %v", i, tc.desc, clusters, tc.wantedClusters)
-		}
+			clusters, err := makeRemoteBackendClusters(fakeServiceInfo)
+			if err != nil {
+				if tc.wantedError == "" || !strings.Contains(err.Error(), tc.wantedError) {
+					t.Fatal(err)
+
+				}
+			}
+
+			if tc.wantedClusters != nil && !cmp.Equal(clusters, tc.wantedClusters, cmp.Comparer(proto.Equal)) {
+				t.Errorf("Test Desc(%d): %s, makeRemoteBackendClusters\ngot: %v,\nwant: %v", i, tc.desc, clusters, tc.wantedClusters)
+			}
+		})
 	}
 }
 

--- a/src/go/configgenerator/listener_generator_test.go
+++ b/src/go/configgenerator/listener_generator_test.go
@@ -112,6 +112,11 @@ func TestTranscoderFilter(t *testing.T) {
 				Apis: []*apipb.Api{
 					{
 						Name: testApiName,
+						Methods: []*apipb.Method{
+							{
+								Name: "Foo",
+							},
+						},
 					},
 				},
 				SourceInfo: &confpb.SourceInfo{
@@ -142,7 +147,7 @@ func TestTranscoderFilter(t *testing.T) {
 				SystemParameters: &confpb.SystemParameters{
 					Rules: []*confpb.SystemParameterRule{
 						{
-							Selector: testApiName,
+							Selector: fmt.Sprintf("%s.Foo", testApiName),
 							Parameters: []*confpb.SystemParameter{
 								{
 									Name:              "api_key",
@@ -233,27 +238,29 @@ func TestTranscoderFilter(t *testing.T) {
 	}
 
 	for i, tc := range testData {
-		opts := options.DefaultConfigGeneratorOptions()
-		opts.BackendAddress = "grpc://127.0.0.0:80"
-		opts.TranscodingAlwaysPrintPrimitiveFields = tc.transcodingAlwaysPrintPrimitiveFields
-		opts.TranscodingPreserveProtoFieldNames = tc.transcodingPreserveProtoFieldNames
-		opts.TranscodingAlwaysPrintEnumsAsInts = tc.transcodingAlwaysPrintEnumsAsInts
-		opts.TranscodingIgnoreQueryParameters = tc.transcodingIgnoreQueryParameters
-		opts.TranscodingIgnoreUnknownQueryParameters = tc.transcodingIgnoreUnknownQueryParameters
-		fakeServiceInfo, err := configinfo.NewServiceInfoFromServiceConfig(tc.fakeServiceConfig, testConfigID, opts)
-		if err != nil {
-			t.Fatal(err)
-		}
+		t.Run(tc.desc, func(t *testing.T) {
+			opts := options.DefaultConfigGeneratorOptions()
+			opts.BackendAddress = "grpc://127.0.0.0:80"
+			opts.TranscodingAlwaysPrintPrimitiveFields = tc.transcodingAlwaysPrintPrimitiveFields
+			opts.TranscodingPreserveProtoFieldNames = tc.transcodingPreserveProtoFieldNames
+			opts.TranscodingAlwaysPrintEnumsAsInts = tc.transcodingAlwaysPrintEnumsAsInts
+			opts.TranscodingIgnoreQueryParameters = tc.transcodingIgnoreQueryParameters
+			opts.TranscodingIgnoreUnknownQueryParameters = tc.transcodingIgnoreUnknownQueryParameters
+			fakeServiceInfo, err := configinfo.NewServiceInfoFromServiceConfig(tc.fakeServiceConfig, testConfigID, opts)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		marshaler := &jsonpb.Marshaler{}
-		gotFilter, err := marshaler.MarshalToString(makeTranscoderFilter(fakeServiceInfo))
-		if err != nil {
-			t.Fatal(err)
-		}
+			marshaler := &jsonpb.Marshaler{}
+			gotFilter, err := marshaler.MarshalToString(makeTranscoderFilter(fakeServiceInfo))
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		if err := util.JsonEqual(tc.wantTranscoderFilter, gotFilter); err != nil {
-			t.Errorf("Test Desc(%d): %s, makeTranscoderFilter failed, \n %v", i, tc.desc, err)
-		}
+			if err := util.JsonEqual(tc.wantTranscoderFilter, gotFilter); err != nil {
+				t.Errorf("Test Desc(%d): %s, makeTranscoderFilter failed, \n %v", i, tc.desc, err)
+			}
+		})
 	}
 }
 
@@ -483,7 +490,7 @@ func TestBackendAuthFilter(t *testing.T) {
 				Name: testProjectName,
 				Apis: []*apipb.Api{
 					{
-						Name: "testapi",
+						Name: "testapipb",
 						Methods: []*apipb.Method{
 							{
 								Name: "foo",
@@ -544,7 +551,7 @@ func TestBackendAuthFilter(t *testing.T) {
 				},
 				Apis: []*apipb.Api{
 					{
-						Name: "testapi",
+						Name: "get_testapi",
 						Methods: []*apipb.Method{
 							{
 								Name: "foo",
@@ -616,7 +623,12 @@ func TestBackendAuthFilter(t *testing.T) {
 				Name: testProjectName,
 				Apis: []*apipb.Api{
 					{
-						Name: "testapi",
+						Name: "testapipb",
+						Methods: []*apipb.Method{
+							{
+								Name: "bar",
+							},
+						},
 					},
 				},
 				Backend: &confpb.Backend{
@@ -666,7 +678,12 @@ func TestBackendAuthFilter(t *testing.T) {
 				Name: testProjectName,
 				Apis: []*apipb.Api{
 					{
-						Name: "testapi",
+						Name: "testapipb",
+						Methods: []*apipb.Method{
+							{
+								Name: "bar",
+							},
+						},
 					},
 				},
 				Backend: &confpb.Backend{

--- a/src/go/configgenerator/route_generator_test.go
+++ b/src/go/configgenerator/route_generator_test.go
@@ -2815,6 +2815,14 @@ func TestMakeFallbackRoute(t *testing.T) {
 				Apis: []*apipb.Api{
 					{
 						Name: testApiName,
+						Methods: []*apipb.Method{
+							{
+								Name: "Echo_Get",
+							},
+							{
+								Name: "Echo_Post",
+							},
+						},
 					},
 				},
 				Http: &annotationspb.Http{Rules: []*annotationspb.HttpRule{
@@ -3009,6 +3017,14 @@ func TestMakeFallbackRoute(t *testing.T) {
 				Apis: []*apipb.Api{
 					{
 						Name: testApiName,
+						Methods: []*apipb.Method{
+							{
+								Name: "Echo_Get",
+							},
+							{
+								Name: "Echo_Post",
+							},
+						},
 					},
 				},
 				Http: &annotationspb.Http{Rules: []*annotationspb.HttpRule{
@@ -3142,6 +3158,14 @@ func TestMakeFallbackRoute(t *testing.T) {
 				Apis: []*apipb.Api{
 					{
 						Name: testApiName,
+						Methods: []*apipb.Method{
+							{
+								Name: "Echo_Get",
+							},
+							{
+								Name: "Echo_Post",
+							},
+						},
 					},
 				},
 				Http: &annotationspb.Http{Rules: []*annotationspb.HttpRule{
@@ -3363,6 +3387,14 @@ func TestMakeFallbackRoute(t *testing.T) {
 				Apis: []*apipb.Api{
 					{
 						Name: testApiName,
+						Methods: []*apipb.Method{
+							{
+								Name: "Long_Get",
+							},
+							{
+								Name: "Short_Get",
+							},
+						},
 					},
 				},
 				Http: &annotationspb.Http{Rules: []*annotationspb.HttpRule{

--- a/src/go/configgenerator/route_generator_test.go
+++ b/src/go/configgenerator/route_generator_test.go
@@ -203,6 +203,11 @@ func TestMakeRouteConfig(t *testing.T) {
 				Apis: []*apipb.Api{
 					{
 						Name: testApiName,
+						Methods: []*apipb.Method{
+							{
+								Name: "Foo",
+							},
+						},
 					},
 				},
 				Backend: &confpb.Backend{
@@ -387,6 +392,11 @@ func TestMakeRouteConfig(t *testing.T) {
 				Apis: []*apipb.Api{
 					{
 						Name: testApiName,
+						Methods: []*apipb.Method{
+							{
+								Name: "Foo",
+							},
+						},
 					},
 				},
 				Backend: &confpb.Backend{

--- a/src/go/configinfo/service_info.go
+++ b/src/go/configinfo/service_info.go
@@ -253,9 +253,9 @@ func (s *ServiceInfo) addGrpcHttpRules() error {
 	for _, api := range s.serviceConfig.GetApis() {
 		for _, method := range api.GetMethods() {
 			selector := fmt.Sprintf("%s.%s", api.GetName(), method.GetName())
-			mi, err := s.getOrCreateMethod(selector)
+			mi, err := s.getMethod(selector)
 			if err != nil {
-				return fmt.Errorf("error creating auto-generated gRPC http rule for operation (%s.%s): %v", api.GetName(), method.GetName(), err)
+				return fmt.Errorf("error processing auto-generated gRPC http rule: %v", err)
 			}
 
 			path := fmt.Sprintf("/%s/%s", api.GetName(), method.GetName())

--- a/src/go/configinfo/service_info.go
+++ b/src/go/configinfo/service_info.go
@@ -117,7 +117,9 @@ func NewServiceInfoFromServiceConfig(serviceConfig *confpb.Service, id string, o
 	if err := serviceInfo.processApis(); err != nil {
 		return nil, err
 	}
-	serviceInfo.processQuota()
+	if err := serviceInfo.processQuota(); err != nil {
+		return nil, err
+	}
 	if err := serviceInfo.processBackendRule(); err != nil {
 		return nil, err
 	}
@@ -303,7 +305,7 @@ func (s *ServiceInfo) processAccessToken() {
 
 }
 
-func (s *ServiceInfo) processQuota() {
+func (s *ServiceInfo) processQuota() error {
 	for _, metricRule := range s.ServiceConfig().GetQuota().GetMetricRules() {
 		var metricCosts []*scpb.MetricCost
 		for name, cost := range metricRule.GetMetricCosts() {
@@ -312,8 +314,15 @@ func (s *ServiceInfo) processQuota() {
 				Cost: cost,
 			})
 		}
-		s.Methods[metricRule.GetSelector()].MetricCosts = metricCosts
+
+		mi, err := s.getMethod(metricRule.GetSelector())
+		if err != nil {
+			return fmt.Errorf("error processing quota metric rule: %v", err)
+		}
+		mi.MetricCosts = metricCosts
 	}
+
+	return nil
 }
 
 func (s *ServiceInfo) processEndpoints() {
@@ -382,9 +391,9 @@ func (s *ServiceInfo) processHttpRule() error {
 	addedRouteMatchWithOptionsSet := make(map[string]bool)
 
 	for _, rule := range s.ServiceConfig().GetHttp().GetRules() {
-		method, err := s.getOrCreateMethod(rule.GetSelector())
+		method, err := s.getMethod(rule.GetSelector())
 		if err != nil {
-			return fmt.Errorf("error creating http rule for operation (%v): %v", rule.Selector, err)
+			return fmt.Errorf("error processing http rule for operation (%v): %v", rule.Selector, err)
 		}
 		if err := addHttpRule(method, rule, addedRouteMatchWithOptionsSet); err != nil {
 			return err
@@ -405,7 +414,11 @@ func (s *ServiceInfo) processHttpRule() error {
 	// urls except the ones already with options.
 	if s.AllowCors {
 		for _, r := range s.ServiceConfig().GetHttp().GetRules() {
-			method := s.Methods[r.GetSelector()]
+			method, err := s.getMethod(r.GetSelector())
+			if err != nil {
+				return fmt.Errorf("error processing http rule for operation (%v): %v", r.GetSelector(), err)
+			}
+
 			for _, httpRule := range method.HttpRule {
 				if httpRule.HttpMethod != util.OPTIONS {
 					uriTemplate, err := httppattern.ParseUriTemplate(httpRule.UriTemplate.Origin)
@@ -529,7 +542,7 @@ func (s *ServiceInfo) processBackendRule() error {
 }
 
 func (s *ServiceInfo) addBackendInfoToMethod(r *confpb.BackendRule, scheme string, hostname string, path string, backendClusterName string) error {
-	method, err := s.getOrCreateMethod(r.GetSelector())
+	method, err := s.getMethod(r.GetSelector())
 	if err != nil {
 		return err
 	}
@@ -620,7 +633,7 @@ func (s *ServiceInfo) processLocalBackendOperations() error {
 
 func (s *ServiceInfo) processUsageRule() error {
 	for _, r := range s.ServiceConfig().GetUsage().GetRules() {
-		method, err := s.getOrCreateMethod(r.GetSelector())
+		method, err := s.getMethod(r.GetSelector())
 		if err != nil {
 			return fmt.Errorf("error processing usage rule for operation (%v): %v", r.Selector, err)
 		}
@@ -676,7 +689,7 @@ func (s *ServiceInfo) processApiKeyLocations() error {
 			}
 		}
 
-		method, err := s.getOrCreateMethod(rule.GetSelector())
+		method, err := s.getMethod(rule.GetSelector())
 		if err != nil {
 			return fmt.Errorf("error processing system parameter rule for operation (%v): %v", rule.Selector, err)
 		}
@@ -788,11 +801,18 @@ func (s *ServiceInfo) processTypes() error {
 	return nil
 }
 
-// get the MethodInfo by full name, and create a new one if not exists.
+// Get the MethodInfo by full name. Prefer to use this function when getting methods,
+// as it outputs an actionable error message.
+func (s *ServiceInfo) getMethod(name string) (*MethodInfo, error) {
+	if s.Methods[name] == nil {
+		return nil, fmt.Errorf("selector (%v) was not defined in the API", name)
+	}
+	return s.Methods[name], nil
+}
+
+// Get the MethodInfo by full name, and create a new one if not exists.
 // Ideally, all selector name in service config rules should exist in the api
-// methods.
-// TODO(b/176433373): Clean-up usage of this method. Non-`apis` aspects should
-// not be creating new methods, they should error if not found.
+// aspect, so use getMethod(...) instead.
 func (s *ServiceInfo) getOrCreateMethod(name string) (*MethodInfo, error) {
 	if s.Methods[name] == nil {
 		names := strings.Split(name, ".")
@@ -817,10 +837,11 @@ func (s *ServiceInfo) processAuthRequirement() error {
 	auth := s.serviceConfig.GetAuthentication()
 	for _, rule := range auth.GetRules() {
 		if len(rule.GetRequirements()) > 0 {
-			if s.Methods[rule.GetSelector()] == nil {
+			mi, err := s.getMethod(rule.GetSelector())
+			if err != nil {
 				return fmt.Errorf("error processing authentication rule for operation (%v): selector not defined in Api.method or Http.rule", rule.GetSelector())
 			}
-			s.Methods[rule.GetSelector()].RequireAuth = true
+			mi.RequireAuth = true
 		}
 	}
 	return nil

--- a/src/go/configinfo/service_info_test.go
+++ b/src/go/configinfo/service_info_test.go
@@ -1685,7 +1685,20 @@ func TestProcessBackendRuleForDeadline(t *testing.T) {
 			fakeServiceConfig: &confpb.Service{
 				Apis: []*apipb.Api{
 					{
-						Name: testApiName,
+						Name: "abc.com",
+						Methods: []*apipb.Method{
+							{
+								Name: "api",
+							},
+						},
+					},
+					{
+						Name: "cnn.com",
+						Methods: []*apipb.Method{
+							{
+								Name: "api",
+							},
+						},
 					},
 				},
 				Backend: &confpb.Backend{
@@ -1713,7 +1726,12 @@ func TestProcessBackendRuleForDeadline(t *testing.T) {
 			fakeServiceConfig: &confpb.Service{
 				Apis: []*apipb.Api{
 					{
-						Name: testApiName,
+						Name: "abc.com",
+						Methods: []*apipb.Method{
+							{
+								Name: "api",
+							},
+						},
 					},
 				},
 				Backend: &confpb.Backend{
@@ -1735,7 +1753,12 @@ func TestProcessBackendRuleForDeadline(t *testing.T) {
 			fakeServiceConfig: &confpb.Service{
 				Apis: []*apipb.Api{
 					{
-						Name: testApiName,
+						Name: "abc.com",
+						Methods: []*apipb.Method{
+							{
+								Name: "api",
+							},
+						},
 					},
 				},
 				Backend: &confpb.Backend{
@@ -1755,22 +1778,24 @@ func TestProcessBackendRuleForDeadline(t *testing.T) {
 	}
 
 	for i, tc := range testData {
-		opts := options.DefaultConfigGeneratorOptions()
-		s, err := NewServiceInfoFromServiceConfig(tc.fakeServiceConfig, testConfigID, opts)
+		t.Run(tc.desc, func(t *testing.T) {
+			opts := options.DefaultConfigGeneratorOptions()
+			s, err := NewServiceInfoFromServiceConfig(tc.fakeServiceConfig, testConfigID, opts)
 
-		if err != nil {
-			t.Errorf("Test Desc(%d): %s, TestProcessBackendRuleForDeadline error not expected, got: %v", i, tc.desc, err)
-			return
-		}
-
-		for _, rule := range tc.fakeServiceConfig.Backend.Rules {
-			gotDeadline := s.Methods[rule.Selector].BackendInfo.Deadline
-			wantDeadline := tc.wantedMethodDeadlines[rule.Selector]
-
-			if wantDeadline != gotDeadline {
-				t.Errorf("Test Desc(%d): %s, TestProcessBackendRuleForDeadline, Deadline not expected, got: %v, want: %v", i, tc.desc, gotDeadline, wantDeadline)
+			if err != nil {
+				t.Errorf("Test Desc(%d): %s, TestProcessBackendRuleForDeadline error not expected, got: %v", i, tc.desc, err)
+				return
 			}
-		}
+
+			for _, rule := range tc.fakeServiceConfig.Backend.Rules {
+				gotDeadline := s.Methods[rule.Selector].BackendInfo.Deadline
+				wantDeadline := tc.wantedMethodDeadlines[rule.Selector]
+
+				if wantDeadline != gotDeadline {
+					t.Errorf("Test Desc(%d): %s, TestProcessBackendRuleForDeadline, Deadline not expected, got: %v, want: %v", i, tc.desc, gotDeadline, wantDeadline)
+				}
+			}
+		})
 	}
 }
 
@@ -1786,7 +1811,20 @@ func TestProcessBackendRuleForProtocol(t *testing.T) {
 			fakeServiceConfig: &confpb.Service{
 				Apis: []*apipb.Api{
 					{
-						Name: testApiName,
+						Name: "abc.com",
+						Methods: []*apipb.Method{
+							{
+								Name: "api",
+							},
+						},
+					},
+					{
+						Name: "cnn.com",
+						Methods: []*apipb.Method{
+							{
+								Name: "api",
+							},
+						},
 					},
 				},
 				Backend: &confpb.Backend{
@@ -1815,7 +1853,15 @@ func TestProcessBackendRuleForProtocol(t *testing.T) {
 			fakeServiceConfig: &confpb.Service{
 				Apis: []*apipb.Api{
 					{
-						Name: testApiName,
+						Name: "api.test",
+						Methods: []*apipb.Method{
+							{
+								Name: "1",
+							},
+							{
+								Name: "2",
+							},
+						},
 					},
 				},
 				Backend: &confpb.Backend{
@@ -1840,27 +1886,29 @@ func TestProcessBackendRuleForProtocol(t *testing.T) {
 	}
 
 	for _, tc := range testData {
-		opts := options.DefaultConfigGeneratorOptions()
-		s, err := NewServiceInfoFromServiceConfig(tc.fakeServiceConfig, testConfigID, opts)
+		t.Run(tc.desc, func(t *testing.T) {
+			opts := options.DefaultConfigGeneratorOptions()
+			s, err := NewServiceInfoFromServiceConfig(tc.fakeServiceConfig, testConfigID, opts)
 
-		if err != nil {
-			t.Errorf("Test Desc(%s): error not expected, got: %v", tc.desc, err)
-			return
-		}
-
-		for _, gotBackendRoutingCluster := range s.RemoteBackendClusters {
-			gotProtocol := gotBackendRoutingCluster.Protocol
-			wantProtocol, ok := tc.wantedClusterProtocols[gotBackendRoutingCluster.ClusterName]
-
-			if !ok {
-				t.Errorf("Test Desc(%s): Unknown backend routing cluster generated: %+v", tc.desc, gotBackendRoutingCluster)
-				continue
+			if err != nil {
+				t.Errorf("Test Desc(%s): error not expected, got: %v", tc.desc, err)
+				return
 			}
 
-			if wantProtocol != gotProtocol {
-				t.Errorf("Test Desc(%s): Protocol not expected, got: %v, want: %v", tc.desc, gotProtocol, wantProtocol)
+			for _, gotBackendRoutingCluster := range s.RemoteBackendClusters {
+				gotProtocol := gotBackendRoutingCluster.Protocol
+				wantProtocol, ok := tc.wantedClusterProtocols[gotBackendRoutingCluster.ClusterName]
+
+				if !ok {
+					t.Errorf("Test Desc(%s): Unknown backend routing cluster generated: %+v", tc.desc, gotBackendRoutingCluster)
+					continue
+				}
+
+				if wantProtocol != gotProtocol {
+					t.Errorf("Test Desc(%s): Protocol not expected, got: %v, want: %v", tc.desc, gotProtocol, wantProtocol)
+				}
 			}
-		}
+		})
 	}
 }
 
@@ -1953,36 +2001,43 @@ func TestProcessBackendRuleForClusterName(t *testing.T) {
 	}
 
 	for _, tc := range testData {
-		fakeServiceConfig := &confpb.Service{
-			Apis: []*apipb.Api{
-				{
-					Name: testApiName,
-				},
-			},
-			Backend: &confpb.Backend{
-				Rules: []*confpb.BackendRule{
+		t.Run(tc.desc, func(t *testing.T) {
+			fakeServiceConfig := &confpb.Service{
+				Apis: []*apipb.Api{
 					{
-						Address:  tc.Address,
-						Selector: "http.abc.com.api",
+						Name: "http.abc.com",
+						Methods: []*apipb.Method{
+							{
+								Name: "api",
+							},
+						},
 					},
 				},
-			},
-		}
-		opts := options.DefaultConfigGeneratorOptions()
-		s, err := NewServiceInfoFromServiceConfig(fakeServiceConfig, testConfigID, opts)
+				Backend: &confpb.Backend{
+					Rules: []*confpb.BackendRule{
+						{
+							Address:  tc.Address,
+							Selector: "http.abc.com.api",
+						},
+					},
+				},
+			}
+			opts := options.DefaultConfigGeneratorOptions()
+			s, err := NewServiceInfoFromServiceConfig(fakeServiceConfig, testConfigID, opts)
 
-		if err != nil {
-			t.Errorf("Test Desc(%s): error not expected, got: %v", tc.desc, err)
-			return
-		}
+			if err != nil {
+				t.Errorf("Test Desc(%s): error not expected, got: %v", tc.desc, err)
+				return
+			}
 
-		if len(s.RemoteBackendClusters) != 1 {
-			t.Errorf("Test Desc(%s): generated number of clusters is not 1", tc.desc)
-			return
-		}
-		if tc.ClusterName != s.RemoteBackendClusters[0].ClusterName {
-			t.Errorf("Test Desc(%s): cluster name is different, want: %s, got %s", tc.desc, tc.ClusterName, s.RemoteBackendClusters[0].ClusterName)
-		}
+			if len(s.RemoteBackendClusters) != 1 {
+				t.Errorf("Test Desc(%s): generated number of clusters is not 1", tc.desc)
+				return
+			}
+			if tc.ClusterName != s.RemoteBackendClusters[0].ClusterName {
+				t.Errorf("Test Desc(%s): cluster name is different, want: %s, got %s", tc.desc, tc.ClusterName, s.RemoteBackendClusters[0].ClusterName)
+			}
+		})
 	}
 }
 
@@ -1999,7 +2054,12 @@ func TestProcessBackendRuleForJwtAudience(t *testing.T) {
 			fakeServiceConfig: &confpb.Service{
 				Apis: []*apipb.Api{
 					{
-						Name: testApiName,
+						Name: "abc.com",
+						Methods: []*apipb.Method{
+							{
+								Name: "api",
+							},
+						},
 					},
 				},
 				Backend: &confpb.Backend{
@@ -2023,7 +2083,12 @@ func TestProcessBackendRuleForJwtAudience(t *testing.T) {
 			fakeServiceConfig: &confpb.Service{
 				Apis: []*apipb.Api{
 					{
-						Name: testApiName,
+						Name: "abc.com",
+						Methods: []*apipb.Method{
+							{
+								Name: "api",
+							},
+						},
 					},
 				},
 				Backend: &confpb.Backend{
@@ -2047,7 +2112,12 @@ func TestProcessBackendRuleForJwtAudience(t *testing.T) {
 			fakeServiceConfig: &confpb.Service{
 				Apis: []*apipb.Api{
 					{
-						Name: testApiName,
+						Name: "abc.com",
+						Methods: []*apipb.Method{
+							{
+								Name: "api",
+							},
+						},
 					},
 				},
 				Backend: &confpb.Backend{
@@ -2070,7 +2140,12 @@ func TestProcessBackendRuleForJwtAudience(t *testing.T) {
 			fakeServiceConfig: &confpb.Service{
 				Apis: []*apipb.Api{
 					{
-						Name: testApiName,
+						Name: "abc.com",
+						Methods: []*apipb.Method{
+							{
+								Name: "api",
+							},
+						},
 					},
 				},
 				Backend: &confpb.Backend{
@@ -2093,7 +2168,12 @@ func TestProcessBackendRuleForJwtAudience(t *testing.T) {
 			fakeServiceConfig: &confpb.Service{
 				Apis: []*apipb.Api{
 					{
-						Name: testApiName,
+						Name: "abc.com",
+						Methods: []*apipb.Method{
+							{
+								Name: "api",
+							},
+						},
 					},
 				},
 				Backend: &confpb.Backend{
@@ -2117,7 +2197,12 @@ func TestProcessBackendRuleForJwtAudience(t *testing.T) {
 			fakeServiceConfig: &confpb.Service{
 				Apis: []*apipb.Api{
 					{
-						Name: testApiName,
+						Name: "abc.com",
+						Methods: []*apipb.Method{
+							{
+								Name: "api",
+							},
+						},
 					},
 				},
 				Backend: &confpb.Backend{
@@ -2140,7 +2225,44 @@ func TestProcessBackendRuleForJwtAudience(t *testing.T) {
 			fakeServiceConfig: &confpb.Service{
 				Apis: []*apipb.Api{
 					{
-						Name: testApiName,
+						Name: "abc.com",
+						Methods: []*apipb.Method{
+							{
+								Name: "api",
+							},
+						},
+					},
+					{
+						Name: "def.com",
+						Methods: []*apipb.Method{
+							{
+								Name: "api",
+							},
+						},
+					},
+					{
+						Name: "ghi.com",
+						Methods: []*apipb.Method{
+							{
+								Name: "api",
+							},
+						},
+					},
+					{
+						Name: "jkl.com",
+						Methods: []*apipb.Method{
+							{
+								Name: "api",
+							},
+						},
+					},
+					{
+						Name: "mno.com",
+						Methods: []*apipb.Method{
+							{
+								Name: "api",
+							},
+						},
 					},
 				},
 				Backend: &confpb.Backend{


### PR DESCRIPTION
`getOrCreateMethod` is called from a few aspects where selectors are processed (http rules, usage rules, authentication rules, etc). However, these should only GET, not CREATE. If the selector doesn't exist, it should error instead of creating a new one. With this PR, `getOrCreateMethod` will only be used for:
- The initial processing of the API methods
- Auto-generated CORS operations
- Auto-generated HealthCheck operation

Also cleanup usages of directly accessing `Methods[selector]`. Some places do not check for `nil`. This can cause a crash in config generator if the service config has selectors with typos.

Diff is large because of test changes, feel free to ignore them. They are just normalizing the service config.