### PR TITLE
b/185919750: upgrade to the latest 18.2

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -39,9 +39,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # 3) Check if envoy_build_config/extensions_build_config.bzl is up-to-date.
 # Try to match it with the one in source/extensions and comment out unneeded extensions.
 
-ENVOY_SHA1 = "d362e791eb9e4efa8d87f6d878740e72dc8330ac"  # 2021-04-15: v1.18.2
+ENVOY_SHA1 = "6bcb3a01baa018c2b1be99354ee25db0d40651e9"  # 2021-05-04: v1.18.2
 
-ENVOY_SHA256 = "ced848e0e319fee89ba2945aeeba30e81c2f07dc1e9089797b04c6b5c03e7445"
+ENVOY_SHA256 = "79bff2302302388c9f0551ca72a4a921c7cd300bbccd1ed925670b4b40ccdbc4"
 
 http_archive(
     name = "envoy",

--- a/examples/grpc_dynamic_routing/envoy_config.json
+++ b/examples/grpc_dynamic_routing/envoy_config.json
@@ -1045,9 +1045,6 @@
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
                               "idleTimeout": "400s",
-                              "maxStreamDuration": {
-                                "maxStreamDuration": "3600s"
-                              },
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -1086,9 +1083,6 @@
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
                               "idleTimeout": "400s",
-                              "maxStreamDuration": {
-                                "maxStreamDuration": "3600s"
-                              },
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -1127,9 +1121,6 @@
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
                               "idleTimeout": "400s",
-                              "maxStreamDuration": {
-                                "maxStreamDuration": "3600s"
-                              },
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -1164,9 +1155,6 @@
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
                               "idleTimeout": "400s",
-                              "maxStreamDuration": {
-                                "maxStreamDuration": "3600s"
-                              },
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -1337,9 +1325,6 @@
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
                               "idleTimeout": "400s",
-                              "maxStreamDuration": {
-                                "maxStreamDuration": "3600s"
-                              },
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"
@@ -1378,9 +1363,6 @@
                               "cluster": "backend-cluster-grpc-echo-oxouww7xzq-uc.a.run.app:443",
                               "hostRewriteLiteral": "grpc-echo-oxouww7xzq-uc.a.run.app",
                               "idleTimeout": "400s",
-                              "maxStreamDuration": {
-                                "maxStreamDuration": "3600s"
-                              },
                               "retryPolicy": {
                                 "numRetries": 1,
                                 "retryOn": "reset,connect-failure,refused-stream"

--- a/src/go/configgenerator/route_generator.go
+++ b/src/go/configgenerator/route_generator.go
@@ -25,7 +25,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/duration"
 
 	corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
@@ -375,18 +374,6 @@ func makeRouteTable(serviceInfo *configinfo.ServiceInfo) ([]*routepb.Route, []*r
 }
 
 func makeRoute(routeMatcher *routepb.RouteMatch, method *configinfo.MethodInfo) *routepb.Route {
-	var maxStreamDuration *routepb.RouteAction_MaxStreamDuration
-	// If `route.MaxStreamDuration` unset, it will pick up `route.Timeout`.
-	// Consider we don't have timeout setting for streaming case before, statically
-	// set a 1-hr stream timeout to workaround.
-	if method.IsStreaming {
-		maxStreamDuration = &routepb.RouteAction_MaxStreamDuration{
-			MaxStreamDuration: &duration.Duration{
-				Seconds: 3600,
-			},
-		}
-	}
-
 	return &routepb.Route{
 		Match: routeMatcher,
 		Action: &routepb.Route_Route{
@@ -402,7 +389,6 @@ func makeRoute(routeMatcher *routepb.RouteMatch, method *configinfo.MethodInfo) 
 						Value: uint32(method.BackendInfo.RetryNum),
 					},
 				},
-				MaxStreamDuration: maxStreamDuration,
 			},
 		},
 		Decorator: &routepb.Decorator{

--- a/tests/integration_test/http1_deadline_test/http1_deadline_test.go
+++ b/tests/integration_test/http1_deadline_test/http1_deadline_test.go
@@ -73,9 +73,9 @@ func TestDeadlinesForDynamicRouting(t *testing.T) {
 		},
 		{
 			desc:           "Fail before 20s due to ESPv2 default response timeout being 15s",
-			reqDuration:    time.Second * 25,
+			reqDuration:    time.Second * 20,
 			deadlineToTest: Default,
-			wantErr:        `408 Request Timeout, {"code":408,"message":"downstream duration timeout"}`,
+			wantErr:        `504 Gateway Timeout, {"code":504,"message":"upstream request timeout"}`,
 		},
 		{
 			desc:           "Success after 2s due to user-configured deadline being 5s",
@@ -86,7 +86,7 @@ func TestDeadlinesForDynamicRouting(t *testing.T) {
 			desc:           "Fail before 8s due to user-configured deadline being 5s",
 			reqDuration:    time.Second * 8,
 			deadlineToTest: Short,
-			wantErr:        `408 Request Timeout, {"code":408,"message":"downstream duration timeout"}`,
+			wantErr:        `504 Gateway Timeout, {"code":504,"message":"upstream request timeout"}`,
 		},
 	}
 
@@ -145,7 +145,7 @@ func TestDeadlinesForLocalBackend(t *testing.T) {
 		{
 			desc:        "Fail before 20s due to ESPv2 default response timeout being 15s",
 			reqDuration: time.Second * 20,
-			wantErr:     `408 Request Timeout, {"code":408,"message":"downstream duration timeout"}`,
+			wantErr:     `504 Gateway Timeout, {"code":504,"message":"upstream request timeout"}`,
 			path:        "/sleep",
 		},
 		{
@@ -157,7 +157,7 @@ func TestDeadlinesForLocalBackend(t *testing.T) {
 			desc:        "Fail before 8s due to user-configured deadline being 5s, even for a local backend.",
 			reqDuration: time.Second * 8,
 			path:        "/sleep/with/backend/rule",
-			wantErr:     `408 Request Timeout, {"code":408,"message":"downstream duration timeout"}`,
+			wantErr:     `504 Gateway Timeout, {"code":504,"message":"upstream request timeout"}`,
 		},
 	}
 
@@ -209,8 +209,7 @@ func TestIdleTimeoutsForUnaryRPCs(t *testing.T) {
 			}, utils.CommonArgs()...),
 			reqDuration:    time.Second * 20,
 			deadlineToTest: Default,
-			// TODO(b/185919750):deflake the timeout integration tests on 408 downstream timeout  and 504 upstream timeout.
-			wantErr: `timeout`,
+			wantErr:        `504 Gateway Timeout, {"code":504,"message":"upstream request timeout"}`,
 		},
 		{
 			// route deadline = 15s (default, not explicitly specified), global stream idle timeout = 5s, request = 10s
@@ -241,8 +240,7 @@ func TestIdleTimeoutsForUnaryRPCs(t *testing.T) {
 			}, utils.CommonArgs()...),
 			reqDuration:    time.Second * 8,
 			deadlineToTest: Short,
-			// TODO(b/185919750):deflake the timeout integration tests on 408 downstream timeout  and 504 upstream timeout.
-			wantErr: `timeout`,
+			wantErr:        `504 Gateway Timeout, {"code":504,"message":"upstream request timeout"}`,
 		},
 		{
 			// route deadline = 5s, global stream idle timeout = 2s, request = 8s
@@ -253,8 +251,7 @@ func TestIdleTimeoutsForUnaryRPCs(t *testing.T) {
 			}, utils.CommonArgs()...),
 			reqDuration:    time.Second * 8,
 			deadlineToTest: Short,
-			// TODO(b/185919750):deflake the timeout integration tests on 408 downstream timeout  and 504 upstream timeout.
-			wantErr: `timeout`,
+			wantErr:        `504 Gateway Timeout, {"code":504,"message":"upstream request timeout"}`,
 		},
 	}
 


### PR DESCRIPTION
Envoy just backport one bad PR from 18.2 in https://github.com/envoyproxy/envoy/pull/16289 so upgrade our envoy also.