### PR TITLE
Add flag --cors_max_age to support configure Access-Control-Max-Age response header

### DIFF
--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -341,6 +341,17 @@ environment variable or by passing "-k" flag to this script.
         Access-Control-Allow-Credentials. By default, this header is disabled.
         ''')
     parser.add_argument(
+        '--cors_max_age',
+        default='480h',
+        help='''
+        Only works when --cors_preset is in use. Configures the CORS header
+        Access-Control-Max-Age. Defaults to 20 days (1728000 seconds).
+
+        The acceptable format is a sequence of decimal numbers, each with
+        optional fraction and a unit suffix, such as "300m", "1.5h" or "2h45m".
+        Valid time units are "m" for minutes, "h" for hours.
+        ''')
+    parser.add_argument(
         '--check_metadata',
         action='store_true',
         help='''Enable fetching service name, service config ID and rollout
@@ -1085,6 +1096,8 @@ def gen_proxy_config(args):
             args.cors_allow_headers,
             "--cors_expose_headers",
             args.cors_expose_headers,
+            "--cors_max_age",
+            args.cors_max_age,
         ])
         if args.cors_allow_credentials:
             proxy_conf.append("--cors_allow_credentials")

--- a/src/go/configgenerator/route_generator.go
+++ b/src/go/configgenerator/route_generator.go
@@ -17,6 +17,7 @@ package configgenerator
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/configinfo"
@@ -204,6 +205,7 @@ func makeRouteCors(serviceInfo *configinfo.ServiceInfo) (*routepb.CorsPolicy, []
 	if cors == nil {
 		return nil, nil, nil
 	}
+	cors.MaxAge = strconv.Itoa(int(serviceInfo.Options.CorsMaxAge.Seconds()))
 	cors.AllowMethods = serviceInfo.Options.CorsAllowMethods
 	cors.AllowHeaders = serviceInfo.Options.CorsAllowHeaders
 	cors.ExposeHeaders = serviceInfo.Options.CorsExposeHeaders

--- a/src/go/configgenerator/route_generator_test.go
+++ b/src/go/configgenerator/route_generator_test.go
@@ -16,6 +16,7 @@ package configgenerator
 
 import (
 	"fmt"
+	"time"
 	"strings"
 	"testing"
 
@@ -2745,7 +2746,7 @@ func TestMakeFallbackRoute(t *testing.T) {
 				},
 				},
 			},
-			params: []string{"basic", "http://example.com", "", "GET,POST,PUT,OPTIONS", "", ""},
+			params: []string{"basic", "http://example.com", "", "GET,POST,PUT,OPTIONS", "", "", "2m"},
 			wantRouteConfig: `
 {
   "name": "local_route",
@@ -2758,7 +2759,8 @@ func TestMakeFallbackRoute(t *testing.T) {
           {
             "exact": "http://example.com"
           }
-        ]
+        ],
+			  "maxAge":"120"
       },
       "domains": [
         "*"
@@ -3172,6 +3174,11 @@ func TestMakeFallbackRoute(t *testing.T) {
 				opts.CorsAllowMethods = tc.params[3]
 				opts.CorsAllowHeaders = tc.params[4]
 				opts.CorsExposeHeaders = tc.params[5]
+				var err error
+				opts.CorsMaxAge, err = time.ParseDuration(tc.params[6])
+				if err != nil {
+					t.Fatal(err)
+				}
 			}
 			fakeServiceInfo, err := configinfo.NewServiceInfoFromServiceConfig(tc.fakeServiceConfig, testConfigID, opts)
 			if err != nil {
@@ -3213,27 +3220,27 @@ func TestMakeRouteConfigForCors(t *testing.T) {
 		},
 		{
 			desc:        "Incorrect configured basic Cors",
-			params:      []string{"basic", "", `^https?://.+\\.example\\.com\/?$`, "", "", ""},
+			params:      []string{"basic", "", `^https?://.+\\.example\\.com\/?$`, "", "", "", "2m"},
 			wantedError: "cors_allow_origin cannot be empty when cors_preset=basic",
 		},
 		{
 			desc:        "Incorrect configured  Cors",
-			params:      []string{"", "", "", "GET", "", ""},
+			params:      []string{"", "", "", "GET", "", "", "2m"},
 			wantedError: "cors_preset must be set in order to enable CORS support",
 		},
 		{
 			desc:        "Incorrect configured regex Cors",
-			params:      []string{"cors_with_regexs", "", `^https?://.+\\.example\\.com\/?$`, "", "", ""},
+			params:      []string{"cors_with_regexs", "", `^https?://.+\\.example\\.com\/?$`, "", "", "", "2m"},
 			wantedError: `cors_preset must be either "basic" or "cors_with_regex"`,
 		},
 		{
 			desc:        "Oversize cors origin regex",
-			params:      []string{"cors_with_regex", "", getOverSizeRegexForTest(), "", "Origin,Content-Type,Accept", ""},
+			params:      []string{"cors_with_regex", "", getOverSizeRegexForTest(), "", "Origin,Content-Type,Accept", "", "2m"},
 			wantedError: `invalid cors origin regex: regex program size(1001) is larger than the max expected(1000)`,
 		},
 		{
 			desc:   "Correct configured basic Cors, with allow methods",
-			params: []string{"basic", "http://example.com", "", "GET,POST,PUT,OPTIONS", "", ""},
+			params: []string{"basic", "http://example.com", "", "GET,POST,PUT,OPTIONS", "", "", "2m"},
 			wantCorsPolicy: &routepb.CorsPolicy{
 				AllowOriginStringMatch: []*matcher.StringMatcher{
 					{
@@ -3244,11 +3251,12 @@ func TestMakeRouteConfigForCors(t *testing.T) {
 				},
 				AllowMethods:     "GET,POST,PUT,OPTIONS",
 				AllowCredentials: &wrapperspb.BoolValue{Value: false},
+				MaxAge: "120",
 			},
 		},
 		{
 			desc:   "Correct configured regex Cors, with allow headers",
-			params: []string{"cors_with_regex", "", `^https?://.+\\.example\\.com\/?$`, "", "Origin,Content-Type,Accept", ""},
+			params: []string{"cors_with_regex", "", `^https?://.+\\.example\\.com\/?$`, "", "Origin,Content-Type,Accept", "", "2m"},
 			wantCorsPolicy: &routepb.CorsPolicy{
 				AllowOriginStringMatch: []*matcher.StringMatcher{
 					{
@@ -3264,11 +3272,12 @@ func TestMakeRouteConfigForCors(t *testing.T) {
 				},
 				AllowHeaders:     "Origin,Content-Type,Accept",
 				AllowCredentials: &wrapperspb.BoolValue{Value: false},
+				MaxAge: "120",
 			},
 		},
 		{
 			desc:             "Correct configured regex Cors, with expose headers",
-			params:           []string{"cors_with_regex", "", `^https?://.+\\.example\\.com\/?$`, "", "", "Content-Length"},
+			params:           []string{"cors_with_regex", "", `^https?://.+\\.example\\.com\/?$`, "", "", "Content-Length", "2m"},
 			allowCredentials: true,
 			wantCorsPolicy: &routepb.CorsPolicy{
 				AllowOriginStringMatch: []*matcher.StringMatcher{
@@ -3285,6 +3294,7 @@ func TestMakeRouteConfigForCors(t *testing.T) {
 				},
 				ExposeHeaders:    "Content-Length",
 				AllowCredentials: &wrapperspb.BoolValue{Value: true},
+				MaxAge: "120",
 			},
 		},
 	}
@@ -3298,6 +3308,11 @@ func TestMakeRouteConfigForCors(t *testing.T) {
 			opts.CorsAllowMethods = tc.params[3]
 			opts.CorsAllowHeaders = tc.params[4]
 			opts.CorsExposeHeaders = tc.params[5]
+			var err error
+			opts.CorsMaxAge, err = time.ParseDuration(tc.params[6])
+			if err != nil {
+				t.Fatal(err)
+			}
 		}
 		opts.CorsAllowCredentials = tc.allowCredentials
 

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -39,6 +39,7 @@ var (
 	CorsAllowOrigin      = flag.String("cors_allow_origin", "", "set Access-Control-Allow-Origin to a specific origin")
 	CorsAllowOriginRegex = flag.String("cors_allow_origin_regex", "", "set Access-Control-Allow-Origin to a regular expression")
 	CorsExposeHeaders    = flag.String("cors_expose_headers", "", "set Access-Control-Expose-Headers to the specified headers")
+	CorsMaxAge           = flag.Duration("cors_max_age", 480 * time.Hour, "set Access-Control-Max-Age response header for CORS preflight request.")
 	CorsPreset           = flag.String("cors_preset", "", `enable CORS support, must be either "basic" or "cors_with_regex"`)
 
 	// Backend routing configurations.
@@ -175,6 +176,7 @@ func EnvoyConfigOptionsFromFlags() options.ConfigGeneratorOptions {
 		CorsAllowOrigin:                         *CorsAllowOrigin,
 		CorsAllowOriginRegex:                    *CorsAllowOriginRegex,
 		CorsExposeHeaders:                       *CorsExposeHeaders,
+		CorsMaxAge:                              *CorsMaxAge,
 		CorsPreset:                              *CorsPreset,
 		BackendDnsLookupFamily:                  *BackendDnsLookupFamily,
 		ClusterConnectTimeout:                   *ClusterConnectTimeout,

--- a/src/go/options/configgenerator.go
+++ b/src/go/options/configgenerator.go
@@ -35,6 +35,7 @@ type ConfigGeneratorOptions struct {
 	CorsAllowOrigin      string
 	CorsAllowOriginRegex string
 	CorsExposeHeaders    string
+	CorsMaxAge           time.Duration
 	CorsPreset           string
 
 	// Backend routing configurations.
@@ -154,5 +155,6 @@ func DefaultConfigGeneratorOptions() ConfigGeneratorOptions {
 		ScCheckRetries:                   -1,
 		ScQuotaRetries:                   -1,
 		ScReportRetries:                  -1,
+		CorsMaxAge:                       480 * time.Hour,
 	}
 }

--- a/tests/integration_test/cors_integration_test/cors_integration_test.go
+++ b/tests/integration_test/cors_integration_test/cors_integration_test.go
@@ -60,6 +60,7 @@ func TestProxyHandleCorsSimpleRequestsBasic(t *testing.T) {
 		origin            string
 		wantAllowOrigin   string
 		wantExposeHeaders string
+		wantMaxAge        string
 	}{
 		{
 			desc:              "CORS simple request origin matches, so there are CORS headers in response.",
@@ -136,6 +137,7 @@ func TestProxyHandleCorsSimpleRequestsRegex(t *testing.T) {
 		origin            string
 		wantAllowOrigin   string
 		wantExposeHeaders string
+		wantMaxAge        string
 	}{
 		{
 			desc:              "CORS simple request origin matches, so there are CORS headers in response.",
@@ -184,12 +186,14 @@ func TestProxyHandlesCorsPreflightRequestsBasic(t *testing.T) {
 	corsAllowHeadersValue := "DNT,User-Agent,Cache-Control,Content-Type,Authorization, X-PINGOTHER"
 	corsExposeHeadersValue := "Content-Length,Content-Range"
 	corsAllowCredentialsValue := "true"
+	corsMaxAgeValue := "7200"
 
 	args := []string{"--service=" + serviceName, "--service_config_id=" + configId,
 		"--rollout_strategy=fixed", "--cors_preset=basic",
 		"--cors_allow_origin=" + corsAllowOriginValue, "--cors_allow_methods=" + corsAllowMethodsValue,
 		"--cors_allow_headers=" + corsAllowHeadersValue,
-		"--cors_expose_headers=" + corsExposeHeadersValue, "--cors_allow_credentials"}
+		"--cors_expose_headers=" + corsExposeHeadersValue, "--cors_allow_credentials",
+	        "--cors_max_age=2h"}
 
 	s := env.NewTestEnv(platform.TestProxyHandlesCorsPreflightRequestsBasic, platform.EchoSidecar)
 	defer s.TearDown(t)
@@ -216,6 +220,7 @@ func TestProxyHandlesCorsPreflightRequestsBasic(t *testing.T) {
 				"Access-Control-Allow-Headers":     corsAllowHeadersValue,
 				"Access-Control-Expose-Headers":    corsExposeHeadersValue,
 				"Access-Control-Allow-Credentials": corsAllowCredentialsValue,
+				"Access-Control-Max-Age":           corsMaxAgeValue,
 			},
 		},
 		{
@@ -235,6 +240,7 @@ func TestProxyHandlesCorsPreflightRequestsBasic(t *testing.T) {
 				"Access-Control-Allow-Headers":     "",
 				"Access-Control-Expose-Headers":    "",
 				"Access-Control-Allow-Credentials": "",
+				"Access-Control-Max-Age":           "",
 			},
 		},
 		{
@@ -250,6 +256,7 @@ func TestProxyHandlesCorsPreflightRequestsBasic(t *testing.T) {
 				"Access-Control-Allow-Headers":     "",
 				"Access-Control-Expose-Headers":    "",
 				"Access-Control-Allow-Credentials": "",
+				"Access-Control-Max-Age":           "",
 			},
 		},
 		{
@@ -265,6 +272,7 @@ func TestProxyHandlesCorsPreflightRequestsBasic(t *testing.T) {
 				"Access-Control-Allow-Headers":     "",
 				"Access-Control-Expose-Headers":    "",
 				"Access-Control-Allow-Credentials": "",
+				"Access-Control-Max-Age":           "",
 			},
 		},
 	}
@@ -374,6 +382,7 @@ func TestGrpcBackendPreflightCors(t *testing.T) {
 			"Access-Control-Allow-Headers":     corsAllowHeadersValue,
 			"Access-Control-Expose-Headers":    corsExposeHeadersValue,
 			"Access-Control-Allow-Credentials": corsAllowCredentialsValue,
+			"Access-Control-Max-Age":           "1728000",
 		},
 	}
 

--- a/tests/start_proxy/start_proxy_test.py
+++ b/tests/start_proxy/start_proxy_test.py
@@ -276,6 +276,7 @@ class TestStartProxy(unittest.TestCase):
               '--cors_allow_methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
               '--cors_allow_headers', 'X-Requested-With',
               '--cors_expose_headers', 'Content-Length,Content-Range',
+              '--cors_max_age', "480h",
               '--service_account_key', '/tmp/service_accout_key', '--non_gcp',
               ]),
             # backend routing (with deprecated flag)


### PR DESCRIPTION
Add flag --cors_max_age to support configure Access-Control-Max-Age response header as proposed in https://github.com/GoogleCloudPlatform/esp-v2/issues/492#issuecomment-803006016.

Unit test is done. I'll do an e2e test after the image is built.

Fixes #492