### PR TITLE
b/178530647 #1: Respond with HTTP 400 when required headers are omitted in CORS preflight request

### DIFF
--- a/src/go/configgenerator/route_generator_test.go
+++ b/src/go/configgenerator/route_generator_test.go
@@ -3372,12 +3372,40 @@ func TestMakeFallbackRoute(t *testing.T) {
               {
                 "exactMatch": "OPTIONS",
                 "name": ":method"
+              },
+              {
+                "name": "origin",
+                "presentMatch": true
+              },
+              {
+                "name": "access-control-request-method",
+                "presentMatch": true
               }
             ],
             "prefix": "/"
           },
           "route": {
             "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local"
+          }
+        },
+        {
+          "decorator": {
+            "operation": "ingress"
+          },
+          "directResponse": {
+            "body": {
+              "inlineString": "The CORS preflight request is missing one (or more) of the following required headers: Origin, Access-Control-Request-Method"
+            },
+            "status": 400
+          },
+          "match": {
+            "headers": [
+              {
+                "exactMatch": "OPTIONS",
+                "name": ":method"
+              }
+            ],
+            "prefix": "/"
           }
         },
         {

--- a/src/go/gcsrunner/main/runner.go
+++ b/src/go/gcsrunner/main/runner.go
@@ -49,8 +49,8 @@ var (
 	envoyBinaryPath = flag.String("envoy_bin_path", "bin/envoy", "Location of the Envoy binary.")
 	envoyLogLevel   = flag.String("envoy_log_level", "info",
 		"Envoy logging level. Default is `info`. Options are: [trace][debug][info][warning][error][critical][off]")
-	envoyLogPath    = flag.String("envoy_log_path", "",
-                "Envoy application logging path. Default is to write to stderr.")
+	envoyLogPath = flag.String("envoy_log_path", "",
+		"Envoy application logging path. Default is to write to stderr.")
 )
 
 func main() {

--- a/src/go/gcsrunner/start_envoy.go
+++ b/src/go/gcsrunner/start_envoy.go
@@ -30,7 +30,7 @@ type StartEnvoyOptions struct {
 	BinaryPath       string
 	ConfigPath       string
 	LogLevel         string
-	LogPath		 string
+	LogPath          string
 	TerminateTimeout time.Duration
 }
 

--- a/tests/env/platform/ports.go
+++ b/tests/env/platform/ports.go
@@ -86,7 +86,7 @@ const (
 	TestMethodOverrideBackendMethod
 	TestMethodOverrideScReport
 	TestMultiGrpcServices
-	TestPreflightCorsWithBasicPreset
+	TestProxyHandlesCorsPreflightRequestsBasic
 	TestPreflightRequestWithAllowCors
 	TestReportGCPAttributes
 	TestReportGCPAttributesPerPlatform
@@ -129,8 +129,8 @@ const (
 	TestServiceControlTLSWithValidCert
 	TestServiceManagementWithInvalidCert
 	TestServiceManagementWithValidCert
-	TestSimpleCorsWithBasicPreset
-	TestSimpleCorsWithRegexPreset
+	TestProxyHandleCorsSimpleRequestsBasic
+	TestProxyHandleCorsSimpleRequestsRegex
 	TestStartupDuplicatedPathsWithAllowCors
 	TestStatistics
 	TestStatisticsServiceControlCallStatus

--- a/tests/integration_test/cors_integration_test.go
+++ b/tests/integration_test/cors_integration_test.go
@@ -219,6 +219,9 @@ func TestProxyHandlesCorsPreflightRequestsBasic(t *testing.T) {
 			},
 		},
 		{
+			// TODO(nareddyt): The response code here is a minor bug.
+			// It's coming from the SC filter, as the CORS filters just continues
+			// the pipeline when the origin mismatches.
 			desc: "CORS preflight request is invalid because the origin does not match.",
 			reqHeaders: map[string]string{
 				"Origin":                         "https://some.unknown.origin.com",

--- a/tests/utils/http.go
+++ b/tests/utils/http.go
@@ -100,9 +100,9 @@ func DoWithHeadersAndTimeout(url, method, message string, headers map[string]str
 
 	if resp.StatusCode != http.StatusOK {
 		if resp.Header.Get("Content-Type") == "application/json" {
-			return nil, nil, fmt.Errorf("http response status is not 200 OK: %s, %s", resp.Status, RpcStatusDeterministicJsonFormat(bodyBytes))
+			return resp.Header, bodyBytes, fmt.Errorf("http response status is not 200 OK: %s, %s", resp.Status, RpcStatusDeterministicJsonFormat(bodyBytes))
 		}
-		return nil, nil, fmt.Errorf("http response status is not 200 OK: %s, %s", resp.Status, bodyBytes)
+		return resp.Header, bodyBytes, fmt.Errorf("http response status is not 200 OK: %s, %s", resp.Status, bodyBytes)
 	}
 	return resp.Header, bodyBytes, err
 }


### PR DESCRIPTION
**Background:** The Envoy CORS filter is coded to `Continue` the request when a required header is missing or mismatched. See https://github.com/envoyproxy/envoy/issues/14233 for more details. This results in requests with missing `origin` or `access-control-request-method` headers not being handled properly.

**Fix:** Modify the CORS route config to generate two routes:
- First route will match OPTIONS request with _all_ required headers. This will be treated as a CORS request.
- Second round is a fallback. It will match OPTIONS requests with _any_ missing headers. It will direct reply with HTTP 400.

**Testing done:**
- Current CORS integration tests are very confusing. I combined/rewrote the first few to make it clear if they are testing simple vs. preflight request, which CORS config is used, etc. Feel free to ignore these rewrites, the diff is messy unfortunately.
- The bug fix in this PR is tested via `TestProxyHandlesCorsPreflightRequestsBasic`. You can find the `400` and `405` response codes in this test.

**Follow-up:** This PR only handles missing headers. When the `origin` header is specified but mismatched, the CORS filter `continues` the request as described above. It is not easy to handle this unless we do some "hack" in the SC filter. I may look into this later, not a big deal.

Fixes #465
Signed-off-by: Teju Nareddy nareddyt@google.com