### PR TITLE
b/182919834: Add options for path normalization and merge slashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,13 @@ upload-e2e-client-binaries: build-grpc-echo build-grpc-interop
 .PHONY: test test-debug test-envoy
 test: format
 	@echo "--> running unit tests"
+	@go test ./src/go/...
+	# The unit tests under src/go/serviceconfig reads/writes the global variable
+	# util.CallGoogleapis(no mutex proctection) plus the function code reads it,
+	# so it is easy to get into race condition when multiple test runs
+	# and skip them for race detection.
+	@go test -race $(shell go list ./src/go/... | grep -v serviceconfig) -count=1
+	@go test -msan ./src/go/...
 	@python3 -m unittest tests/start_proxy/start_proxy_test.py
 	@python3 -m unittest tests/start_proxy/env_start_proxy_test.py
 

--- a/Makefile
+++ b/Makefile
@@ -142,13 +142,6 @@ upload-e2e-client-binaries: build-grpc-echo build-grpc-interop
 .PHONY: test test-debug test-envoy
 test: format
 	@echo "--> running unit tests"
-	@go test ./src/go/...
-	# The unit tests under src/go/serviceconfig reads/writes the global variable
-	# util.CallGoogleapis(no mutex proctection) plus the function code reads it,
-	# so it is easy to get into race condition when multiple test runs
-	# and skip them for race detection.
-	@go test -race $(shell go list ./src/go/... | grep -v serviceconfig) -count=1
-	@go test -msan ./src/go/...
 	@python3 -m unittest tests/start_proxy/start_proxy_test.py
 	@python3 -m unittest tests/start_proxy/env_start_proxy_test.py
 

--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -350,6 +350,41 @@ environment variable or by passing "-k" flag to this script.
         help='''Allow headers contain underscores to pass through. By default
         ESPv2 rejects requests that have headers with underscores.''')
 
+    parser.add_argument('--normalize_path', action='store_true',
+        help='''Enable normalization of the `path` HTTP header according to
+        RFC 3986. It is recommended to turn on this option if your backend
+        performs path normalization by default.
+        
+        The following table provides examples of the request `path` the backend
+        will receive from ESPv2 based on the configuration of this flag.
+        
+        -----------------------------------------------------------------
+        | Request Path     | Without Normalization | With Normalization |
+        -----------------------------------------------------------------
+        | /hello/../world  | Rejected              | /world             |
+        | /%%4A            | /%%4A                 | /J                 |
+        | /%%4a            | /%%4a                 | /J                 |
+        -----------------------------------------------------------------
+        
+        By default, ESPv2 will not normalize paths.''')
+
+    parser.add_argument('--merge_slashes_in_path', action='store_true',
+        help='''Enable merging of adjacent slashes in the `path` HTTP header.
+        It is recommended to turn on this option if your backend
+        performs merging by default.
+        
+        The following table provides examples of the request `path` the backend
+        will receive from ESPv2 based on the configuration of this flag.
+        
+        -----------------------------------------------------------------
+        | Request Path     | Without Normalization | With Normalization |
+        -----------------------------------------------------------------
+        | /hello//world    | Rejected              | /hello/world       |
+        | /hello///        | Rejected              | /hello             |
+        -----------------------------------------------------------------
+        
+        By default, ESPv2 will not merge slashes.''')
+
     parser.add_argument(
         '--envoy_use_remote_address',
         action='store_true',
@@ -1001,6 +1036,10 @@ def gen_proxy_config(args):
 
     if args.underscores_in_headers:
         proxy_conf.append("--underscores_in_headers")
+    if args.normalize_path:
+        proxy_conf.append("--normalize_path")
+    if args.merge_slashes_in_path:
+        proxy_conf.append("--merge_slashes_in_path")
 
     if args.backend_retry_ons:
         proxy_conf.extend(["--backend_retry_ons", args.backend_retry_ons])

--- a/src/go/configgenerator/listener_generator.go
+++ b/src/go/configgenerator/listener_generator.go
@@ -189,6 +189,9 @@ func makeHttpConMgr(opts *options.ConfigGeneratorOptions, route *routepb.RouteCo
 				},
 			},
 		},
+		// Security options for `path` header.
+		NormalizePath: &wrapperspb.BoolValue{Value: opts.NormalizePath},
+		MergeSlashes:  opts.MergeSlashesInPath,
 	}
 
 	if opts.AccessLog != "" {

--- a/src/go/configgenerator/listener_generator.go
+++ b/src/go/configgenerator/listener_generator.go
@@ -189,9 +189,14 @@ func makeHttpConMgr(opts *options.ConfigGeneratorOptions, route *routepb.RouteCo
 				},
 			},
 		},
-		// Security options for `path` header.
-		NormalizePath: &wrapperspb.BoolValue{Value: opts.NormalizePath},
-		MergeSlashes:  opts.MergeSlashesInPath,
+	}
+
+	// Security options for `path` header.
+	if opts.NormalizePath {
+		httpConMgr.NormalizePath = &wrapperspb.BoolValue{Value: opts.NormalizePath}
+	}
+	if opts.MergeSlashesInPath {
+		httpConMgr.MergeSlashes = opts.MergeSlashesInPath
 	}
 
 	if opts.AccessLog != "" {

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -114,6 +114,8 @@ var (
 	SuppressEnvoyHeaders = flag.Bool("suppress_envoy_headers", true, `Do not add any additional x-envoy- headers to requests or responses. This only affects the router filter
 	generated *x-envoy-* headers, other Envoy filters and the HTTP connection manager may continue to set x-envoy- headers.`)
 	UnderscoresInHeaders = flag.Bool("underscores_in_headers", false, `When true, ESPv2 allows HTTP headers name has underscore and pass it through. Otherwise, rejects the request.`)
+	NormalizePath        = flag.Bool("normalize_path", true, ``)
+	MergeSlashesInPath   = flag.Bool("merge_slashes_in_path", true, ``)
 
 	ServiceControlNetworkFailOpen = flag.Bool("service_control_network_fail_open", true, ` In case of network failures when connecting to Google service control,
         the requests will be allowed if this flag is on. The default is on.`)
@@ -212,6 +214,8 @@ func EnvoyConfigOptionsFromFlags() options.ConfigGeneratorOptions {
 		MinStreamReportIntervalMs:               *MinStreamReportIntervalMs,
 		SuppressEnvoyHeaders:                    *SuppressEnvoyHeaders,
 		UnderscoresInHeaders:                    *UnderscoresInHeaders,
+		NormalizePath:                           *NormalizePath,
+		MergeSlashesInPath:                      *MergeSlashesInPath,
 		ServiceControlNetworkFailOpen:           *ServiceControlNetworkFailOpen,
 		EnableGrpcForHttp1:                      *EnableGrpcForHttp1,
 		ConnectionBufferLimitBytes:              *ConnectionBufferLimitBytes,

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -114,8 +114,8 @@ var (
 	SuppressEnvoyHeaders = flag.Bool("suppress_envoy_headers", true, `Do not add any additional x-envoy- headers to requests or responses. This only affects the router filter
 	generated *x-envoy-* headers, other Envoy filters and the HTTP connection manager may continue to set x-envoy- headers.`)
 	UnderscoresInHeaders = flag.Bool("underscores_in_headers", false, `When true, ESPv2 allows HTTP headers name has underscore and pass it through. Otherwise, rejects the request.`)
-	NormalizePath        = flag.Bool("normalize_path", true, ``)
-	MergeSlashesInPath   = flag.Bool("merge_slashes_in_path", true, ``)
+	NormalizePath        = flag.Bool("normalize_path", false, `Normalizes the path according to RFC 3986 before processing requests.`)
+	MergeSlashesInPath   = flag.Bool("merge_slashes_in_path", false, `Determines if adjacent slashes in the path are merged into one before processing requests.`)
 
 	ServiceControlNetworkFailOpen = flag.Bool("service_control_network_fail_open", true, ` In case of network failures when connecting to Google service control,
         the requests will be allowed if this flag is on. The default is on.`)

--- a/src/go/options/configgenerator.go
+++ b/src/go/options/configgenerator.go
@@ -156,7 +156,5 @@ func DefaultConfigGeneratorOptions() ConfigGeneratorOptions {
 		ScCheckRetries:                   -1,
 		ScQuotaRetries:                   -1,
 		ScReportRetries:                  -1,
-		NormalizePath:                    true,
-		MergeSlashesInPath:               true,
 	}
 }

--- a/src/go/options/configgenerator.go
+++ b/src/go/options/configgenerator.go
@@ -97,6 +97,8 @@ type ConfigGeneratorOptions struct {
 
 	SuppressEnvoyHeaders          bool
 	UnderscoresInHeaders          bool
+	NormalizePath                 bool
+	MergeSlashesInPath            bool
 	ServiceControlNetworkFailOpen bool
 	EnableGrpcForHttp1            bool
 	ConnectionBufferLimitBytes    int
@@ -154,5 +156,7 @@ func DefaultConfigGeneratorOptions() ConfigGeneratorOptions {
 		ScCheckRetries:                   -1,
 		ScQuotaRetries:                   -1,
 		ScReportRetries:                  -1,
+		NormalizePath:                    true,
+		MergeSlashesInPath:               true,
 	}
 }

--- a/tests/env/platform/ports.go
+++ b/tests/env/platform/ports.go
@@ -58,6 +58,7 @@ const (
 	TestDynamicGrpcBackendTLS
 	TestDynamicRouting
 	TestDynamicRoutingCorsByEnvoy
+	TestDynamicRoutingPathPreprocessing
 	TestDynamicRoutingWithAllowCors
 	TestFrontendAndBackendAuthHeaders
 	TestGeneratedHeaders

--- a/tests/start_proxy/start_proxy_test.py
+++ b/tests/start_proxy/start_proxy_test.py
@@ -595,6 +595,18 @@ class TestStartProxy(unittest.TestCase):
               '--append_response_headers', 'k1=v1;k2=v2',
               '--service_json_path', '/tmp/service_config.json',
               ]),
+            # Path security options.
+            (['--rollout_strategy=fixed',
+              '--service_json_path=/tmp/service_config.json',
+              '--normalize_path',
+              '--merge_slashes_in_path',
+              ],
+             ['bin/configmanager',  '--logtostderr', '--rollout_strategy', 'fixed',
+              '--backend_address', 'http://127.0.0.1:8082', '--v', '0',
+              '--service_json_path', '/tmp/service_config.json',
+              '--normalize_path',
+              '--merge_slashes_in_path',
+              ]),
         ]
 
         i = 0


### PR DESCRIPTION
See b/182919834#comment18 for more details on why we are adding this. It is useful for customers who want automatic translation of percent-encoded characters.
Since this is a breaking change, we keep it turned off by default.

Signed-off-by: Teju Nareddy <nareddyt@google.com>