### PR TITLE
b/176433373: Normalize service configs in integration tests

### DIFF
--- a/tests/env/env.go
+++ b/tests/env/env.go
@@ -30,7 +30,6 @@ import (
 	bookserver "github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/bookstore_grpc/server"
 	annotationspb "google.golang.org/genproto/googleapis/api/annotations"
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
-	apipb "google.golang.org/genproto/protobuf/api"
 )
 
 const (
@@ -216,11 +215,6 @@ func (e *TestEnv) OverrideSystemParameters(systemParameters *confpb.SystemParame
 // OverrideQuota overrides Service.Quota.
 func (e *TestEnv) OverrideQuota(quota *confpb.Quota) {
 	e.fakeServiceConfig.Quota = quota
-}
-
-// AppendApiMethods appends methods to the service config.
-func (e *TestEnv) AppendApiMethods(methods []*apipb.Method) {
-	e.fakeServiceConfig.Apis[0].Methods = append(e.fakeServiceConfig.Apis[0].Methods, methods...)
 }
 
 // AppendHttpRules appends Service.Http.Rules.

--- a/tests/env/testdata/fake_echo_service_config.go
+++ b/tests/env/testdata/fake_echo_service_config.go
@@ -47,6 +47,18 @@ var (
 						ResponseTypeUrl: "type.googleapis.com/EchoMessage",
 					},
 					{
+						Name: "Simpleget",
+					},
+					{
+						Name: "SimplegetNotModified",
+					},
+					{
+						Name: "SimplegetUnauthorized",
+					},
+					{
+						Name: "SimplegetForbidden",
+					},
+					{
 						Name:            "Simplegetcors",
 						RequestTypeUrl:  "type.googleapis.com/google.protobuf.Empty",
 						ResponseTypeUrl: "type.googleapis.com/SimpleCorsMessage",
@@ -72,13 +84,43 @@ var (
 						Name: "EchoGetWithBody",
 					},
 					{
+						Name: "echoGET",
+					},
+					{
+						Name: "echoPOST",
+					},
+					{
+						Name: "echoPUT",
+					},
+					{
+						Name: "echoPATCH",
+					},
+					{
+						Name: "echoDELETE",
+					},
+					{
 						Name: "Root",
 					},
 					{
 						Name: "Echo_nokey",
 					},
 					{
-						Name: "post_anypath",
+						Name: "_post_anypath",
+					},
+					{
+						Name: "Echo_nokey_override_as_get",
+					},
+					{
+						Name: "CorsShelves",
+					},
+					{
+						Name: "GetShelf",
+					},
+					{
+						Name: "UpdateShelf",
+					},
+					{
+						Name: "DeleteShelf",
 					},
 				},
 				Version: "1.0.0",
@@ -149,6 +191,30 @@ var (
 					Body: "message",
 				},
 				{
+					Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Simpleget",
+					Pattern: &annotationspb.HttpRule_Get{
+						Get: "/simpleget",
+					},
+				},
+				{
+					Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.SimplegetNotModified",
+					Pattern: &annotationspb.HttpRule_Get{
+						Get: "/simpleget/304",
+					},
+				},
+				{
+					Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.SimplegetUnauthorized",
+					Pattern: &annotationspb.HttpRule_Get{
+						Get: "/simpleget/401",
+					},
+				},
+				{
+					Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.SimplegetForbidden",
+					Pattern: &annotationspb.HttpRule_Get{
+						Get: "/simpleget/403",
+					},
+				},
+				{
 					Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Simplegetcors",
 					Pattern: &annotationspb.HttpRule_Get{
 						Get: "/simplegetcors",
@@ -176,6 +242,39 @@ var (
 					Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.SleepWithBackendRule",
 					Pattern: &annotationspb.HttpRule_Get{
 						Get: "/sleep/with/backend/rule",
+					},
+				},
+				{
+					Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo_nokey_override_as_get",
+					Pattern: &annotationspb.HttpRule_Get{
+						Get: "/echo/nokey/OverrideAsGet",
+					},
+				},
+				{
+					Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.CorsShelves",
+					Pattern: &annotationspb.HttpRule_Custom{
+						Custom: &annotationspb.CustomHttpPattern{
+							Kind: "OPTIONS",
+							Path: "/bookstore/shelves",
+						},
+					},
+				},
+				{
+					Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.GetShelf",
+					Pattern: &annotationspb.HttpRule_Get{
+						Get: "/bookstore/shelves/{shelf}",
+					},
+				},
+				{
+					Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.echoGET",
+					Pattern: &annotationspb.HttpRule_Get{
+						Get: "/echoMethod",
+					},
+				},
+				{
+					Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.echoPOST",
+					Pattern: &annotationspb.HttpRule_Post{
+						Post: "/echoMethod",
 					},
 				},
 			},
@@ -261,6 +360,18 @@ var (
 				},
 				{
 					Selector:               "1.echo_api_endpoints_cloudesf_testing_cloud_goog.SleepWithBackendRule",
+					AllowUnregisteredCalls: true,
+				},
+				{
+					Selector:               "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo_nokey_override_as_get",
+					AllowUnregisteredCalls: true,
+				},
+				{
+					Selector:               "1.echo_api_endpoints_cloudesf_testing_cloud_goog.SimplegetNotModified",
+					AllowUnregisteredCalls: true,
+				},
+				{
+					Selector:               "1.echo_api_endpoints_cloudesf_testing_cloud_goog.SimplegetForbidden",
 					AllowUnregisteredCalls: true,
 				},
 			},

--- a/tests/env/testdata/fake_echo_service_config.go
+++ b/tests/env/testdata/fake_echo_service_config.go
@@ -62,6 +62,24 @@ var (
 					{
 						Name: "SleepWithBackendRule",
 					},
+					{
+						Name: "Auth0",
+					},
+					{
+						Name: "EchoHeader",
+					},
+					{
+						Name: "EchoGetWithBody",
+					},
+					{
+						Name: "Root",
+					},
+					{
+						Name: "Echo_nokey",
+					},
+					{
+						Name: "post_anypath",
+					},
 				},
 				Version: "1.0.0",
 			},

--- a/tests/env/testdata/fake_echo_service_config_for_dynamic_routing.go
+++ b/tests/env/testdata/fake_echo_service_config_for_dynamic_routing.go
@@ -84,7 +84,19 @@ var (
 						Name: "dynamic_routing_BearertokenConstantAddress",
 					},
 					{
+						Name: "dynamic_routing_AuthenticationNotSet",
+					},
+					{
+						Name: "dynamic_routing_DisableAuthSetToFalse",
+					},
+					{
+						Name: "dynamic_routing_DisableAuthSetToTrue",
+					},
+					{
 						Name: "dynamic_routing_BearertokenAppendAddress",
+					},
+					{
+						Name: "dynamic_routing_EmptyPath",
 					},
 					{
 						Name: "dynamic_routing_Simplegetcors",

--- a/tests/env/testdata/fake_grpc_bookstore_service_config.go
+++ b/tests/env/testdata/fake_grpc_bookstore_service_config.go
@@ -75,6 +75,9 @@ var (
 						RequestTypeUrl:  "type.googleapis.com/google.protobuf.Empty",
 						ResponseTypeUrl: "type.googleapis.com/google.protobuf.Empty",
 					},
+					{
+						Name: "GetShelfAutoBind",
+					},
 				},
 				Version: "1.0.0",
 			},

--- a/tests/env/testdata/fake_grpc_bookstore_service_config.go
+++ b/tests/env/testdata/fake_grpc_bookstore_service_config.go
@@ -78,6 +78,9 @@ var (
 					{
 						Name: "GetShelfAutoBind",
 					},
+					{
+						Name: "Unspecified",
+					},
 				},
 				Version: "1.0.0",
 			},
@@ -223,7 +226,12 @@ var (
 			},
 		},
 		Usage: &confpb.Usage{
-			Rules: []*confpb.UsageRule{},
+			Rules: []*confpb.UsageRule{
+				{
+					Selector:               "endpoints.examples.bookstore.Bookstore.Unspecified",
+					AllowUnregisteredCalls: true,
+				},
+			},
 		},
 	}
 )

--- a/tests/integration_test/cors_integration_test.go
+++ b/tests/integration_test/cors_integration_test.go
@@ -23,8 +23,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
-	apipb "google.golang.org/genproto/protobuf/api"
-
 	annotationspb "google.golang.org/genproto/googleapis/api/annotations"
 )
 
@@ -474,40 +472,6 @@ func TestServiceControlRequestWithAllowCors(t *testing.T) {
 
 	s := env.NewTestEnv(platform.TestServiceControlRequestWithAllowCors, platform.EchoSidecar)
 	s.SetAllowCors()
-	s.AppendApiMethods([]*apipb.Method{
-		{
-			Name: "ListShelves",
-		},
-		{
-			Name: "CorsShelves",
-		},
-		{
-			Name: "GetShelf",
-		},
-	})
-	s.AppendHttpRules([]*annotationspb.HttpRule{
-		{
-			Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.ListShelves",
-			Pattern: &annotationspb.HttpRule_Get{
-				Get: "/bookstore/shelves",
-			},
-		},
-		{
-			Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.CorsShelves",
-			Pattern: &annotationspb.HttpRule_Custom{
-				Custom: &annotationspb.CustomHttpPattern{
-					Kind: "OPTIONS",
-					Path: "/bookstore/shelves",
-				},
-			},
-		},
-		{
-			Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.GetShelf",
-			Pattern: &annotationspb.HttpRule_Get{
-				Get: "/bookstore/shelves/{shelf}",
-			},
-		},
-	})
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
@@ -658,29 +622,6 @@ func TestServiceControlRequestWithoutAllowCors(t *testing.T) {
 		"--rollout_strategy=fixed", "--suppress_envoy_headers"}
 
 	s := env.NewTestEnv(platform.TestServiceControlRequestWithoutAllowCors, platform.EchoSidecar)
-	s.AppendHttpRules([]*annotationspb.HttpRule{
-		{
-			Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.ListShelves",
-			Pattern: &annotationspb.HttpRule_Get{
-				Get: "/bookstore/shelves",
-			},
-		},
-		{
-			Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.CorsShelves",
-			Pattern: &annotationspb.HttpRule_Custom{
-				Custom: &annotationspb.CustomHttpPattern{
-					Kind: "OPTIONS",
-					Path: "/bookstore/shelves",
-				},
-			},
-		},
-		{
-			Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.GetShelf",
-			Pattern: &annotationspb.HttpRule_Get{
-				Get: "/bookstore/shelves/{shelf}",
-			},
-		},
-	})
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
@@ -724,6 +665,7 @@ func TestServiceControlRequestWithoutAllowCors(t *testing.T) {
 					ApiKeyState:                  "VERIFIED",
 					ApiMethod:                    "1.echo_api_endpoints_cloudesf_testing_cloud_goog.CorsShelves",
 					ApiName:                      "1.echo_api_endpoints_cloudesf_testing_cloud_goog",
+					ApiVersion:                   "1.0.0",
 					ProducerProjectID:            "producer-project",
 					ConsumerProjectID:            "123456",
 					FrontendProtocol:             "http",
@@ -794,12 +736,6 @@ func TestStartupDuplicatedPathsWithAllowCors(t *testing.T) {
 	s := env.NewTestEnv(platform.TestStartupDuplicatedPathsWithAllowCors, platform.EchoSidecar)
 	s.SetAllowCors()
 	s.AppendHttpRules([]*annotationspb.HttpRule{
-		{
-			Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.GetShelf",
-			Pattern: &annotationspb.HttpRule_Get{
-				Get: "/bookstore/shelves/{shelf}",
-			},
-		},
 		{
 			// URL is exactly the same even though method differs.
 			// When the bug was reported, our code already handles this.

--- a/tests/integration_test/grpc_fallback_test.go
+++ b/tests/integration_test/grpc_fallback_test.go
@@ -25,8 +25,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
 
 	annotationspb "google.golang.org/genproto/googleapis/api/annotations"
-	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
-	apipb "google.golang.org/genproto/protobuf/api"
 )
 
 func TestGRPCFallback(t *testing.T) {
@@ -41,13 +39,6 @@ func TestGRPCFallback(t *testing.T) {
 
 	// But then spin up the gRPC Echo backend.
 	s.OverrideBackendService(platform.GrpcEchoSidecar)
-
-	// And modify the gRPC Bookstore service config to add a fallback path.
-	s.AppendApiMethods([]*apipb.Method{
-		{
-			Name: "Unspecified",
-		},
-	})
 	s.AppendHttpRules([]*annotationspb.HttpRule{
 		{
 			Selector: "endpoints.examples.bookstore.Bookstore.Unspecified",
@@ -59,12 +50,7 @@ func TestGRPCFallback(t *testing.T) {
 			},
 		},
 	})
-	s.AppendUsageRules([]*confpb.UsageRule{
-		{
-			Selector:               "endpoints.examples.bookstore.Bookstore.Unspecified",
-			AllowUnregisteredCalls: true,
-		},
-	})
+
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)

--- a/tests/integration_test/http_method_override_test.go
+++ b/tests/integration_test/http_method_override_test.go
@@ -24,28 +24,12 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
-
-	annotationspb "google.golang.org/genproto/googleapis/api/annotations"
 )
 
 func TestMethodOverrideBackendMethod(t *testing.T) {
 	t.Parallel()
 
 	s := env.NewTestEnv(platform.TestMethodOverrideBackendMethod, platform.EchoSidecar)
-	s.AppendHttpRules([]*annotationspb.HttpRule{
-		{
-			Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.echoGET",
-			Pattern: &annotationspb.HttpRule_Get{
-				Get: "/echoMethod",
-			},
-		},
-		{
-			Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.echoPOST",
-			Pattern: &annotationspb.HttpRule_Post{
-				Post: "/echoMethod",
-			},
-		},
-	})
 
 	defer s.TearDown(t)
 	if err := s.Setup(utils.CommonArgs()); err != nil {
@@ -225,6 +209,7 @@ func TestMethodOverrideScReport(t *testing.T) {
 					ApiKeyState:                  "VERIFIED",
 					ApiMethod:                    "1.echo_api_endpoints_cloudesf_testing_cloud_goog.EchoGetWithBody",
 					ApiName:                      "1.echo_api_endpoints_cloudesf_testing_cloud_goog",
+					ApiVersion:                   "1.0.0",
 					ProducerProjectID:            "producer-project",
 					ConsumerProjectID:            "123456",
 					HttpMethod:                   "GET",

--- a/tests/integration_test/service_control_basic_test.go
+++ b/tests/integration_test/service_control_basic_test.go
@@ -24,9 +24,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
-
-	annotationspb "google.golang.org/genproto/googleapis/api/annotations"
-	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
 )
 
 func TestServiceControlBasic(t *testing.T) {
@@ -38,28 +35,6 @@ func TestServiceControlBasic(t *testing.T) {
 		"--rollout_strategy=fixed", "--suppress_envoy_headers"}
 
 	s := env.NewTestEnv(platform.TestServiceControlBasic, platform.EchoSidecar)
-	s.AppendHttpRules([]*annotationspb.HttpRule{
-		{
-			Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Simpleget",
-			Pattern: &annotationspb.HttpRule_Get{
-				Get: "/simpleget",
-			},
-		},
-		{
-			Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo_nokey_override_as_get",
-			Pattern: &annotationspb.HttpRule_Get{
-				Get: "/echo/nokey/OverrideAsGet",
-			},
-		},
-	})
-	s.AppendUsageRules(
-		[]*confpb.UsageRule{
-			{
-				Selector:               "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo_nokey_override_as_get",
-				AllowUnregisteredCalls: true,
-			},
-		})
-
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
@@ -100,6 +75,7 @@ func TestServiceControlBasic(t *testing.T) {
 					ApiKeyState:                  "VERIFIED",
 					ApiMethod:                    "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Simpleget",
 					ApiName:                      "1.echo_api_endpoints_cloudesf_testing_cloud_goog",
+					ApiVersion:                   "1.0.0",
 					ProducerProjectID:            "producer-project",
 					ConsumerProjectID:            "123456",
 					FrontendProtocol:             "http",
@@ -192,6 +168,7 @@ func TestServiceControlBasic(t *testing.T) {
 					URL:               "/echo/nokey",
 					ApiMethod:         "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo_nokey",
 					ApiName:           "1.echo_api_endpoints_cloudesf_testing_cloud_goog",
+					ApiVersion:        "1.0.0",
 					ApiKeyState:       "NOT CHECKED",
 					ProducerProjectID: "producer-project",
 					HttpMethod:        "POST",
@@ -221,6 +198,7 @@ func TestServiceControlBasic(t *testing.T) {
 					// API Key is not verified by check, but still log it.
 					ApiKeyInLogEntryOnly: "api-key",
 					ApiKeyState:          "NOT CHECKED",
+					ApiVersion:           "1.0.0",
 					ProducerProjectID:    "producer-project",
 					HttpMethod:           "POST",
 					FrontendProtocol:     "http",
@@ -249,6 +227,7 @@ func TestServiceControlBasic(t *testing.T) {
 					URL:               "/echo/nokey",
 					ApiMethod:         "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Echo_nokey",
 					ApiName:           "1.echo_api_endpoints_cloudesf_testing_cloud_goog",
+					ApiVersion:        "1.0.0",
 					ApiKeyState:       "NOT CHECKED",
 					ProducerProjectID: "producer-project",
 					HttpMethod:        "POST",
@@ -277,6 +256,7 @@ func TestServiceControlBasic(t *testing.T) {
 					ApiMethod:         "1.echo_api_endpoints_cloudesf_testing_cloud_goog._post_anypath",
 					ApiName:           "1.echo_api_endpoints_cloudesf_testing_cloud_goog",
 					ApiKeyState:       "NOT CHECKED",
+					ApiVersion:        "1.0.0",
 					ProducerProjectID: "producer-project",
 					HttpMethod:        "POST",
 					FrontendProtocol:  "http",

--- a/tests/integration_test/service_control_check_fail_test.go
+++ b/tests/integration_test/service_control_check_fail_test.go
@@ -197,6 +197,7 @@ func TestServiceControlCheckError(t *testing.T) {
 					ApiMethod:                    "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Auth0",
 					ErrorCause:                   "Client project not valid. Please pass a valid project.",
 					ApiName:                      "1.echo_api_endpoints_cloudesf_testing_cloud_goog",
+					ApiVersion:                   "1.0.0",
 					ProducerProjectID:            "producer-project",
 					ConsumerProjectID:            "123456",
 					FrontendProtocol:             "http",

--- a/tests/integration_test/service_control_http_method_test.go
+++ b/tests/integration_test/service_control_http_method_test.go
@@ -39,18 +39,6 @@ func TestServiceControlAllHTTPMethods(t *testing.T) {
 	s := env.NewTestEnv(platform.TestServiceControlAllHTTPMethod, platform.EchoSidecar)
 	s.AppendHttpRules([]*annotationspb.HttpRule{
 		{
-			Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.echoGET",
-			Pattern: &annotationspb.HttpRule_Get{
-				Get: "/echoMethod",
-			},
-		},
-		{
-			Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.echoPOST",
-			Pattern: &annotationspb.HttpRule_Post{
-				Post: "/echoMethod",
-			},
-		},
-		{
 			Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.echoPUT",
 			Pattern: &annotationspb.HttpRule_Put{
 				Put: "/echoMethod",
@@ -109,6 +97,7 @@ func TestServiceControlAllHTTPMethods(t *testing.T) {
 					ApiKeyState:                  "VERIFIED",
 					ApiMethod:                    "1.echo_api_endpoints_cloudesf_testing_cloud_goog.echoGET",
 					ApiName:                      "1.echo_api_endpoints_cloudesf_testing_cloud_goog",
+					ApiVersion:                   "1.0.0",
 					ProducerProjectID:            "producer-project",
 					ConsumerProjectID:            "123456",
 					FrontendProtocol:             "http",
@@ -145,6 +134,7 @@ func TestServiceControlAllHTTPMethods(t *testing.T) {
 					ApiKeyState:                  "VERIFIED",
 					ApiMethod:                    "1.echo_api_endpoints_cloudesf_testing_cloud_goog.echoPOST",
 					ApiName:                      "1.echo_api_endpoints_cloudesf_testing_cloud_goog",
+					ApiVersion:                   "1.0.0",
 					ProducerProjectID:            "producer-project",
 					ConsumerProjectID:            "123456",
 					FrontendProtocol:             "http",
@@ -181,6 +171,7 @@ func TestServiceControlAllHTTPMethods(t *testing.T) {
 					ApiKeyState:                  "VERIFIED",
 					ApiMethod:                    "1.echo_api_endpoints_cloudesf_testing_cloud_goog.echoPUT",
 					ApiName:                      "1.echo_api_endpoints_cloudesf_testing_cloud_goog",
+					ApiVersion:                   "1.0.0",
 					ProducerProjectID:            "producer-project",
 					ConsumerProjectID:            "123456",
 					FrontendProtocol:             "http",
@@ -217,6 +208,7 @@ func TestServiceControlAllHTTPMethods(t *testing.T) {
 					ApiKeyState:                  "VERIFIED",
 					ApiMethod:                    "1.echo_api_endpoints_cloudesf_testing_cloud_goog.echoPATCH",
 					ApiName:                      "1.echo_api_endpoints_cloudesf_testing_cloud_goog",
+					ApiVersion:                   "1.0.0",
 					ProducerProjectID:            "producer-project",
 					ConsumerProjectID:            "123456",
 					FrontendProtocol:             "http",
@@ -252,6 +244,7 @@ func TestServiceControlAllHTTPMethods(t *testing.T) {
 					ApiKeyState:                  "VERIFIED",
 					ApiMethod:                    "1.echo_api_endpoints_cloudesf_testing_cloud_goog.echoDELETE",
 					ApiName:                      "1.echo_api_endpoints_cloudesf_testing_cloud_goog",
+					ApiVersion:                   "1.0.0",
 					ProducerProjectID:            "producer-project",
 					ConsumerProjectID:            "123456",
 					FrontendProtocol:             "http",

--- a/tests/integration_test/service_control_http_path_test.go
+++ b/tests/integration_test/service_control_http_path_test.go
@@ -67,6 +67,7 @@ func TestServiceControlAllHTTPPath(t *testing.T) {
 					URL:               "/",
 					ApiMethod:         "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Root",
 					ApiKeyState:       "NOT CHECKED",
+					ApiVersion:        "1.0.0",
 					ProducerProjectID: "producer-project",
 					FrontendProtocol:  "http",
 					HttpMethod:        "GET",

--- a/tests/integration_test/service_control_log_test.go
+++ b/tests/integration_test/service_control_log_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
 
 	bsClient "github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/bookstore_grpc/client"
-	annotationspb "google.golang.org/genproto/googleapis/api/annotations"
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
 )
 
@@ -41,14 +40,6 @@ func TestServiceControlLogHeaders(t *testing.T) {
 		"--rollout_strategy=fixed", "--suppress_envoy_headers", "--log_request_headers=Fake-Header-Key0,Fake-Header-Key1,Fake-Header-Key2,Non-Existing-Header-Key", "--log_response_headers=Echo-Fake-Header-Key0,Echo-Fake-Header-Key1,Echo-Fake-Header-Key2,Non-Existing-Header-Key"}
 
 	s := env.NewTestEnv(platform.TestServiceControlLogHeaders, platform.EchoSidecar)
-	s.AppendHttpRules([]*annotationspb.HttpRule{
-		{
-			Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Simpleget",
-			Pattern: &annotationspb.HttpRule_Get{
-				Get: "/simpleget",
-			},
-		},
-	})
 
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {

--- a/tests/integration_test/service_control_response_code_test.go
+++ b/tests/integration_test/service_control_response_code_test.go
@@ -24,9 +24,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
-
-	annotationspb "google.golang.org/genproto/googleapis/api/annotations"
-	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
 )
 
 func TestServiceControlReportResponseCode(t *testing.T) {
@@ -38,38 +35,6 @@ func TestServiceControlReportResponseCode(t *testing.T) {
 		"--rollout_strategy=fixed"}
 
 	s := env.NewTestEnv(platform.TestServiceControlReportResponseCode, platform.EchoSidecar)
-	s.AppendHttpRules([]*annotationspb.HttpRule{
-		{
-			Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.SimplegetNotModified",
-			Pattern: &annotationspb.HttpRule_Get{
-				Get: "/simpleget/304",
-			},
-		},
-		{
-			Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.SimplegetUnauthorized",
-			Pattern: &annotationspb.HttpRule_Get{
-				Get: "/simpleget/401",
-			},
-		},
-		{
-			Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.SimplegetForbidden",
-			Pattern: &annotationspb.HttpRule_Get{
-				Get: "/simpleget/403",
-			},
-		},
-	})
-	s.AppendUsageRules(
-		[]*confpb.UsageRule{
-			{
-				Selector:               "1.echo_api_endpoints_cloudesf_testing_cloud_goog.SimplegetNotModified",
-				AllowUnregisteredCalls: true,
-			},
-			{
-				Selector:               "1.echo_api_endpoints_cloudesf_testing_cloud_goog.SimplegetForbidden",
-				AllowUnregisteredCalls: true,
-			},
-		})
-
 	defer s.TearDown(t)
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
@@ -85,7 +50,6 @@ func TestServiceControlReportResponseCode(t *testing.T) {
 		wantScRequests        []interface{}
 		wantGetScRequestError error
 	}{
-		// TODO(jcwang): add test cases for 304 and 403 to validate status in Check request
 		{
 			desc:          "succeed which has 304 response, no Jwt required, service control sends report request only with status code 304.",
 			url:           fmt.Sprintf("http://localhost:%v%v", s.Ports().ListenerPort, "/simpleget/304"),
@@ -98,6 +62,7 @@ func TestServiceControlReportResponseCode(t *testing.T) {
 					URL:               "/simpleget/304",
 					ApiMethod:         "1.echo_api_endpoints_cloudesf_testing_cloud_goog.SimplegetNotModified",
 					ApiName:           "1.echo_api_endpoints_cloudesf_testing_cloud_goog",
+					ApiVersion:        "1.0.0",
 					ApiKeyState:       "NOT CHECKED",
 					ProducerProjectID: "producer-project",
 					FrontendProtocol:  "http",
@@ -122,6 +87,7 @@ func TestServiceControlReportResponseCode(t *testing.T) {
 					URL:               "/simpleget/403",
 					ApiMethod:         "1.echo_api_endpoints_cloudesf_testing_cloud_goog.SimplegetForbidden",
 					ApiName:           "1.echo_api_endpoints_cloudesf_testing_cloud_goog",
+					ApiVersion:        "1.0.0",
 					ApiKeyState:       "NOT CHECKED",
 					ProducerProjectID: "producer-project",
 					FrontendProtocol:  "http",
@@ -146,6 +112,7 @@ func TestServiceControlReportResponseCode(t *testing.T) {
 					URL:                "/simpleget/401",
 					ApiMethod:          "1.echo_api_endpoints_cloudesf_testing_cloud_goog.SimplegetUnauthorized",
 					ApiName:            "1.echo_api_endpoints_cloudesf_testing_cloud_goog",
+					ApiVersion:         "1.0.0",
 					ApiKeyState:        "NOT CHECKED",
 					ProducerProjectID:  "producer-project",
 					FrontendProtocol:   "http",

--- a/tests/integration_test/transport_security_test.go
+++ b/tests/integration_test/transport_security_test.go
@@ -27,7 +27,6 @@ import (
 
 	bsclient "github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/bookstore_grpc/client"
 	comp "github.com/GoogleCloudPlatform/esp-v2/tests/env/components"
-	annotationspb "google.golang.org/genproto/googleapis/api/annotations"
 )
 
 func TestServiceManagementWithTLS(t *testing.T) {
@@ -174,14 +173,6 @@ func TestHttpsClients(t *testing.T) {
 
 	s := env.NewTestEnv(platform.TestHttpsClients, platform.EchoSidecar)
 	defer s.TearDown(t)
-	s.AppendHttpRules([]*annotationspb.HttpRule{
-		{
-			Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Simpleget",
-			Pattern: &annotationspb.HttpRule_Get{
-				Get: "/simpleget",
-			},
-		},
-	})
 
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
@@ -248,14 +239,6 @@ func TestHSTS(t *testing.T) {
 
 	s := env.NewTestEnv(platform.TestHSTS, platform.EchoSidecar)
 	defer s.TearDown(t)
-	s.AppendHttpRules([]*annotationspb.HttpRule{
-		{
-			Selector: "1.echo_api_endpoints_cloudesf_testing_cloud_goog.Simpleget",
-			Pattern: &annotationspb.HttpRule_Get{
-				Get: "/simpleget",
-			},
-		},
-	})
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)
 	}


### PR DESCRIPTION
Normalizes service configs to unblock #454. This ensures most of the commonly-duplicated methods are in the service config (instead of appended the config for every integration test). There is no behavior change in the tests.