### PR TITLE
b/177252401: Add integration test for bug in transcoding

### DIFF
--- a/tests/env/platform/ports.go
+++ b/tests/env/platform/ports.go
@@ -144,7 +144,7 @@ const (
 	TestTranscodingErrors
 	TestTranscodingIgnoreQueryParameters
 	TestTranscodingPrintOptions
-	TestTranscodingServiceUnavailableError
+	TestTranscodingBackendUnavailableError
 	TestWebsocket
 	// The number of total tests. has to be the last one.
 	maxTestNum


### PR DESCRIPTION
### Overview

Original analysis is here: go/espv2-backend-retry-analysis

Add an integration test to confirm and document the bug. Fix should be in upstream envoy's gRPC transcoder filter (and/or the transcoding library).

### Context

If a HTTP client sends unexpected query params, the transcoder does not handle them correctly. It returns the following error:

```
{"code":503,"message":"upstream connect error or disconnect/reset before headers. reset reason: remote reset"}
```

This is not good, it results in ESPv2 retrying the request and wastes time on the critical path. There is no easy way to configure Envoy to ignore this error specifically. This error is considered a **reset**, which we should retry on in general. 

Ref: [Documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-on) on different retry triggers in Envoy.

Instead, the transcoder should return a HTTP 400 Bad Request for the invalid query param. This will prevent the unnecessary retry and be the correct behavior clients expect.

Signed-off-by: Teju Nareddy <nareddyt@google.com>