### PR TITLE
b/176538814: Propagate trace ID to correlate access logs and traces

### DIFF
--- a/src/api_proxy/service_control/request_builder.cc
+++ b/src/api_proxy/service_control/request_builder.cc
@@ -814,6 +814,11 @@ void SetOperationCommonFields(const OperationInfo& info,
   *op->mutable_end_time() = current_time;
 }
 
+std::string TraceResourceName(absl::string_view trace_id,
+                              absl::string_view project_id) {
+  return absl::StrCat("projects/", project_id, "/traces/", trace_id);
+}
+
 void FillLogEntry(const ReportRequestInfo& info, const std::string& name,
                   const std::string& config_id, const Timestamp& current_time,
                   LogEntry* log_entry) {
@@ -822,6 +827,11 @@ void FillLogEntry(const ReportRequestInfo& info, const std::string& name,
   auto severity = (get_status_code(info) >= 400) ? google::logging::type::ERROR
                                                  : google::logging::type::INFO;
   log_entry->set_severity(severity);
+
+  // Add trace if available.
+  if (!info.trace_id.empty() && !info.project_id.empty()) {
+    log_entry->set_trace(TraceResourceName(info.trace_id, info.project_id));
+  }
 
   // Fill in http request.
   auto* http_request = log_entry->mutable_http_request();

--- a/src/api_proxy/service_control/request_builder_test.cc
+++ b/src/api_proxy/service_control/request_builder_test.cc
@@ -260,6 +260,8 @@ TEST_F(RequestBuilderTest, FillGoodReportRequestTest) {
   FillOperationInfo(&info);
   FillReportRequestInfo(&info);
   info.backend_protocol = protocol::GRPC;
+  info.project_id = "test_project_id";
+  info.trace_id = "test_trace_id";
 
   gasv1::ReportRequest request;
   ASSERT_TRUE(scp_.FillReportRequest(info, &request).ok());

--- a/src/api_proxy/service_control/request_info.h
+++ b/src/api_proxy/service_control/request_info.h
@@ -261,6 +261,12 @@ struct ReportRequestInfo : public OperationInfo {
   // The response code detail.
   std::string response_code_detail;
 
+  // The GCP project ID the proxy is deployed on.
+  std::string project_id;
+
+  // Trace id (in hex) the request is tied to.
+  std::string trace_id;
+
   ReportRequestInfo()
       : http_response_code(0),
         request_size(-1),

--- a/src/api_proxy/service_control/testdata/report_request.golden
+++ b/src/api_proxy/service_control/testdata/report_request.golden
@@ -464,6 +464,7 @@ operations {
       }
       protocol: "http"
     }
+    trace: "projects/test_project_id/traces/test_trace_id"
   }
 }
 service_config_id: "2016-09-19r0"

--- a/src/envoy/http/service_control/filter.cc
+++ b/src/envoy/http/service_control/filter.cc
@@ -151,7 +151,9 @@ void ServiceControlFilter::log(
     handler_ = factory_.createHandler(*request_headers, stream_info, stats_);
   }
 
-  handler_->callReport(request_headers, response_headers, response_trailers);
+  Envoy::Tracing::Span& parent_span = decoder_callbacks_->activeSpan();
+  handler_->callReport(request_headers, response_headers, response_trailers,
+                       parent_span);
 }
 
 }  // namespace service_control

--- a/src/envoy/http/service_control/filter_test.cc
+++ b/src/envoy/http/service_control/filter_test.cc
@@ -225,7 +225,7 @@ TEST_F(ServiceControlFilterTest, LogWithoutHandlerOrHeaders) {
 
 TEST_F(ServiceControlFilterTest, LogWithoutHandler) {
   // Test: When a Filter has no Handler yet, another is created for log()
-  EXPECT_CALL(*mock_handler_, callReport(_, _, _));
+  EXPECT_CALL(*mock_handler_, callReport(_, _, _, _));
   filter_->log(&req_headers_, &resp_headers_, &resp_trailer_,
                mock_decoder_callbacks_.stream_info_);
 }
@@ -236,7 +236,7 @@ TEST_F(ServiceControlFilterTest, LogWithHandler) {
   filter_->decodeHeaders(req_headers_, true);
 
   EXPECT_CALL(mock_handler_factory_, createHandler(_, _, _)).Times(0);
-  EXPECT_CALL(*mock_handler_, callReport(_, _, _));
+  EXPECT_CALL(*mock_handler_, callReport(_, _, _, _));
   filter_->log(&req_headers_, &resp_headers_, &resp_trailer_,
                mock_decoder_callbacks_.stream_info_);
 }

--- a/src/envoy/http/service_control/handler.h
+++ b/src/envoy/http/service_control/handler.h
@@ -48,7 +48,8 @@ class ServiceControlHandler {
   virtual void callReport(
       const Envoy::Http::RequestHeaderMap* request_headers,
       const Envoy::Http::ResponseHeaderMap* response_headers,
-      const Envoy::Http::ResponseTrailerMap* response_trailers) PURE;
+      const Envoy::Http::ResponseTrailerMap* response_trailers,
+      const Envoy::Tracing::Span& parent_span) PURE;
 
   // Fill filter state with request information for access logging.
   virtual void fillFilterState(

--- a/src/envoy/http/service_control/handler_impl.cc
+++ b/src/envoy/http/service_control/handler_impl.cc
@@ -302,7 +302,8 @@ void ServiceControlHandlerImpl::onCheckResponse(
 void ServiceControlHandlerImpl::callReport(
     const Envoy::Http::RequestHeaderMap* request_headers,
     const Envoy::Http::ResponseHeaderMap* response_headers,
-    const Envoy::Http::ResponseTrailerMap* response_trailers) {
+    const Envoy::Http::ResponseTrailerMap* response_trailers,
+    const Envoy::Tracing::Span& parent_span) {
   if (!isReportRequired()) {
     return;
   }
@@ -355,6 +356,8 @@ void ServiceControlHandlerImpl::callReport(
   info.response_size = stream_info_.bytesSent() + response_header_size;
 
   info.response_code_detail = stream_info_.responseCodeDetails().value_or("");
+
+  info.trace_id = parent_span.getTraceIdAsHex();
 
   require_ctx_->service_ctx().call().callReport(info);
 }

--- a/src/envoy/http/service_control/handler_impl.h
+++ b/src/envoy/http/service_control/handler_impl.h
@@ -54,10 +54,10 @@ class ServiceControlHandlerImpl
                  Envoy::Tracing::Span& parent_span,
                  CheckDoneCallback& callback) override;
 
-  void callReport(
-      const Envoy::Http::RequestHeaderMap* request_headers,
-      const Envoy::Http::ResponseHeaderMap* response_headers,
-      const Envoy::Http::ResponseTrailerMap* response_trailers) override;
+  void callReport(const Envoy::Http::RequestHeaderMap* request_headers,
+                  const Envoy::Http::ResponseHeaderMap* response_headers,
+                  const Envoy::Http::ResponseTrailerMap* response_trailers,
+                  const Envoy::Tracing::Span& parent_span) override;
 
   void fillFilterState(::Envoy::StreamInfo::FilterState& filter_state) override;
 

--- a/src/envoy/http/service_control/handler_utils.cc
+++ b/src/envoy/http/service_control/handler_utils.cc
@@ -148,6 +148,10 @@ void fillGCPInfo(
   if (!gcp_attributes.platform().empty()) {
     info.compute_platform = gcp_attributes.platform();
   }
+
+  if (!gcp_attributes.project_id().empty()) {
+    info.project_id = gcp_attributes.project_id();
+  }
 }
 
 void fillLoggedHeader(

--- a/src/envoy/http/service_control/mocks.h
+++ b/src/envoy/http/service_control/mocks.h
@@ -35,7 +35,8 @@ class MockServiceControlHandler : public ServiceControlHandler {
   MOCK_METHOD(void, callReport,
               (const Envoy::Http::RequestHeaderMap* request_headers,
                const Envoy::Http::ResponseHeaderMap* response_headers,
-               const Envoy::Http::ResponseTrailerMap* response_trailers),
+               const Envoy::Http::ResponseTrailerMap* response_trailers,
+               const Envoy::Tracing::Span& parent_span),
               (override));
 
   MOCK_METHOD(void, onDestroy, (), (override));

--- a/tests/utils/service_control_utils.go
+++ b/tests/utils/service_control_utils.go
@@ -96,6 +96,7 @@ type ExpectedReport struct {
 	ResponseHeaders              string
 	ResponseCodeDetail           string
 	JwtPayloads                  string
+	Trace                        string
 }
 
 type distOptions struct {
@@ -379,7 +380,7 @@ func createLogEntry(er *ExpectedReport) *scpb.LogEntry {
 	}
 	pl["http_status_code"] = makeNumberValue(er.HttpStatusCode)
 
-	return &scpb.LogEntry{
+	entry := &scpb.LogEntry{
 		Name:     "endpoints_log",
 		Severity: severity,
 		Payload: &scpb.LogEntry_StructPayload{
@@ -389,6 +390,12 @@ func createLogEntry(er *ExpectedReport) *scpb.LogEntry {
 		},
 		HttpRequest: httpRequest,
 	}
+
+	if er.Trace != "" {
+		entry.Trace = er.Trace
+	}
+
+	return entry
 }
 
 func createInt64MetricSet(name string, value int64) *scpb.MetricValueSet {


### PR DESCRIPTION
**Description**: Plumbing to take the trace ID provided by Envoy's trace interface and fill the data into SC report. See #431 for more background on the feature request.

**Limitations**: Will only work if ESPv2 is running on GCP. If running with `--non_gcp` (even with `--tracing_project_id` flag), this will be a NOOP and the trace won't be associated with the access log.

**Testing done**:
- Integration tests verify trace ID is propagated correctly
- e2e test to check Cloud Trace can correlate a trace to a request in Cloud Logging

**Examples**

You can now correlate access logs for a single request.

![image](https://user-images.githubusercontent.com/11142171/105267380-718cb680-5b5f-11eb-9e8d-57afe19955a4.png)

Fixes #431