### PR TITLE
Update envoy to v1.17.1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -39,9 +39,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # 3) Check if envoy_build_config/extensions_build_config.bzl is up-to-date.
 # Try to match it with the one in source/extensions and comment out unneeded extensions.
 
-ENVOY_SHA1 = "5c801b25cae04f06bf48248c90e87d623d7a6283"  # 2021-01-11: v1.17.0
+ENVOY_SHA1 = "d6a4496e712d7a2335b26e2f76210d5904002c26"  # 2021-02-26: v1.17.1
 
-ENVOY_SHA256 = "c958a88b0690b83b0d48737474df8d6b43a7841401fadbe94fa56c0e03aaaaf3"
+ENVOY_SHA256 = "7d68c8d30203e6f5fd0c7d44c522b010c0a5d593f2c85fe7e9b94c57a3933f01"
 
 http_archive(
     name = "envoy",


### PR DESCRIPTION
This is to fix the [zero-day JWT auth vulnerability](https://groups.google.com/g/envoy-announce/c/VkqM-5MlUeY). No other behavior change should be introduced based on the [Envoy version history](https://www.envoyproxy.io/docs/envoy/v1.17.1/version_history/v1.17.1).

Signed-off-by: Teju Nareddy <nareddyt@google.com>