### PR TITLE
b/181656360: Component-level logging for gcsrunner

### DIFF
--- a/scripts/release/release-stable.sh
+++ b/scripts/release/release-stable.sh
@@ -30,7 +30,7 @@ This script will release stable ESPv2 docker image with format of:
   $(get_serverless_image_release_name):\${MINOR_BASE_VERSION}
   $(get_serverless_image_release_name):\${MAJOR_BASE_VERSION}
   $(get_gcsrunner_image_release_name):\${MINOR_BASE_VERSION}
-  $(get_gcsrruner_image_release_name):\${MAJOR_BASE_VERSION}
+  $(get_gcsrunner_image_release_name):\${MAJOR_BASE_VERSION}
 where:
   MINOR_BASE_VERSION=major.minor
   MAJOR_BASE_VERSION=major

--- a/src/go/gcsrunner/main/runner.go
+++ b/src/go/gcsrunner/main/runner.go
@@ -51,6 +51,7 @@ var (
 		"Envoy logging level. Default is `info`. Options are: [trace][debug][info][warning][error][critical][off]")
 	envoyLogPath = flag.String("envoy_log_path", "",
 		"Envoy application logging path. Default is to write to stderr.")
+	envoyComponentLogLevel = flag.String("envoy_component_log_level", "", "Mapping for Envoy log level by component.")
 )
 
 func main() {
@@ -68,6 +69,11 @@ func main() {
 	logLevel := os.Getenv("ENVOY_LOG_LEVEL")
 	if logLevel == "" {
 		logLevel = *envoyLogLevel
+	}
+
+	componentLogLevel := os.Getenv("ENVOY_COMPONENT_LOG_LEVEL")
+	if componentLogLevel == "" {
+		componentLogLevel = *envoyComponentLogLevel
 	}
 
 	logPath := os.Getenv("ENVOY_LOG_PATH")
@@ -94,11 +100,12 @@ func main() {
 	}
 
 	if err := gcsrunner.StartEnvoyAndWait(signalChan, gcsrunner.StartEnvoyOptions{
-		BinaryPath:       envoyBin,
-		ConfigPath:       envoyConfigPath,
-		LogLevel:         logLevel,
-		LogPath:          logPath,
-		TerminateTimeout: terminateEnvoyTimeout,
+		BinaryPath:        envoyBin,
+		ComponentLogLevel: componentLogLevel,
+		ConfigPath:        envoyConfigPath,
+		LogLevel:          logLevel,
+		LogPath:           logPath,
+		TerminateTimeout:  terminateEnvoyTimeout,
 	}); err != nil {
 		glog.Fatalf("Envoy erred: %v", err)
 	}


### PR DESCRIPTION
This allows for more fine-grained control over what is logged in the case that extra debugging may be necessary without getting too much noise.

It is the first step in b/181656360 (followed by changes on our end).