### PR TITLE
Allow backend address override

### DIFF
--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -133,6 +133,10 @@ environment variable or by passing "-k" flag to this script.
 
         Default value is {backend}. Follow the same format when setting
         manually. Valid schemes are `http`, `https`, `grpc`, and `grpcs`.
+        
+        See the flag --enable_backend_address_override for details on how ESPv2
+        decides between using this flag vs using the backend addresses specified
+        in the service configuration.
         '''.format(backend=DEFAULT_BACKEND))
 
     parser.add_argument(
@@ -141,7 +145,11 @@ environment variable or by passing "-k" flag to this script.
         help='''
         Backend addresses can be specified using either the --backend flag
         or the `backend.rule.address` field in the service configuration.
+        For OpenAPI users, note the `backend.rule.address` field is set
+        by the `address` field in the `x-google-backend` extension.
         
+        `backend.rule.address` is usually specified when routing to different
+        backends based on the route.
         By default, the `backend.rule.address` will take priority over 
         the --backend flag for each individual operation.
         
@@ -152,9 +160,7 @@ environment variable or by passing "-k" flag to this script.
         
         Note: Only the address will be overridden.
         All other components of `backend.rule` will still apply 
-        (deadlines, backend auth, etc).
-        Consider setting --non_gcp as well to override the 
-        backend auth configuration.
+        (deadlines, backend auth, path translation, etc).
         ''')
 
     parser.add_argument('--listener_port', default=None, type=int, help='''

--- a/src/go/configinfo/service_info.go
+++ b/src/go/configinfo/service_info.go
@@ -629,9 +629,10 @@ func (s *ServiceInfo) determineBackendAuthJwtAud(r *confpb.BackendRule, scheme s
 	}
 }
 
-// For methods that are not associated with any backend rules, create one
-// to associate with the local backend cluster.
 func (s *ServiceInfo) processLocalBackendOperations() error {
+
+	// For methods that are not associated with any backend rules, create one
+	// to associate with the local backend cluster.
 	for _, method := range s.Methods {
 		if method.BackendInfo != nil {
 			// This method is already associated with a backend rule.
@@ -648,6 +649,13 @@ func (s *ServiceInfo) processLocalBackendOperations() error {
 			IdleTimeout: idleTimeout,
 			RetryOns:    s.Options.BackendRetryOns,
 			RetryNum:    s.Options.BackendRetryNum,
+		}
+	}
+
+	// Honor backend address override.
+	if s.Options.EnableBackendAddressOverride {
+		for _, method := range s.Methods {
+			method.BackendInfo.ClusterName = s.LocalBackendCluster.ClusterName
 		}
 	}
 

--- a/src/go/configinfo/service_info.go
+++ b/src/go/configinfo/service_info.go
@@ -496,7 +496,7 @@ func (s *ServiceInfo) processBackendRule() error {
 
 	for _, r := range s.ServiceConfig().Backend.GetRules() {
 
-		if r.Address == "" {
+		if r.Address == "" || s.Options.EnableBackendAddressOverride {
 			// Processing a backend rule associated with the local backend.
 			if err := s.addBackendInfoToMethod(r, "", "", "", s.LocalBackendClusterName()); err != nil {
 				return fmt.Errorf("error processing local backend rule for operation (%v), %v", r.Selector, err)
@@ -649,13 +649,6 @@ func (s *ServiceInfo) processLocalBackendOperations() error {
 			IdleTimeout: idleTimeout,
 			RetryOns:    s.Options.BackendRetryOns,
 			RetryNum:    s.Options.BackendRetryNum,
-		}
-	}
-
-	// Honor backend address override.
-	if s.Options.EnableBackendAddressOverride {
-		for _, method := range s.Methods {
-			method.BackendInfo.ClusterName = s.LocalBackendCluster.ClusterName
 		}
 	}
 

--- a/src/go/configinfo/service_info_test.go
+++ b/src/go/configinfo/service_info_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/google/go-cmp/cmp"
 	"github.com/gorilla/mux"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	commonpb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/v9/http/common"
 	scpb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/v9/http/service_control"
@@ -633,12 +634,14 @@ func TestProcessTranscodingIgnoredQueryParams(t *testing.T) {
 
 func TestMethods(t *testing.T) {
 	testData := []struct {
-		desc              string
-		fakeServiceConfig *confpb.Service
-		BackendAddress    string
-		healthz           string
-		wantMethods       map[string]*MethodInfo
-		wantError         string
+		desc                         string
+		fakeServiceConfig            *confpb.Service
+		BackendAddress               string
+		healthz                      string
+		enableBackendAddressOverride bool
+		isNonGcp                     bool
+		wantMethods                  map[string]*MethodInfo
+		wantError                    string
 	}{
 		{
 			desc: "Succeed for gRPC, no Http rule, with Healthz",
@@ -1639,6 +1642,57 @@ func TestMethods(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc:                         "Backend address override with non GCP results in local backend used instead of backend rule.",
+			enableBackendAddressOverride: true,
+			isNonGcp:                     true,
+			fakeServiceConfig: &confpb.Service{
+				Name: testProjectName,
+				Apis: []*apipb.Api{
+					{
+						Name: testApiName,
+						Methods: []*apipb.Method{
+							{
+								Name: "ListShelves",
+							},
+						},
+					},
+				},
+				Backend: &confpb.Backend{
+					Rules: []*confpb.BackendRule{
+						{
+							Address:         "grpc://abc.com/a/",
+							Selector:        fmt.Sprintf("%s.%s", testApiName, "ListShelves"),
+							PathTranslation: confpb.BackendRule_APPEND_PATH_TO_ADDRESS,
+							Authentication: &confpb.BackendRule_JwtAudience{
+								JwtAudience: "grpc://abc.com/a/",
+							},
+						},
+					},
+				},
+			},
+			BackendAddress: "grpc://127.0.0.1:80",
+			wantMethods: map[string]*MethodInfo{
+				fmt.Sprintf("%s.%s", testApiName, "ListShelves"): &MethodInfo{
+					ShortName: "ListShelves",
+					ApiName:   testApiName,
+					HttpRule: []*httppattern.Pattern{
+						{
+							HttpMethod:  util.POST,
+							UriTemplate: parseUriTemplate(fmt.Sprintf("/%s/%s", testApiName, "ListShelves")),
+						},
+					},
+					BackendInfo: &backendInfo{
+						ClusterName: "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+						Deadline:    util.DefaultResponseDeadline,
+						RetryOns:    "reset,connect-failure,refused-stream",
+						RetryNum:    1,
+						// Even though translation type is specified, it won't matter: Path is empty.
+						TranslationType: confpb.BackendRule_APPEND_PATH_TO_ADDRESS,
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testData {
@@ -1646,6 +1700,8 @@ func TestMethods(t *testing.T) {
 			opts := options.DefaultConfigGeneratorOptions()
 			opts.BackendAddress = tc.BackendAddress
 			opts.Healthz = tc.healthz
+			opts.EnableBackendAddressOverride = tc.enableBackendAddressOverride
+			opts.NonGCP = tc.isNonGcp
 			serviceInfo, err := NewServiceInfoFromServiceConfig(tc.fakeServiceConfig, testConfigID, opts)
 			if tc.wantError != "" {
 				if err == nil || !strings.Contains(err.Error(), tc.wantError) {
@@ -1668,8 +1724,8 @@ func TestMethods(t *testing.T) {
 
 				if !ok {
 					t.Errorf("cannot find key: %v\n got methods : %+v\nwant methods: %+v", key, serviceInfo.Methods, tc.wantMethods)
-				} else if eq := cmp.Equal(gotMethod, wantMethod, cmp.Comparer(proto.Equal)); !eq {
-					t.Errorf("methods mismtatch \ngot : %+v, \nwant: %+v", gotMethod, wantMethod)
+				} else if diff := cmp.Diff(gotMethod, wantMethod, protocmp.Transform()); diff != "" {
+					t.Errorf("methods mismtatch: %v", diff)
 				}
 			}
 		})

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -48,10 +48,11 @@ var (
 	ClusterConnectTimeout = flag.Duration("cluster_connect_timeout", 20*time.Second, "cluster connect timeout in seconds")
 
 	// Network related configurations.
-	BackendAddress       = flag.String("backend_address", "http://127.0.0.1:8082", `The application server URI to which ESPv2 proxies requests.`)
-	ListenerAddress      = flag.String("listener_address", "0.0.0.0", "listener socket ip address")
-	ServiceManagementURL = flag.String("service_management_url", "https://servicemanagement.googleapis.com", "url of service management server")
-	ServiceControlURL    = flag.String("service_control_url", "https://servicecontrol.googleapis.com", "url of service control server")
+	BackendAddress               = flag.String("backend_address", "http://127.0.0.1:8082", `The application server URI to which ESPv2 proxies requests.`)
+	ListenerAddress              = flag.String("listener_address", "0.0.0.0", "listener socket ip address")
+	ServiceManagementURL         = flag.String("service_management_url", "https://servicemanagement.googleapis.com", "url of service management server")
+	ServiceControlURL            = flag.String("service_control_url", "https://servicecontrol.googleapis.com", "url of service control server")
+	EnableBackendAddressOverride = flag.Bool("enable_backend_address_override", false, "Allow the --backend flag to override the backend.rule.address for all operations.")
 
 	ListenerPort = flag.Int("listener_port", 8080, "listener port")
 	Healthz      = flag.String("healthz", "", "path for health check of ESPv2 proxy itself")
@@ -155,6 +156,7 @@ func EnvoyConfigOptionsFromFlags() options.ConfigGeneratorOptions {
 	opts := options.ConfigGeneratorOptions{
 		CommonOptions:                           commonflags.DefaultCommonOptionsFromFlags(),
 		BackendAddress:                          *BackendAddress,
+		EnableBackendAddressOverride:            *EnableBackendAddressOverride,
 		AccessLog:                               *AccessLog,
 		AccessLogFormat:                         *AccessLogFormat,
 		ComputePlatformOverride:                 *ComputePlatformOverride,

--- a/src/go/options/configgenerator.go
+++ b/src/go/options/configgenerator.go
@@ -45,7 +45,8 @@ type ConfigGeneratorOptions struct {
 	StreamIdleTimeout     time.Duration
 
 	// Full URI to the backend: scheme, address/hostname, port
-	BackendAddress string
+	BackendAddress               string
+	EnableBackendAddressOverride bool
 
 	// Network related configurations.
 	ListenerAddress                  string
@@ -124,6 +125,7 @@ func DefaultConfigGeneratorOptions() ConfigGeneratorOptions {
 		CommonOptions:                    DefaultCommonOptions(),
 		BackendDnsLookupFamily:           "auto",
 		BackendAddress:                   fmt.Sprintf("http://%s:8082", util.LoopbackIPv4Addr),
+		EnableBackendAddressOverride:     false,
 		ClusterConnectTimeout:            20 * time.Second,
 		StreamIdleTimeout:                util.DefaultIdleTimeout,
 		EnvoyXffNumTrustedHops:           2,

--- a/tests/env/platform/ports.go
+++ b/tests/env/platform/ports.go
@@ -90,6 +90,7 @@ const (
 	TestPreflightRequestWithAllowCors
 	TestReportGCPAttributes
 	TestReportGCPAttributesPerPlatform
+	TestReportTraceId
 	TestRetryCallServiceManagement
 	TestServiceControlAccessTokenFromIam
 	TestServiceControlAccessTokenFromTokenAgent

--- a/tests/env/platform/ports.go
+++ b/tests/env/platform/ports.go
@@ -32,8 +32,10 @@ const (
 	TestAsymmetricKeys
 	TestAuthAllowMissing
 	TestAuthJwksCache
+	TestBackendAddressOverride
 	TestBackendAuthDisableAuth
 	TestBackendAuthUsingIamIdTokenWithDelegates
+	TestBackendAuthPerPlatform
 	TestBackendAuthWithIamIdToken
 	TestBackendAuthWithIamIdTokenRetries
 	TestBackendAuthWithIamIdTokenTimeouts

--- a/tests/integration_test/opencensus_tracing_test.go
+++ b/tests/integration_test/opencensus_tracing_test.go
@@ -680,7 +680,7 @@ func TestReportTraceId(t *testing.T) {
 	for _, tc := range testData {
 		t.Run(tc.desc, func(t *testing.T) {
 
-			s := env.NewTestEnv(platform.TestTraceContextPropagationHeaders, platform.EchoSidecar)
+			s := env.NewTestEnv(platform.TestReportTraceId, platform.EchoSidecar)
 			s.SetupFakeTraceServer(tc.tracingSampleRate)
 			defer s.TearDown(t)
 			if err := s.Setup(utils.CommonArgs()); err != nil {


### PR DESCRIPTION
**Description**: Adds a new flag `--enable_backend_address_override`. When enabled, the `--backend` flag will override the backend address specified by any `backend.rule.address`.

**Testing done**:
- Unit tests of generated methods for `ServiceInfo`.
- Integration tests for both `--enable_backend_address_override` and `--non_gcp`.

**Unrelated change**: Fix a integration test name

Fixes #449
Signed-off-by: Teju Nareddy <nareddyt@google.com>
