### PR TITLE
b/176912395: Automatically configure stream idle timeouts

### DIFF
--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -591,27 +591,6 @@ environment variable or by passing "-k" flag to this script.
         Otherwise use ignored_query_parameters. Defaults to false.
         ''')
 
-    parser.add_argument(
-        '--stream_idle_timeout', action=None,
-        help='''
-        The amount of time client connections can exist without any activity.
-        
-        For non-streaming HTTP traffic, prefer to set `deadline` in the service
-        config to override this global value on a per-route basis. 
-        A large deadline will ensure the stream idle timeout never occurs for a
-        request on that route.
-        
-        For streaming gRPC traffic, prefer to set this flag to a higher value to
-        ensure ESPv2 does not terminate an idle stream while maintaining a short
-        deadline for each request in the stream.
-        
-        Defaults to 5 minutes (5m).
-        Specify the value as a duration. Examples: 30s, 2m, 1h, etc.
-        
-        ESPv2 will not honor small values for this flag, such as values under
-        the default deadline of 15s.
-        ''')
-
     # Start Deprecated Flags Section
 
     parser.add_argument(
@@ -1004,10 +983,6 @@ def gen_proxy_config(args):
 
     if args.transcoding_ignore_unknown_query_parameters:
         proxy_conf.append("--transcoding_ignore_unknown_query_parameters")
-
-    if args.stream_idle_timeout:
-        proxy_conf.extend(["--stream_idle_timeout",
-                           args.stream_idle_timeout])
 
     if args.on_serverless:
         proxy_conf.extend([

--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -591,6 +591,27 @@ environment variable or by passing "-k" flag to this script.
         Otherwise use ignored_query_parameters. Defaults to false.
         ''')
 
+    parser.add_argument(
+        '--stream_idle_timeout', action=None,
+        help='''
+        The amount of time client connections can exist without any activity.
+        
+        For non-streaming HTTP traffic, prefer to set `deadline` in the service
+        config to override this global value on a per-route basis. 
+        A large deadline will ensure the stream idle timeout never occurs for a
+        request on that route.
+        
+        For streaming gRPC traffic, prefer to set this flag to a higher value to
+        ensure ESPv2 does not terminate an idle stream while maintaining a short
+        deadline for each request in the stream.
+        
+        Defaults to 5 minutes (5m).
+        Specify the value as a duration. Examples: 30s, 2m, 1h, etc.
+        
+        ESPv2 will not honor small values for this flag, such as values under
+        the default deadline of 15s.
+        ''')
+
     # Start Deprecated Flags Section
 
     parser.add_argument(
@@ -983,6 +1004,10 @@ def gen_proxy_config(args):
 
     if args.transcoding_ignore_unknown_query_parameters:
         proxy_conf.append("--transcoding_ignore_unknown_query_parameters")
+
+    if args.stream_idle_timeout:
+        proxy_conf.extend(["--stream_idle_timeout",
+                           args.stream_idle_timeout])
 
     if args.on_serverless:
         proxy_conf.extend([

--- a/examples/auth/envoy_config.json
+++ b/examples/auth/envoy_config.json
@@ -330,6 +330,7 @@
                             },
                             "route": {
                               "cluster": "backend-cluster-examples-auth.endpoints.cloudesf-testing.cloud.goog_local",
+                              "idleTimeout": "300s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -362,6 +363,7 @@
                             },
                             "route": {
                               "cluster": "backend-cluster-examples-auth.endpoints.cloudesf-testing.cloud.goog_local",
+                              "idleTimeout": "300s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -394,6 +396,7 @@
                             },
                             "route": {
                               "cluster": "backend-cluster-examples-auth.endpoints.cloudesf-testing.cloud.goog_local",
+                              "idleTimeout": "300s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -426,6 +429,7 @@
                             },
                             "route": {
                               "cluster": "backend-cluster-examples-auth.endpoints.cloudesf-testing.cloud.goog_local",
+                              "idleTimeout": "300s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"

--- a/examples/dynamic_routing/envoy_config.json
+++ b/examples/dynamic_routing/envoy_config.json
@@ -268,6 +268,7 @@
                             "route": {
                               "cluster": "backend-cluster-http-bookstore-abc123456-uc.a.run.app:443",
                               "hostRewriteLiteral": "http-bookstore-abc123456-uc.a.run.app",
+                              "idleTimeout": "300s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -305,6 +306,7 @@
                             "route": {
                               "cluster": "backend-cluster-http-bookstore-abc123456-uc.a.run.app:443",
                               "hostRewriteLiteral": "http-bookstore-abc123456-uc.a.run.app",
+                              "idleTimeout": "300s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -342,6 +344,7 @@
                             "route": {
                               "cluster": "backend-cluster-http-bookstore-edf123456-uc.a.run.app:443",
                               "hostRewriteLiteral": "http-bookstore-edf123456-uc.a.run.app",
+                              "idleTimeout": "300s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -377,6 +380,7 @@
                             "route": {
                               "cluster": "backend-cluster-http-bookstore-edf123456-uc.a.run.app:443",
                               "hostRewriteLiteral": "http-bookstore-edf123456-uc.a.run.app",
+                              "idleTimeout": "300s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"

--- a/examples/grpc_dynamic_routing/envoy_config.json
+++ b/examples/grpc_dynamic_routing/envoy_config.json
@@ -908,7 +908,7 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
-                              "idleTimeout": "400s",
+                              "idleTimeout": "401s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -942,7 +942,7 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
-                              "idleTimeout": "400s",
+                              "idleTimeout": "401s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -976,7 +976,7 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
-                              "idleTimeout": "400s",
+                              "idleTimeout": "401s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -1010,7 +1010,7 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
-                              "idleTimeout": "400s",
+                              "idleTimeout": "401s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -1044,7 +1044,7 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
-                              "idleTimeout": "400s",
+                              "idleTimeout": "401s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -1082,7 +1082,7 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
-                              "idleTimeout": "400s",
+                              "idleTimeout": "401s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -1120,7 +1120,7 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
-                              "idleTimeout": "400s",
+                              "idleTimeout": "401s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -1154,7 +1154,7 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
-                              "idleTimeout": "400s",
+                              "idleTimeout": "401s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -1188,7 +1188,7 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
-                              "idleTimeout": "400s",
+                              "idleTimeout": "401s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -1222,7 +1222,7 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
-                              "idleTimeout": "400s",
+                              "idleTimeout": "401s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -1256,7 +1256,7 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
-                              "idleTimeout": "400s",
+                              "idleTimeout": "401s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -1290,7 +1290,7 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
-                              "idleTimeout": "400s",
+                              "idleTimeout": "401s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -1324,7 +1324,7 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
-                              "idleTimeout": "400s",
+                              "idleTimeout": "401s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -1362,7 +1362,7 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
-                              "idleTimeout": "400s",
+                              "idleTimeout": "401s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"

--- a/examples/grpc_dynamic_routing/envoy_config.json
+++ b/examples/grpc_dynamic_routing/envoy_config.json
@@ -908,11 +908,12 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
+                              "idleTimeout": "400s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
                               },
-                              "timeout": "300s"
+                              "timeout": "400s"
                             },
                             "typedPerFilterConfig": {
                               "com.google.espv2.filters.http.backend_auth": {
@@ -941,11 +942,12 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
+                              "idleTimeout": "400s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
                               },
-                              "timeout": "300s"
+                              "timeout": "400s"
                             },
                             "typedPerFilterConfig": {
                               "com.google.espv2.filters.http.backend_auth": {
@@ -974,11 +976,12 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
+                              "idleTimeout": "400s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
                               },
-                              "timeout": "300s"
+                              "timeout": "400s"
                             },
                             "typedPerFilterConfig": {
                               "com.google.espv2.filters.http.backend_auth": {
@@ -1007,11 +1010,12 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
+                              "idleTimeout": "400s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
                               },
-                              "timeout": "300s"
+                              "timeout": "400s"
                             },
                             "typedPerFilterConfig": {
                               "com.google.espv2.filters.http.backend_auth": {
@@ -1040,6 +1044,7 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
+                              "idleTimeout": "400s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -1077,6 +1082,7 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
+                              "idleTimeout": "400s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -1114,6 +1120,7 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
+                              "idleTimeout": "400s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -1147,6 +1154,7 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
+                              "idleTimeout": "400s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -1180,11 +1188,12 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
+                              "idleTimeout": "400s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
                               },
-                              "timeout": "300s"
+                              "timeout": "400s"
                             },
                             "typedPerFilterConfig": {
                               "com.google.espv2.filters.http.backend_auth": {
@@ -1213,11 +1222,12 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
+                              "idleTimeout": "400s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
                               },
-                              "timeout": "300s"
+                              "timeout": "400s"
                             },
                             "typedPerFilterConfig": {
                               "com.google.espv2.filters.http.backend_auth": {
@@ -1246,11 +1256,12 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
+                              "idleTimeout": "400s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
                               },
-                              "timeout": "300s"
+                              "timeout": "400s"
                             },
                             "typedPerFilterConfig": {
                               "com.google.espv2.filters.http.backend_auth": {
@@ -1279,11 +1290,12 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
+                              "idleTimeout": "400s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
                               },
-                              "timeout": "300s"
+                              "timeout": "400s"
                             },
                             "typedPerFilterConfig": {
                               "com.google.espv2.filters.http.backend_auth": {
@@ -1312,6 +1324,7 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
+                              "idleTimeout": "400s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -1349,6 +1362,7 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
+                              "idleTimeout": "400s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"

--- a/examples/grpc_dynamic_routing/envoy_config.json
+++ b/examples/grpc_dynamic_routing/envoy_config.json
@@ -1044,7 +1044,7 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
-                              "idleTimeout": "401s",
+                              "idleTimeout": "400s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -1082,7 +1082,7 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
-                              "idleTimeout": "401s",
+                              "idleTimeout": "400s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -1120,7 +1120,7 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
-                              "idleTimeout": "401s",
+                              "idleTimeout": "400s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -1154,7 +1154,7 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
-                              "idleTimeout": "401s",
+                              "idleTimeout": "400s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -1324,7 +1324,7 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
-                              "idleTimeout": "401s",
+                              "idleTimeout": "400s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -1362,7 +1362,7 @@
                             "route": {
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
-                              "idleTimeout": "401s",
+                              "idleTimeout": "400s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"

--- a/examples/grpc_dynamic_routing/grpc-test.yaml
+++ b/examples/grpc_dynamic_routing/grpc-test.yaml
@@ -36,4 +36,4 @@ backend:
     - selector: "*"
       address: "grpcs://grpc-echo-oxouww7xzq-uc.a.run.app"
       jwt_audience: "https://grpc-echo-oxouww7xzq-uc.a.run.app"
-      deadline: 300
+      deadline: 400

--- a/examples/grpc_dynamic_routing/service_config_generated.json
+++ b/examples/grpc_dynamic_routing/service_config_generated.json
@@ -88,25 +88,25 @@
     "rules": [
       {
         "address": "grpcs://grpc-echo-oxouww7xzq-uc.a.run.app",
-        "deadline": 300,
+        "deadline": 400,
         "jwtAudience": "https://grpc-echo-oxouww7xzq-uc.a.run.app",
         "selector": "test.grpc.Test.Echo"
       },
       {
         "address": "grpcs://grpc-echo-oxouww7xzq-uc.a.run.app",
-        "deadline": 300,
+        "deadline": 400,
         "jwtAudience": "https://grpc-echo-oxouww7xzq-uc.a.run.app",
         "selector": "test.grpc.Test.EchoStream"
       },
       {
         "address": "grpcs://grpc-echo-oxouww7xzq-uc.a.run.app",
-        "deadline": 300,
+        "deadline": 400,
         "jwtAudience": "https://grpc-echo-oxouww7xzq-uc.a.run.app",
         "selector": "test.grpc.Test.Cork"
       },
       {
         "address": "grpcs://grpc-echo-oxouww7xzq-uc.a.run.app",
-        "deadline": 300,
+        "deadline": 400,
         "jwtAudience": "https://grpc-echo-oxouww7xzq-uc.a.run.app",
         "selector": "test.grpc.Test.EchoReport"
       }

--- a/examples/service_control/envoy_config.json
+++ b/examples/service_control/envoy_config.json
@@ -748,6 +748,7 @@
                             },
                             "route": {
                               "cluster": "backend-cluster-examples-service-control.endpoints.cloudesf-testing.cloud.goog_local",
+                              "idleTimeout": "300s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -776,6 +777,7 @@
                             },
                             "route": {
                               "cluster": "backend-cluster-examples-service-control.endpoints.cloudesf-testing.cloud.goog_local",
+                              "idleTimeout": "300s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -804,6 +806,7 @@
                             },
                             "route": {
                               "cluster": "backend-cluster-examples-service-control.endpoints.cloudesf-testing.cloud.goog_local",
+                              "idleTimeout": "300s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -832,6 +835,7 @@
                             },
                             "route": {
                               "cluster": "backend-cluster-examples-service-control.endpoints.cloudesf-testing.cloud.goog_local",
+                              "idleTimeout": "300s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"

--- a/examples/testdata/route_match/envoy_config.json
+++ b/examples/testdata/route_match/envoy_config.json
@@ -268,6 +268,7 @@
                             "route": {
                               "cluster": "backend-cluster-http-bookstore-edf123456-uc.a.run.app:443",
                               "hostRewriteLiteral": "http-bookstore-edf123456-uc.a.run.app",
+                              "idleTimeout": "300s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -311,6 +312,7 @@
                             "route": {
                               "cluster": "backend-cluster-http-bookstore-edf123456-uc.a.run.app:443",
                               "hostRewriteLiteral": "http-bookstore-edf123456-uc.a.run.app",
+                              "idleTimeout": "300s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -354,6 +356,7 @@
                             "route": {
                               "cluster": "backend-cluster-http-bookstore-abc9876-uc.a.run.app:443",
                               "hostRewriteLiteral": "http-bookstore-abc9876-uc.a.run.app",
+                              "idleTimeout": "300s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -390,6 +393,7 @@
                             "route": {
                               "cluster": "backend-cluster-http-bookstore-abc9876-uc.a.run.app:443",
                               "hostRewriteLiteral": "http-bookstore-abc9876-uc.a.run.app",
+                              "idleTimeout": "300s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -426,6 +430,7 @@
                             "route": {
                               "cluster": "backend-cluster-http-bookstore-abc9876-uc.a.run.app:443",
                               "hostRewriteLiteral": "http-bookstore-abc9876-uc.a.run.app",
+                              "idleTimeout": "300s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -462,6 +467,7 @@
                             "route": {
                               "cluster": "backend-cluster-http-bookstore-abc9876-uc.a.run.app:443",
                               "hostRewriteLiteral": "http-bookstore-abc9876-uc.a.run.app",
+                              "idleTimeout": "300s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -498,6 +504,7 @@
                             "route": {
                               "cluster": "backend-cluster-http-bookstore-abc9876-uc.a.run.app:443",
                               "hostRewriteLiteral": "http-bookstore-abc9876-uc.a.run.app",
+                              "idleTimeout": "300s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -534,6 +541,7 @@
                             "route": {
                               "cluster": "backend-cluster-http-bookstore-abc9876-uc.a.run.app:443",
                               "hostRewriteLiteral": "http-bookstore-abc9876-uc.a.run.app",
+                              "idleTimeout": "300s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"

--- a/examples/testdata/sidecar_backend/envoy_config.json
+++ b/examples/testdata/sidecar_backend/envoy_config.json
@@ -169,6 +169,7 @@
                             },
                             "route": {
                               "cluster": "backend-cluster-examples-sidecar-backend.endpoints.cloudesf-testing.cloud.goog_local",
+                              "idleTimeout": "300s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -197,6 +198,7 @@
                             },
                             "route": {
                               "cluster": "backend-cluster-examples-sidecar-backend.endpoints.cloudesf-testing.cloud.goog_local",
+                              "idleTimeout": "300s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -225,6 +227,7 @@
                             },
                             "route": {
                               "cluster": "backend-cluster-examples-sidecar-backend.endpoints.cloudesf-testing.cloud.goog_local",
+                              "idleTimeout": "300s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -253,6 +256,7 @@
                             },
                             "route": {
                               "cluster": "backend-cluster-examples-sidecar-backend.endpoints.cloudesf-testing.cloud.goog_local",
+                              "idleTimeout": "300s",
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"

--- a/src/go/configgenerator/route_generator.go
+++ b/src/go/configgenerator/route_generator.go
@@ -274,16 +274,6 @@ func makeRouteTable(serviceInfo *configinfo.ServiceInfo) ([]*routepb.Route, []*r
 			HttpMethod:  httpPatternMethod.HttpMethod,
 		}
 
-		// Response timeouts are not compatible with streaming methods (documented in Envoy).
-		// If this method is non-unary gRPC, explicitly set 0s to disable the timeout.
-		// This even applies for routes with gRPC-JSON transcoding where only the upstream is streaming.
-		var respTimeout time.Duration
-		if method.IsStreaming {
-			respTimeout = 0 * time.Second
-		} else {
-			respTimeout = method.BackendInfo.Deadline
-		}
-
 		// The `methodNotAllowedRouteMatchers` are the route matches covers all the defined uri templates
 		// but no specific methods. As all the defined requests are matched by `routeMatchers`, the rest
 		// matched by `methodNotAllowedRouteMatchers` fall in the category of `405 Method Not Allowed`.
@@ -299,7 +289,7 @@ func makeRouteTable(serviceInfo *configinfo.ServiceInfo) ([]*routepb.Route, []*r
 		}
 
 		for _, routeMatcher := range routeMatchers {
-			r := makeRoute(routeMatcher, method, respTimeout)
+			r := makeRoute(routeMatcher, method)
 
 			r.TypedPerFilterConfig, err = makePerRouteFilterConfig(operation, method, httpRule)
 			if err != nil {
@@ -336,7 +326,17 @@ func makeRouteTable(serviceInfo *configinfo.ServiceInfo) ([]*routepb.Route, []*r
 	return backendRoutes, methodNotAllowedRoutes, nil
 }
 
-func makeRoute(routeMatcher *routepb.RouteMatch, method *configinfo.MethodInfo, respTimeout time.Duration) *routepb.Route {
+func makeRoute(routeMatcher *routepb.RouteMatch, method *configinfo.MethodInfo) *routepb.Route {
+	// Response timeouts are not compatible with streaming methods (documented in Envoy).
+	// If this method is non-unary gRPC, explicitly set 0s to disable the timeout.
+	// This even applies for routes with gRPC-JSON transcoding where only the upstream is streaming.
+	var respTimeout time.Duration
+	if method.IsStreaming {
+		respTimeout = 0 * time.Second
+	} else {
+		respTimeout = method.BackendInfo.Deadline
+	}
+
 	return &routepb.Route{
 		Match: routeMatcher,
 		Action: &routepb.Route_Route{
@@ -344,7 +344,8 @@ func makeRoute(routeMatcher *routepb.RouteMatch, method *configinfo.MethodInfo, 
 				ClusterSpecifier: &routepb.RouteAction_Cluster{
 					Cluster: method.BackendInfo.ClusterName,
 				},
-				Timeout: ptypes.DurationProto(respTimeout),
+				Timeout:     ptypes.DurationProto(respTimeout),
+				IdleTimeout: ptypes.DurationProto(method.BackendInfo.IdleTimeout),
 				RetryPolicy: &routepb.RetryPolicy{
 					RetryOn: method.BackendInfo.RetryOns,
 					NumRetries: &wrapperspb.UInt32Value{

--- a/src/go/configgenerator/route_generator_test.go
+++ b/src/go/configgenerator/route_generator_test.go
@@ -99,6 +99,7 @@ func TestMakeRouteConfig(t *testing.T) {
           ],
           "route": {
             "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "idleTimeout": "300s",
             "retryPolicy": {
               "numRetries": 1,
               "retryOn": "reset,connect-failure,refused-stream"
@@ -135,6 +136,7 @@ func TestMakeRouteConfig(t *testing.T) {
           ],
           "route": {
             "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "idleTimeout": "300s",
             "retryPolicy": {
               "numRetries": 1,
               "retryOn": "reset,connect-failure,refused-stream"
@@ -261,6 +263,7 @@ func TestMakeRouteConfig(t *testing.T) {
           ],
           "route": {
             "cluster": "backend-cluster-testapipb.com:443",
+            "idleTimeout": "300s",
             "hostRewriteLiteral": "testapipb.com",
             "retryPolicy": {
               "numRetries": 1,
@@ -308,6 +311,7 @@ func TestMakeRouteConfig(t *testing.T) {
           ],
           "route": {
             "cluster": "backend-cluster-testapipb.com:443",
+            "idleTimeout": "300s",
             "hostRewriteLiteral": "testapipb.com",
             "retryPolicy": {
               "numRetries": 1,
@@ -437,6 +441,7 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-testapipb.com:443",
+            "idleTimeout": "300s",
             "hostRewriteLiteral": "testapipb.com",
             "retryPolicy": {
               "numRetries": 1,
@@ -562,6 +567,7 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-testapipb.com:443",
+            "idleTimeout": "300s",
             "hostRewriteLiteral": "testapipb.com",
             "retryPolicy": {
               "numRetries": 1,
@@ -602,6 +608,7 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-testapipb.com:443",
+            "idleTimeout": "300s",
             "hostRewriteLiteral": "testapipb.com",
             "retryPolicy": {
               "numRetries": 1,
@@ -742,6 +749,7 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-testapipb.com:443",
+            "idleTimeout": "300s",
             "hostRewriteLiteral": "testapipb.com",
             "retryPolicy": {
               "numRetries": 1,
@@ -779,6 +787,7 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-testapipb.com:443",
+            "idleTimeout": "300s",
             "hostRewriteLiteral": "testapipb.com",
             "retryPolicy": {
               "numRetries": 1,
@@ -816,6 +825,7 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-testapipb.com:443",
+            "idleTimeout": "300s",
             "hostRewriteLiteral": "testapipb.com",
             "retryPolicy": {
               "numRetries": 1,
@@ -855,6 +865,7 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-testapipb.com:443",
+            "idleTimeout": "300s",
             "hostRewriteLiteral": "testapipb.com",
             "retryPolicy": {
               "numRetries": 1,
@@ -1039,6 +1050,7 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-testapipb.com:443",
+            "idleTimeout": "300s",
             "hostRewriteLiteral": "testapipb.com",
             "retryPolicy": {
               "numRetries": 1,
@@ -1076,6 +1088,7 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-testapipb.com:443",
+            "idleTimeout": "300s",
             "hostRewriteLiteral": "testapipb.com",
             "retryPolicy": {
               "numRetries": 1,
@@ -1113,6 +1126,7 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-testapipb.com:443",
+            "idleTimeout": "300s",
             "hostRewriteLiteral": "testapipb.com",
             "retryPolicy": {
               "numRetries": 1,
@@ -1150,6 +1164,7 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-testapipb.com:443",
+            "idleTimeout": "300s",
             "hostRewriteLiteral": "testapipb.com",
             "retryPolicy": {
               "numRetries": 1,
@@ -1190,6 +1205,7 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-testapipb.com:443",
+            "idleTimeout": "300s",
             "hostRewriteLiteral": "testapipb.com",
             "retryPolicy": {
               "numRetries": 1,
@@ -1233,6 +1249,7 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-testapipb.com:443",
+            "idleTimeout": "300s",
             "hostRewriteLiteral": "testapipb.com",
             "retryPolicy": {
               "numRetries": 1,
@@ -1396,6 +1413,7 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-testapipb.com:443",
+            "idleTimeout": "300s",
             "hostRewriteLiteral": "testapipb.com",
             "retryPolicy": {
               "numRetries": 1,
@@ -1429,6 +1447,7 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-testapipb.com:443",
+            "idleTimeout": "300s",
             "hostRewriteLiteral": "testapipb.com",
             "retryPolicy": {
               "numRetries": 1,
@@ -1462,6 +1481,7 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-testapipb.com:443",
+            "idleTimeout": "300s",
             "hostRewriteLiteral": "testapipb.com",
             "retryPolicy": {
               "numRetries": 1,
@@ -1495,6 +1515,7 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-testapipb.com:443",
+            "idleTimeout": "300s",
             "hostRewriteLiteral": "testapipb.com",
             "retryPolicy": {
               "numRetries": 1,
@@ -1662,6 +1683,7 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-testapipb.com:443",
+            "idleTimeout": "300s",
             "hostRewriteLiteral": "testapipb.com",
             "retryPolicy": {
               "numRetries": 1,
@@ -1701,6 +1723,7 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-testapipb.com:443",
+            "idleTimeout": "300s",
             "hostRewriteLiteral": "testapipb.com",
             "retryPolicy": {
               "numRetries": 1,
@@ -1740,6 +1763,7 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-testapipb.com:443",
+            "idleTimeout": "300s",
             "hostRewriteLiteral": "testapipb.com",
             "retryPolicy": {
               "numRetries": 1,
@@ -1779,6 +1803,7 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-testapipb.com:443",
+            "idleTimeout": "300s",
             "hostRewriteLiteral": "testapipb.com",
             "retryPolicy": {
               "numRetries": 1,
@@ -1938,6 +1963,7 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-testapipb.com:443",
+            "idleTimeout": "300s",
             "hostRewriteLiteral": "testapipb.com",
             "retryPolicy": {
               "numRetries": 1,
@@ -2061,6 +2087,7 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-testapipb.com:443",
+            "idleTimeout": "300s",
             "hostRewriteLiteral": "testapipb.com",
             "retryPolicy": {
               "numRetries": 1,
@@ -2103,6 +2130,7 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-testapipb.com:443",
+            "idleTimeout": "300s",
             "hostRewriteLiteral": "testapipb.com",
             "retryPolicy": {
               "numRetries": 1,
@@ -2287,6 +2315,7 @@ func TestMakeRouteConfig(t *testing.T) {
           ],
           "route": {
             "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "idleTimeout": "300s",
             "retryPolicy": {
               "numRetries": 1,
               "retryOn": "reset,connect-failure,refused-stream"
@@ -2323,6 +2352,7 @@ func TestMakeRouteConfig(t *testing.T) {
           ],
           "route": {
             "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "idleTimeout": "300s",
             "retryPolicy": {
               "numRetries": 1,
               "retryOn": "reset,connect-failure,refused-stream"
@@ -2353,6 +2383,7 @@ func TestMakeRouteConfig(t *testing.T) {
           ],
           "route": {
             "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "idleTimeout": "300s",
             "retryPolicy": {
               "numRetries": 1,
               "retryOn": "reset,connect-failure,refused-stream"
@@ -2383,6 +2414,7 @@ func TestMakeRouteConfig(t *testing.T) {
           ],
           "route": {
             "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "idleTimeout": "300s",
             "retryPolicy": {
               "numRetries": 1,
               "retryOn": "reset,connect-failure,refused-stream"
@@ -2422,6 +2454,7 @@ func TestMakeRouteConfig(t *testing.T) {
           ],
           "route": {
             "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "idleTimeout": "300s",
             "retryPolicy": {
               "numRetries": 1,
               "retryOn": "reset,connect-failure,refused-stream"
@@ -2461,6 +2494,7 @@ func TestMakeRouteConfig(t *testing.T) {
           ],
           "route": {
             "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "idleTimeout": "300s",
             "retryPolicy": {
               "numRetries": 1,
               "retryOn": "reset,connect-failure,refused-stream"
@@ -2500,6 +2534,7 @@ func TestMakeRouteConfig(t *testing.T) {
           ],
           "route": {
             "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "idleTimeout": "300s",
             "retryPolicy": {
               "numRetries": 1,
               "retryOn": "reset,connect-failure,refused-stream"
@@ -2539,6 +2574,7 @@ func TestMakeRouteConfig(t *testing.T) {
           ],
           "route": {
             "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "idleTimeout": "300s",
             "retryPolicy": {
               "numRetries": 1,
               "retryOn": "reset,connect-failure,refused-stream"
@@ -2578,6 +2614,7 @@ func TestMakeRouteConfig(t *testing.T) {
           ],
           "route": {
             "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "idleTimeout": "300s",
             "retryPolicy": {
               "numRetries": 1,
               "retryOn": "reset,connect-failure,refused-stream"
@@ -2848,6 +2885,7 @@ func TestMakeFallbackRoute(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "idleTimeout": "300s",
             "retryPolicy": {
               "numRetries": 1,
               "retryOn": "reset,connect-failure,refused-stream"
@@ -2876,6 +2914,7 @@ func TestMakeFallbackRoute(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "idleTimeout": "300s",
             "retryPolicy": {
               "numRetries": 1,
               "retryOn": "reset,connect-failure,refused-stream"
@@ -2904,6 +2943,7 @@ func TestMakeFallbackRoute(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "idleTimeout": "300s",
             "retryPolicy": {
               "numRetries": 1,
               "retryOn": "reset,connect-failure,refused-stream"
@@ -2932,6 +2972,7 @@ func TestMakeFallbackRoute(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "idleTimeout": "300s",
             "retryPolicy": {
               "numRetries": 1,
               "retryOn": "reset,connect-failure,refused-stream"
@@ -3045,6 +3086,7 @@ func TestMakeFallbackRoute(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "idleTimeout": "300s",
             "retryPolicy": {
               "numRetries": 1,
               "retryOn": "reset,connect-failure,refused-stream"
@@ -3076,6 +3118,7 @@ func TestMakeFallbackRoute(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "idleTimeout": "300s",
             "retryPolicy": {
               "numRetries": 1,
               "retryOn": "reset,connect-failure,refused-stream"
@@ -3185,6 +3228,7 @@ func TestMakeFallbackRoute(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "idleTimeout": "300s",
             "retryPolicy": {
               "numRetries": 1,
               "retryOn": "reset,connect-failure,refused-stream"
@@ -3213,6 +3257,7 @@ func TestMakeFallbackRoute(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "idleTimeout": "300s",
             "retryPolicy": {
               "numRetries": 1,
               "retryOn": "reset,connect-failure,refused-stream"
@@ -3241,6 +3286,7 @@ func TestMakeFallbackRoute(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "idleTimeout": "300s",
             "retryPolicy": {
               "numRetries": 1,
               "retryOn": "reset,connect-failure,refused-stream"
@@ -3269,6 +3315,7 @@ func TestMakeFallbackRoute(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "idleTimeout": "300s",
             "retryPolicy": {
               "numRetries": 1,
               "retryOn": "reset,connect-failure,refused-stream"
@@ -3396,6 +3443,7 @@ func TestMakeFallbackRoute(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "idleTimeout": "300s",
             "retryPolicy": {
               "numRetries": 1,
               "retryOn": "reset,connect-failure,refused-stream"
@@ -3424,6 +3472,7 @@ func TestMakeFallbackRoute(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "idleTimeout": "300s",
             "retryPolicy": {
               "numRetries": 1,
               "retryOn": "reset,connect-failure,refused-stream"
@@ -3452,6 +3501,7 @@ func TestMakeFallbackRoute(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "idleTimeout": "300s",
             "retryPolicy": {
               "numRetries": 1,
               "retryOn": "reset,connect-failure,refused-stream"
@@ -3480,6 +3530,7 @@ func TestMakeFallbackRoute(t *testing.T) {
           },
           "route": {
             "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "idleTimeout": "300s",
             "retryPolicy": {
               "numRetries": 1,
               "retryOn": "reset,connect-failure,refused-stream"

--- a/src/go/configinfo/method_info.go
+++ b/src/go/configinfo/method_info.go
@@ -60,7 +60,8 @@ type backendInfo struct {
 	JwtAudience string
 
 	// Response timeout for the backend.
-	Deadline time.Duration
+	Deadline    time.Duration
+	IdleTimeout time.Duration
 
 	// Retry setting on the backend.
 	RetryOns string

--- a/src/go/configinfo/service_info.go
+++ b/src/go/configinfo/service_info.go
@@ -541,12 +541,12 @@ func (s *ServiceInfo) addBackendInfoToMethod(r *confpb.BackendRule, scheme strin
 	}
 
 	var deadline time.Duration
-	if r.Deadline <= 0 {
-		if r.Deadline < 0 {
-			glog.Warningf("Negative deadline of %v specified for method %v. "+
-				"Using default deadline %v instead.", r.Deadline, r.Selector, util.DefaultResponseDeadline)
-		}
-		// If no deadline specified by the user, explicitly use defaults.
+	if r.Deadline == 0 {
+		// If no deadline specified by the user, explicitly use default.
+		deadline = util.DefaultResponseDeadline
+	} else if r.Deadline < 0 {
+		glog.Warningf("Negative deadline of %v specified for method %v. "+
+			"Using default deadline %v instead.", r.Deadline, r.Selector, util.DefaultResponseDeadline)
 		deadline = util.DefaultResponseDeadline
 	} else {
 		// The backend deadline from the BackendRule is a float64 that represents seconds.

--- a/src/go/configinfo/service_info.go
+++ b/src/go/configinfo/service_info.go
@@ -611,11 +611,13 @@ func (s *ServiceInfo) processLocalBackendOperations() error {
 			continue
 		}
 
+		idleTimeout := util.MaxDuration(util.DefaultResponseDeadline, s.Options.StreamIdleTimeout)
+
 		// Associate the method with the local backend.
 		method.BackendInfo = &backendInfo{
 			ClusterName: s.LocalBackendCluster.ClusterName,
 			Deadline:    util.DefaultResponseDeadline,
-			IdleTimeout: s.Options.StreamIdleTimeout,
+			IdleTimeout: idleTimeout,
 			RetryOns:    s.Options.BackendRetryOns,
 			RetryNum:    s.Options.BackendRetryNum,
 		}

--- a/src/go/configinfo/service_info_test.go
+++ b/src/go/configinfo/service_info_test.go
@@ -1760,7 +1760,12 @@ func TestProcessBackendRuleForDeadline(t *testing.T) {
 			fakeServiceConfig: &confpb.Service{
 				Apis: []*apipb.Api{
 					{
-						Name: testApiName,
+						Name: "abc.com",
+						Methods: []*apipb.Method{
+							{
+								Name: "api",
+							},
+						},
 					},
 				},
 			},
@@ -1853,7 +1858,7 @@ func TestProcessBackendRuleForIdleTimeout(t *testing.T) {
 				},
 			},
 			wantedMethodIdleTimeout: map[string]time.Duration{
-				"abc.com.api": 10*time.Second + 500*time.Millisecond,
+				"abc.com.api": 10*time.Second + 500*time.Millisecond + time.Second,
 			},
 		},
 		{
@@ -1919,7 +1924,7 @@ func TestProcessBackendRuleForIdleTimeout(t *testing.T) {
 				},
 			},
 			wantedMethodIdleTimeout: map[string]time.Duration{
-				"abc.com.api": util.DefaultResponseDeadline,
+				"abc.com.api": util.DefaultResponseDeadline + time.Second,
 			},
 		},
 		{
@@ -1947,7 +1952,7 @@ func TestProcessBackendRuleForIdleTimeout(t *testing.T) {
 				},
 			},
 			wantedMethodIdleTimeout: map[string]time.Duration{
-				"abc.com.api": util.DefaultResponseDeadline,
+				"abc.com.api": util.DefaultResponseDeadline + time.Second,
 			},
 		},
 	}

--- a/src/go/configinfo/service_info_test.go
+++ b/src/go/configinfo/service_info_test.go
@@ -2035,6 +2035,35 @@ func TestProcessBackendRuleForIdleTimeout(t *testing.T) {
 				"abc.com.api": 10*time.Second + 500*time.Millisecond,
 			},
 		},
+		{
+			desc:              "Streaming methods with NO deadline specified use the default stream timeout.",
+			globalIdleTimeout: 25 * time.Second,
+			fakeServiceConfig: &confpb.Service{
+				Apis: []*apipb.Api{
+					{
+						Name: "abc.com",
+						Methods: []*apipb.Method{
+							{
+								Name:             "api",
+								RequestStreaming: true,
+							},
+						},
+					},
+				},
+				Backend: &confpb.Backend{
+					Rules: []*confpb.BackendRule{
+						{
+							Address:  "grpc://abc.com/api/",
+							Selector: "abc.com.api",
+							// Missing deadline
+						},
+					},
+				},
+			},
+			wantedMethodIdleTimeout: map[string]time.Duration{
+				"abc.com.api": 25 * time.Second,
+			},
+		},
 	}
 
 	for _, tc := range testData {

--- a/src/go/configinfo/service_info_test.go
+++ b/src/go/configinfo/service_info_test.go
@@ -1661,7 +1661,10 @@ func TestMethods(t *testing.T) {
 			}
 			for key, gotMethod := range serviceInfo.Methods {
 				wantMethod, ok := tc.wantMethods[key]
+
+				// Remove some items we have other specific tests for.
 				gotMethod.GeneratedCorsMethod = nil
+				gotMethod.BackendInfo.IdleTimeout = 0
 
 				if !ok {
 					t.Errorf("cannot find key: %v\n got methods : %+v\nwant methods: %+v", key, serviceInfo.Methods, tc.wantMethods)

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -46,6 +46,7 @@ var (
 
 	// Envoy specific configurations.
 	ClusterConnectTimeout = flag.Duration("cluster_connect_timeout", 20*time.Second, "cluster connect timeout in seconds")
+	StreamIdleTimeout     = flag.Duration("stream_idle_timeout", 5*time.Minute, "The amount of time client connections can exist without any activity. Set `deadline` in the service config to override this global value on a per-route basis.")
 
 	// Network related configurations.
 	BackendAddress       = flag.String("backend_address", "http://127.0.0.1:8082", `The application server URI to which ESPv2 proxies requests.`)
@@ -165,6 +166,7 @@ func EnvoyConfigOptionsFromFlags() options.ConfigGeneratorOptions {
 		CorsPreset:                              *CorsPreset,
 		BackendDnsLookupFamily:                  *BackendDnsLookupFamily,
 		ClusterConnectTimeout:                   *ClusterConnectTimeout,
+		StreamIdleTimeout:                       *StreamIdleTimeout,
 		ListenerAddress:                         *ListenerAddress,
 		ServiceManagementURL:                    *ServiceManagementURL,
 		ServiceControlURL:                       *ServiceControlURL,

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -46,8 +46,6 @@ var (
 
 	// Envoy specific configurations.
 	ClusterConnectTimeout = flag.Duration("cluster_connect_timeout", 20*time.Second, "cluster connect timeout in seconds")
-	StreamIdleTimeout     = flag.Duration("stream_idle_timeout", util.DefaultIdleTimeout, "The amount of time HTTP/2 streams can exist without any activity. "+
-		"Set `deadline` in the service config to override this global value on a per-route basis.")
 
 	// Network related configurations.
 	BackendAddress       = flag.String("backend_address", "http://127.0.0.1:8082", `The application server URI to which ESPv2 proxies requests.`)
@@ -127,9 +125,11 @@ var (
 
 	ComputePlatformOverride = flag.String("compute_platform_override", "", "the overridden platform where the proxy is running at")
 
-	// Flags for testing purpose.
+	// Flags for testing purpose. They are not exposed to the user via start_proxy.py
 	SkipJwtAuthnFilter       = flag.Bool("skip_jwt_authn_filter", false, "skip jwt authn filter, for test purpose")
 	SkipServiceControlFilter = flag.Bool("skip_service_control_filter", false, "skip service control filter, for test purpose")
+	StreamIdleTimeout        = flag.Duration("stream_idle_timeout_test_only", util.DefaultIdleTimeout, "The amount of time HTTP/2 streams can exist without any activity. "+
+		"Set `deadline` in the service config to override this global value on a per-route basis.")
 
 	TranscodingAlwaysPrintPrimitiveFields   = flag.Bool("transcoding_always_print_primitive_fields", false, "Whether to always print primitive fields for grpc-json transcoding")
 	TranscodingAlwaysPrintEnumsAsInts       = flag.Bool("transcoding_always_print_enums_as_ints", false, "Whether to always print enums as ints for grpc-json transcoding")

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -46,7 +46,8 @@ var (
 
 	// Envoy specific configurations.
 	ClusterConnectTimeout = flag.Duration("cluster_connect_timeout", 20*time.Second, "cluster connect timeout in seconds")
-	StreamIdleTimeout     = flag.Duration("stream_idle_timeout", util.DefaultIdleTimeout, "The amount of time client connections can exist without any activity. Set `deadline` in the service config to override this global value on a per-route basis.")
+	StreamIdleTimeout     = flag.Duration("stream_idle_timeout", util.DefaultIdleTimeout, "The amount of time client connections can exist without any activity. "+
+		"Set `deadline` in the service config to override this global value on a per-route basis.")
 
 	// Network related configurations.
 	BackendAddress       = flag.String("backend_address", "http://127.0.0.1:8082", `The application server URI to which ESPv2 proxies requests.`)

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -46,7 +46,7 @@ var (
 
 	// Envoy specific configurations.
 	ClusterConnectTimeout = flag.Duration("cluster_connect_timeout", 20*time.Second, "cluster connect timeout in seconds")
-	StreamIdleTimeout     = flag.Duration("stream_idle_timeout", util.DefaultIdleTimeout, "The amount of time client connections can exist without any activity. "+
+	StreamIdleTimeout     = flag.Duration("stream_idle_timeout", util.DefaultIdleTimeout, "The amount of time HTTP/2 streams can exist without any activity. "+
 		"Set `deadline` in the service config to override this global value on a per-route basis.")
 
 	// Network related configurations.

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -46,7 +46,7 @@ var (
 
 	// Envoy specific configurations.
 	ClusterConnectTimeout = flag.Duration("cluster_connect_timeout", 20*time.Second, "cluster connect timeout in seconds")
-	StreamIdleTimeout     = flag.Duration("stream_idle_timeout", 5*time.Minute, "The amount of time client connections can exist without any activity. Set `deadline` in the service config to override this global value on a per-route basis.")
+	StreamIdleTimeout     = flag.Duration("stream_idle_timeout", util.DefaultIdleTimeout, "The amount of time client connections can exist without any activity. Set `deadline` in the service config to override this global value on a per-route basis.")
 
 	// Network related configurations.
 	BackendAddress       = flag.String("backend_address", "http://127.0.0.1:8082", `The application server URI to which ESPv2 proxies requests.`)

--- a/src/go/configmanager/testdata/test_fetch_listeners.go
+++ b/src/go/configmanager/testdata/test_fetch_listeners.go
@@ -146,6 +146,7 @@ var (
                       },
                       "route": {
                         "cluster": "%s",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -174,6 +175,7 @@ var (
                       },
                       "route": {
                         "cluster": "%s",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -396,6 +398,7 @@ var (
                       },
                       "route": {
                         "cluster": "%s",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -428,6 +431,7 @@ var (
                       },
                       "route": {
                         "cluster": "%s",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -672,6 +676,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -704,6 +709,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -736,6 +742,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -768,6 +775,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -800,6 +808,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -832,6 +841,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -867,6 +877,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -1222,6 +1233,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -1250,6 +1262,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -1278,6 +1291,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -1310,6 +1324,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -1345,6 +1360,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -1376,6 +1392,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -1681,6 +1698,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -1709,6 +1727,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -1737,6 +1756,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -1765,6 +1785,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -1793,6 +1814,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -1821,6 +1843,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -1849,6 +1872,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -1877,6 +1901,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -2170,6 +2195,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -2202,6 +2228,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -2234,6 +2261,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -2262,6 +2290,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -2505,6 +2534,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -2533,6 +2563,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -2561,6 +2592,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -2589,6 +2621,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"

--- a/src/go/configmanager/testdata/test_fixed_mode_dynamic_routing.go
+++ b/src/go/configmanager/testdata/test_fixed_mode_dynamic_routing.go
@@ -311,6 +311,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-echo-api.endpoints.cloudesf-testing.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -339,6 +340,7 @@ var (
                       },
                       "route": {
                         "cluster": "backend-cluster-echo-api.endpoints.cloudesf-testing.cloud.goog_local",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -368,6 +370,7 @@ var (
                       "route": {
                         "cluster": "backend-cluster-us-central1-cloud-esf.cloudfunctions.net:443",
                         "hostRewriteLiteral": "us-central1-cloud-esf.cloudfunctions.net",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -405,6 +408,7 @@ var (
                       "route": {
                         "cluster": "backend-cluster-us-central1-cloud-esf.cloudfunctions.net:443",
                         "hostRewriteLiteral": "us-central1-cloud-esf.cloudfunctions.net",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -442,6 +446,7 @@ var (
                       "route": {
                         "cluster": "backend-cluster-pets.appspot.com:443",
                         "hostRewriteLiteral": "pets.appspot.com",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -479,6 +484,7 @@ var (
                       "route": {
                         "cluster": "backend-cluster-pets.appspot.com:443",
                         "hostRewriteLiteral": "pets.appspot.com",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -519,6 +525,7 @@ var (
                       "route": {
                         "cluster": "backend-cluster-pets.appspot.com:8008",
                         "hostRewriteLiteral": "pets.appspot.com",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -556,6 +563,7 @@ var (
                       "route": {
                         "cluster": "backend-cluster-pets.appspot.com:443",
                         "hostRewriteLiteral": "pets.appspot.com",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -593,6 +601,7 @@ var (
                       "route": {
                         "cluster": "backend-cluster-pets.appspot.com:443",
                         "hostRewriteLiteral": "pets.appspot.com",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -630,6 +639,7 @@ var (
                       "route": {
                         "cluster": "backend-cluster-us-west2-cloud-esf.cloudfunctions.net:443",
                         "hostRewriteLiteral": "us-west2-cloud-esf.cloudfunctions.net",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"
@@ -669,6 +679,7 @@ var (
                       "route": {
                         "cluster": "backend-cluster-us-west2-cloud-esf.cloudfunctions.net:443",
                         "hostRewriteLiteral": "us-west2-cloud-esf.cloudfunctions.net",
+                        "idleTimeout": "300s",
                         "retryPolicy": {
                           "numRetries": 1,
                           "retryOn": "reset,connect-failure,refused-stream"

--- a/src/go/options/configgenerator.go
+++ b/src/go/options/configgenerator.go
@@ -125,7 +125,7 @@ func DefaultConfigGeneratorOptions() ConfigGeneratorOptions {
 		BackendDnsLookupFamily:           "auto",
 		BackendAddress:                   fmt.Sprintf("http://%s:8082", util.LoopbackIPv4Addr),
 		ClusterConnectTimeout:            20 * time.Second,
-		StreamIdleTimeout:                5 * time.Minute,
+		StreamIdleTimeout:                util.DefaultIdleTimeout,
 		EnvoyXffNumTrustedHops:           2,
 		JwksCacheDurationInS:             300,
 		ListenerAddress:                  "0.0.0.0",

--- a/src/go/options/configgenerator.go
+++ b/src/go/options/configgenerator.go
@@ -42,6 +42,7 @@ type ConfigGeneratorOptions struct {
 
 	// Envoy specific configurations.
 	ClusterConnectTimeout time.Duration
+	StreamIdleTimeout     time.Duration
 
 	// Full URI to the backend: scheme, address/hostname, port
 	BackendAddress string
@@ -124,6 +125,7 @@ func DefaultConfigGeneratorOptions() ConfigGeneratorOptions {
 		BackendDnsLookupFamily:           "auto",
 		BackendAddress:                   fmt.Sprintf("http://%s:8082", util.LoopbackIPv4Addr),
 		ClusterConnectTimeout:            20 * time.Second,
+		StreamIdleTimeout:                5 * time.Minute,
 		EnvoyXffNumTrustedHops:           2,
 		JwksCacheDurationInS:             300,
 		ListenerAddress:                  "0.0.0.0",

--- a/src/go/util/time.go
+++ b/src/go/util/time.go
@@ -1,0 +1,10 @@
+package util
+
+import "time"
+
+func MaxDuration(a, b time.Duration) time.Duration {
+	if a >= b {
+		return a
+	}
+	return b
+}

--- a/src/go/util/util.go
+++ b/src/go/util/util.go
@@ -77,6 +77,9 @@ const (
 	// Default response deadline used if user does not specify one in the BackendRule.
 	DefaultResponseDeadline = 15 * time.Second
 
+	// Default idle timeout applied globally if not specified via flag.
+	DefaultIdleTimeout = 5 * time.Minute
+
 	// A limit configured to restrict resource usage in Envoy's SafeRegex GoogleRE2 matcher.
 	// It will be validated on configmanager side though it may use different GoogleRE2 library.
 	// b/148606900: It is safe to set this to a fairly high value.

--- a/tests/integration_test/grpc_deadline_test.go
+++ b/tests/integration_test/grpc_deadline_test.go
@@ -251,9 +251,30 @@ plans {
 }`,
 		},
 		{
+			// route deadline = 15s (default, not explicitly specified), global stream idle timeout = 20, request = 17s
+			// Global stream idle timeout is used because route deadline is not configured. Request is under the route's stream idle timeout, so it succeeds.
+			desc: "When deadline is NOT specified, the global idle timeout flag is honored. But it is large, so the request succeeds.",
+			confArgs: append([]string{
+				"--stream_idle_timeout_test_only=20s",
+			}, utils.CommonArgs()...),
+			testPlan: `
+plans {
+  echo_stream {
+    call_config {
+      api_key: "this-is-an-api-key"
+    }
+    request {
+      text: "Hello, world!"
+      response_delay: 17
+    }
+    count: 1
+  }
+}`,
+		},
+		{
 			// route deadline = 15s (default, not explicitly specified), global stream idle timeout = 3s, request = 7s
 			// Stream idle timeout is automatically increased to match the default route deadline. Request is under the route's stream idle timeout, so it succeeds.
-			desc: "When deadline is NOT specified, ESPv2 does not honor the global idle timeout flag if the value is lower than the default deadline (15s). Request still succeeds.",
+			desc: "When deadline is NOT specified, ESPv2 does not honor the global idle timeout flag if the value is lower than the default deadline (15s). The request succeeds.",
 			confArgs: append([]string{
 				"--stream_idle_timeout_test_only=3s",
 			}, utils.CommonArgs()...),

--- a/tests/integration_test/http1_deadline_test.go
+++ b/tests/integration_test/http1_deadline_test.go
@@ -29,7 +29,9 @@ import (
 type ConfiguredDeadline int
 
 const (
+	// 5s: configured in service config backend rule.
 	Short ConfiguredDeadline = iota
+	// 15s: Corresponding backend rule does not configure deadline, so default is used.
 	Default
 )
 

--- a/tests/start_proxy/start_proxy_test.py
+++ b/tests/start_proxy/start_proxy_test.py
@@ -511,16 +511,6 @@ class TestStartProxy(unittest.TestCase):
               '--disable_tracing',
               '--compute_platform_override', 'Cloud Run(ESPv2)'
               ]),
-            # stream_idle_timeout
-            (['-R=managed',
-              '--http2_port=8079', '--stream_idle_timeout=1h',
-              '--disable_tracing'],
-             ['bin/configmanager', '--logtostderr', '--rollout_strategy', 'managed',
-              '--backend_address', 'http://127.0.0.1:8082', '--v', '0',
-              '--listener_port', '8079',
-              '--disable_tracing',
-              '--stream_idle_timeout', '1h',
-              ]),
         ]
 
         i = 0

--- a/tests/start_proxy/start_proxy_test.py
+++ b/tests/start_proxy/start_proxy_test.py
@@ -511,6 +511,16 @@ class TestStartProxy(unittest.TestCase):
               '--disable_tracing',
               '--compute_platform_override', 'Cloud Run(ESPv2)'
               ]),
+            # stream_idle_timeout
+            (['-R=managed',
+              '--http2_port=8079', '--stream_idle_timeout=1h',
+              '--disable_tracing'],
+             ['bin/configmanager', '--logtostderr', '--rollout_strategy', 'managed',
+              '--backend_address', 'http://127.0.0.1:8082', '--v', '0',
+              '--listener_port', '8079',
+              '--disable_tracing',
+              '--stream_idle_timeout', '1h',
+              ]),
         ]
 
         i = 0


### PR DESCRIPTION
**Background**: See discussion in #455 

**Implementation**: When `deadline` is set in a backend rule, override the `stream_idle_timeout` for that operation to match the deadline. Created a flag `--stream_idle_timeout` to hold the default value and increase testability, but the flag is **not exposed** to the API producer.

The current solution fixes both cases:
1) Non-streaming HTTP requests over 5m will be supported by increasing the `deadline`. HTTP 408 will never be returned. Only HTTP 504 will occur once the configured deadline is met. 
2) For non-unary gRPC methods, user can configure the `deadline`. We disable request timeouts for streaming methods. Instead, `deadline` will configure stream idle time. So there is no need for the API Producer to set a flag.

Fixes #455