### PR TITLE
b/181697283: Propagate trace context headers to SC Check

### DIFF
--- a/src/envoy/http/service_control/http_call.cc
+++ b/src/envoy/http/service_control/http_call.cc
@@ -205,6 +205,7 @@ class HttpCallImpl : public HttpCall,
     request_span_->setTag(Envoy::Tracing::Tags::get().HttpMethod, "POST");
 
     Envoy::Http::RequestMessagePtr message = prepareHeaders(token);
+    request_span_->injectContext(message->headers());
     ENVOY_LOG(debug, "http call from [uri = {}]: start", uri_);
 
     const auto thread_local_cluster =

--- a/tests/env/platform/ports.go
+++ b/tests/env/platform/ports.go
@@ -141,6 +141,7 @@ const (
 	TestStatistics
 	TestStatisticsServiceControlCallStatus
 	TestTraceContextPropagationHeaders
+	TestTraceContextPropagationHeadersForScCheck
 	TestTracesDynamicRouting
 	TestTracesFetchingJwks
 	TestTracesServiceControlCheckWithRetry

--- a/tests/integration_test/opencensus_tracing_test/opencensus_tracing_test.go
+++ b/tests/integration_test/opencensus_tracing_test/opencensus_tracing_test.go
@@ -622,6 +622,16 @@ func TestTraceContextPropagationHeadersForScCheck(t *testing.T) {
 			createTraceparentContext(traceId, spanId),
 		},
 	}
+	expectedTraceContexts := map[string][]string{
+		// Only the trace id is checked. Span id should be changed.
+		// By default, both trace contexts are generated.
+		"Traceparent": {
+			createTraceparentContextPrefix(traceId),
+		},
+		"X-Cloud-Trace-Context": {
+			createCloudTraceContextPrefix(traceId),
+		},
+	}
 
 	tests := []struct {
 		desc                 string
@@ -629,37 +639,14 @@ func TestTraceContextPropagationHeadersForScCheck(t *testing.T) {
 		expectedScReqHeaders map[string][]string
 	}{
 		{
-			desc:              "SC Check receives trace context propagation header.",
-			tracingSampleRate: 1,
-			expectedScReqHeaders: map[string][]string{
-				// Only the trace id is checked. Span id should be changed.
-				"Traceparent": {
-					createTraceparentContextPrefix(traceId),
-				},
-			},
+			desc:                 "SC Check receives trace context propagation header.",
+			tracingSampleRate:    1,
+			expectedScReqHeaders: expectedTraceContexts,
 		},
 		{
-			desc:              "Trace context is propagated even when sampling rate is 0.",
-			tracingSampleRate: 0,
-			expectedScReqHeaders: map[string][]string{
-				// Only the trace id is checked. Span id should be changed.
-				"Traceparent": {
-					createTraceparentContextPrefix(traceId),
-				},
-			},
-		},
-		{
-			desc:              "By default, both traceparent and cloud trace headers are propagated.",
-			tracingSampleRate: 1,
-			expectedScReqHeaders: map[string][]string{
-				// Only the trace id is checked. Span id should be changed.
-				"Traceparent": {
-					createTraceparentContextPrefix(traceId),
-				},
-				"X-Cloud-Trace-Context": {
-					createCloudTraceContextPrefix(traceId),
-				},
-			},
+			desc:                 "Trace context is propagated even when sampling rate is 0.",
+			tracingSampleRate:    0,
+			expectedScReqHeaders: expectedTraceContexts,
 		},
 	}
 

--- a/tests/integration_test/opencensus_tracing_test/opencensus_tracing_test.go
+++ b/tests/integration_test/opencensus_tracing_test/opencensus_tracing_test.go
@@ -612,6 +612,92 @@ func TestTraceContextPropagationHeaders(t *testing.T) {
 	}
 }
 
+func TestTraceContextPropagationHeadersForScCheck(t *testing.T) {
+	t.Parallel()
+
+	traceId := "0af7651916cd43dd8448eb211c80319c"
+	spanId := "b7ad6b7169203331"
+	incomingTraceContexts := map[string][]string{
+		"traceparent": {
+			createTraceparentContext(traceId, spanId),
+		},
+	}
+
+	tests := []struct {
+		desc                 string
+		tracingSampleRate    float32
+		expectedScReqHeaders map[string][]string
+	}{
+		{
+			desc:              "SC Check receives trace context propagation header.",
+			tracingSampleRate: 1,
+			expectedScReqHeaders: map[string][]string{
+				// Only the trace id is checked. Span id should be changed.
+				"Traceparent": {
+					createTraceparentContextPrefix(traceId),
+				},
+			},
+		},
+		{
+			desc:              "Trace context is propagated even when sampling rate is 0.",
+			tracingSampleRate: 0,
+			expectedScReqHeaders: map[string][]string{
+				// Only the trace id is checked. Span id should be changed.
+				"Traceparent": {
+					createTraceparentContextPrefix(traceId),
+				},
+			},
+		},
+		{
+			desc:              "By default, both traceparent and cloud trace headers are propagated.",
+			tracingSampleRate: 1,
+			expectedScReqHeaders: map[string][]string{
+				// Only the trace id is checked. Span id should be changed.
+				"Traceparent": {
+					createTraceparentContextPrefix(traceId),
+				},
+				"X-Cloud-Trace-Context": {
+					createCloudTraceContextPrefix(traceId),
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			s := env.NewTestEnv(platform.TestTraceContextPropagationHeadersForScCheck, platform.GrpcBookstoreSidecar)
+			s.SetupFakeTraceServer(tc.tracingSampleRate)
+
+			handler := utils.ExpectHeaderHandler{
+				T:               t,
+				ExpectedHeaders: tc.expectedScReqHeaders,
+			}
+			s.ServiceControlServer.OverrideCheckHandler(&handler)
+
+			defer s.TearDown(t)
+			if err := s.Setup(utils.CommonArgs()); err != nil {
+				t.Fatalf("fail to setup test env, %v", err)
+			}
+
+			addr := fmt.Sprintf("%v:%v", platform.GetLoopbackAddress(), s.Ports().ListenerPort)
+			_, err := bsclient.MakeCall("http", addr, "GET", "/v1/shelves?key=api-key-2", testdata.FakeCloudTokenMultiAudiences, incomingTraceContexts)
+			if err != nil {
+				t.Errorf("expected no err, got err: %v", err)
+				return
+			}
+
+			if handler.RequestCount != 1 {
+				t.Errorf("SC Check was expected to be called once, but it was called %v times.", handler.RequestCount)
+				return
+			}
+
+			// Ignore the spans in this test, we do not check the names.
+			time.Sleep(5 * time.Second)
+			_, _ = s.FakeStackdriverServer.RetrieveSpanNames()
+		})
+	}
+}
+
 func TestReportTraceId(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
**Background**: This was an action item from the SRE brainstorming meeting to improve observability of latency issues. We should propagate this header so we can better debug customer issues by correlating the external request with internal ones.

**Implementation**: Very simple, uses the Envoy tracing interface.

**Testing done**: Integration test.

Signed-off-by: Teju Nareddy <nareddyt@google.com>