### PR TITLE
b/187411694: add perTryTimeout for doing retry when the upstream times out

### DIFF
--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -523,10 +523,11 @@ environment variable or by passing "-k" flag to this script.
         '--backend_per_try_timeout_sec',
         default=None,
         help='''
-        The backend timeout per retry attempt in second. If unspecified, ESPv2 
-        will use the `deadline` in the `x-google-backend` extension. Consequently,
-        a request that times out will not be retried as the total timeout budget
-        would have been exhausted.
+        The backend timeout per retry attempt in second. Please note the `deadline`
+        in the `x-google-backend` extension is for the total timeout of request. 
+        If the flag is unspecified, ESPv2 will use the `deadline` in the 
+        `x-google-backend` extension. Consequently, a request that times out will
+        not be retried as the total timeout budget would have been exhausted.
         ''')
     parser.add_argument(
         '--access_log',

--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -520,6 +520,12 @@ environment variable or by passing "-k" flag to this script.
         The allowed number of retries. Must be >= 0 and defaults to 1. 
         ''')
     parser.add_argument(
+        '--backend_per_try_timeout_sec',
+        default=None,
+        help='''
+        The upstream timeout per retry attempt in second. If unspecified, a request that times out won't be retried.
+        ''')
+    parser.add_argument(
         '--access_log',
         help='''
         Path to a local file to which the access log entries will be written.
@@ -1046,6 +1052,9 @@ def gen_proxy_config(args):
 
     if args.backend_retry_num:
         proxy_conf.extend(["--backend_retry_num", args.backend_retry_num])
+
+    if args.backend_per_try_timeout_sec:
+        proxy_conf.extend(["--backend_per_try_timeout_sec", args.backend_per_try_timeout_sec])
 
     if args.access_log:
         proxy_conf.extend(["--access_log",

--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -520,15 +520,17 @@ environment variable or by passing "-k" flag to this script.
         The allowed number of retries. Must be >= 0 and defaults to 1. 
         ''')
     parser.add_argument(
-        '--backend_per_try_timeout_sec',
+        '--backend_per_try_timeout',
         default=None,
         help='''
-        The backend timeout per retry attempt in second. Please note the
-        `deadline` in the `x-google-backend` extension is the total time wait
-        for a full response from one request, including all retries. If the flag
-        is unspecified, ESPv2 will use the  `deadline` in the `x-google-backend`
-        extension. Consequently, a request that times out will not be retried as
-        the total timeout budget would have been exhausted.
+        The backend timeout per retry attempt. Valid time units are "ns", "us",
+        "ms", "s", "m", "h".
+        
+        Please note the `deadline` in the `x-google-backend` extension is the
+        total time wait for a full response from one request, including all
+        retries. If the flag is unspecified, ESPv2 will use the  `deadline` in
+        the `x-google-backend` extension. Consequently, a request that times out
+         will not be retried as the total timeout budget would have been exhausted.
         ''')
     parser.add_argument(
         '--access_log',
@@ -1058,8 +1060,8 @@ def gen_proxy_config(args):
     if args.backend_retry_num:
         proxy_conf.extend(["--backend_retry_num", args.backend_retry_num])
 
-    if args.backend_per_try_timeout_sec:
-        proxy_conf.extend(["--backend_per_try_timeout_sec", args.backend_per_try_timeout_sec])
+    if args.backend_per_try_timeout:
+        proxy_conf.extend(["--backend_per_try_timeout", args.backend_per_try_timeout])
 
     if args.access_log:
         proxy_conf.extend(["--access_log",

--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -523,11 +523,12 @@ environment variable or by passing "-k" flag to this script.
         '--backend_per_try_timeout_sec',
         default=None,
         help='''
-        The backend timeout per retry attempt in second. Please note the `deadline`
-        in the `x-google-backend` extension is for the total timeout of request. 
-        If the flag is unspecified, ESPv2 will use the `deadline` in the 
-        `x-google-backend` extension. Consequently, a request that times out will
-        not be retried as the total timeout budget would have been exhausted.
+        The backend timeout per retry attempt in second. Please note the
+        `deadline` in the `x-google-backend` extension is the total time wait
+        for a full response from one request, including all retries. If the flag
+        is unspecified, ESPv2 will use the  `deadline` in the `x-google-backend`
+        extension. Consequently, a request that times out will not be retried as
+        the total timeout budget would have been exhausted.
         ''')
     parser.add_argument(
         '--access_log',

--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -523,7 +523,10 @@ environment variable or by passing "-k" flag to this script.
         '--backend_per_try_timeout_sec',
         default=None,
         help='''
-        The upstream timeout per retry attempt in second. If unspecified, a request that times out won't be retried.
+        The backend timeout per retry attempt in second. If unspecified, ESPv2 
+        will use the `deadline` in the `x-google-backend` extension. Consequently,
+        a request that times out will not be retried as the total timeout budget
+        would have been exhausted.
         ''')
     parser.add_argument(
         '--access_log',

--- a/src/go/configgenerator/route_generator.go
+++ b/src/go/configgenerator/route_generator.go
@@ -22,14 +22,14 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/configinfo"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
-	"github.com/golang/glog"
-	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
-
 	corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	"github.com/golang/glog"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
 	anypb "github.com/golang/protobuf/ptypes/any"
+	"github.com/golang/protobuf/ptypes/duration"
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 )
 
@@ -374,6 +374,19 @@ func makeRouteTable(serviceInfo *configinfo.ServiceInfo) ([]*routepb.Route, []*r
 }
 
 func makeRoute(routeMatcher *routepb.RouteMatch, method *configinfo.MethodInfo) *routepb.Route {
+	retryPolicy := &routepb.RetryPolicy{
+		RetryOn: method.BackendInfo.RetryOns,
+		NumRetries: &wrapperspb.UInt32Value{
+			Value: uint32(method.BackendInfo.RetryNum),
+		},
+	}
+
+	if method.BackendInfo.PerTryTimeoutSec > 0 {
+		retryPolicy.PerTryTimeout = &duration.Duration{
+			Seconds: int64(method.BackendInfo.PerTryTimeoutSec),
+		}
+	}
+
 	return &routepb.Route{
 		Match: routeMatcher,
 		Action: &routepb.Route_Route{
@@ -383,12 +396,7 @@ func makeRoute(routeMatcher *routepb.RouteMatch, method *configinfo.MethodInfo) 
 				},
 				Timeout:     ptypes.DurationProto(method.BackendInfo.Deadline),
 				IdleTimeout: ptypes.DurationProto(method.BackendInfo.IdleTimeout),
-				RetryPolicy: &routepb.RetryPolicy{
-					RetryOn: method.BackendInfo.RetryOns,
-					NumRetries: &wrapperspb.UInt32Value{
-						Value: uint32(method.BackendInfo.RetryNum),
-					},
-				},
+				RetryPolicy: retryPolicy,
 			},
 		},
 		Decorator: &routepb.Decorator{

--- a/src/go/configgenerator/route_generator.go
+++ b/src/go/configgenerator/route_generator.go
@@ -22,14 +22,12 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/configinfo"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
-	"github.com/golang/glog"
-	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/duration"
-
 	corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	"github.com/golang/glog"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
 	anypb "github.com/golang/protobuf/ptypes/any"
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 )
@@ -382,10 +380,8 @@ func makeRoute(routeMatcher *routepb.RouteMatch, method *configinfo.MethodInfo) 
 		},
 	}
 
-	if method.BackendInfo.PerTryTimeoutSec > 0 {
-		retryPolicy.PerTryTimeout = &duration.Duration{
-			Seconds: int64(method.BackendInfo.PerTryTimeoutSec),
-		}
+	if method.BackendInfo.PerTryTimeout.Nanoseconds() > 0 {
+		retryPolicy.PerTryTimeout = ptypes.DurationProto(method.BackendInfo.PerTryTimeout)
 	}
 
 	return &routepb.Route{

--- a/src/go/configgenerator/route_generator.go
+++ b/src/go/configgenerator/route_generator.go
@@ -22,14 +22,15 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/configinfo"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
-	corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
-	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
-	anypb "github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/duration"
+
+	corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	anypb "github.com/golang/protobuf/ptypes/any"
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 )
 

--- a/src/go/configinfo/method_info.go
+++ b/src/go/configinfo/method_info.go
@@ -70,9 +70,9 @@ type backendInfo struct {
 	IdleTimeout time.Duration
 
 	// Retry setting on the backend.
-	RetryOns         string
-	RetryNum         uint
-	PerTryTimeoutSec uint
+	RetryOns      string
+	RetryNum      uint
+	PerTryTimeout time.Duration
 }
 
 type SnakeToJsonSegments = map[string]string

--- a/src/go/configinfo/method_info.go
+++ b/src/go/configinfo/method_info.go
@@ -70,8 +70,9 @@ type backendInfo struct {
 	IdleTimeout time.Duration
 
 	// Retry setting on the backend.
-	RetryOns string
-	RetryNum uint
+	RetryOns         string
+	RetryNum         uint
+	PerTryTimeoutSec uint
 }
 
 type SnakeToJsonSegments = map[string]string

--- a/src/go/configinfo/service_info.go
+++ b/src/go/configinfo/service_info.go
@@ -588,14 +588,15 @@ func (s *ServiceInfo) addBackendInfoToMethod(r *confpb.BackendRule, scheme strin
 	}
 
 	method.BackendInfo = &backendInfo{
-		ClusterName:     backendClusterName,
-		Path:            path,
-		Hostname:        hostname,
-		TranslationType: r.PathTranslation,
-		Deadline:        deadline,
-		IdleTimeout:     idleTimeout,
-		RetryOns:        s.Options.BackendRetryOns,
-		RetryNum:        s.Options.BackendRetryNum,
+		ClusterName:      backendClusterName,
+		Path:             path,
+		Hostname:         hostname,
+		TranslationType:  r.PathTranslation,
+		Deadline:         deadline,
+		IdleTimeout:      idleTimeout,
+		RetryOns:         s.Options.BackendRetryOns,
+		RetryNum:         s.Options.BackendRetryNum,
+		PerTryTimeoutSec: s.Options.BackendPerTryTimeoutSec,
 	}
 
 	jwtAud := s.determineBackendAuthJwtAud(r, scheme, hostname)
@@ -644,11 +645,12 @@ func (s *ServiceInfo) processLocalBackendOperations() error {
 
 		// Associate the method with the local backend.
 		method.BackendInfo = &backendInfo{
-			ClusterName: s.LocalBackendCluster.ClusterName,
-			Deadline:    util.DefaultResponseDeadline,
-			IdleTimeout: idleTimeout,
-			RetryOns:    s.Options.BackendRetryOns,
-			RetryNum:    s.Options.BackendRetryNum,
+			ClusterName:      s.LocalBackendCluster.ClusterName,
+			Deadline:         util.DefaultResponseDeadline,
+			IdleTimeout:      idleTimeout,
+			RetryOns:         s.Options.BackendRetryOns,
+			RetryNum:         s.Options.BackendRetryNum,
+			PerTryTimeoutSec: s.Options.BackendPerTryTimeoutSec,
 		}
 	}
 

--- a/src/go/configinfo/service_info.go
+++ b/src/go/configinfo/service_info.go
@@ -588,15 +588,15 @@ func (s *ServiceInfo) addBackendInfoToMethod(r *confpb.BackendRule, scheme strin
 	}
 
 	method.BackendInfo = &backendInfo{
-		ClusterName:      backendClusterName,
-		Path:             path,
-		Hostname:         hostname,
-		TranslationType:  r.PathTranslation,
-		Deadline:         deadline,
-		IdleTimeout:      idleTimeout,
-		RetryOns:         s.Options.BackendRetryOns,
-		RetryNum:         s.Options.BackendRetryNum,
-		PerTryTimeoutSec: s.Options.BackendPerTryTimeoutSec,
+		ClusterName:     backendClusterName,
+		Path:            path,
+		Hostname:        hostname,
+		TranslationType: r.PathTranslation,
+		Deadline:        deadline,
+		IdleTimeout:     idleTimeout,
+		RetryOns:        s.Options.BackendRetryOns,
+		RetryNum:        s.Options.BackendRetryNum,
+		PerTryTimeout:   s.Options.BackendPerTryTimeout,
 	}
 
 	jwtAud := s.determineBackendAuthJwtAud(r, scheme, hostname)
@@ -645,12 +645,12 @@ func (s *ServiceInfo) processLocalBackendOperations() error {
 
 		// Associate the method with the local backend.
 		method.BackendInfo = &backendInfo{
-			ClusterName:      s.LocalBackendCluster.ClusterName,
-			Deadline:         util.DefaultResponseDeadline,
-			IdleTimeout:      idleTimeout,
-			RetryOns:         s.Options.BackendRetryOns,
-			RetryNum:         s.Options.BackendRetryNum,
-			PerTryTimeoutSec: s.Options.BackendPerTryTimeoutSec,
+			ClusterName:   s.LocalBackendCluster.ClusterName,
+			Deadline:      util.DefaultResponseDeadline,
+			IdleTimeout:   idleTimeout,
+			RetryOns:      s.Options.BackendRetryOns,
+			RetryNum:      s.Options.BackendRetryNum,
+			PerTryTimeout: s.Options.BackendPerTryTimeout,
 		}
 	}
 

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -160,8 +160,12 @@ var (
         x-envoy-retry-grpc-on(https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-on).`)
 	BackendRetryNum = flag.Uint("backend_retry_num", 1,
 		`The allowed number of retries. Must be >= 0 and defaults to 1. This retry
-	setting will be applied to all the backends if you have multiple ones.`)
-	BackendPerTryTimeoutSec = flag.Uint("backend_per_try_timeout_sec", 0, "The upstream timeout per retry attempt in second. By default it is set with 0 and a request that times out won't be retried.")
+setting will be applied to all the backends if you have multiple ones.`)
+	BackendPerTryTimeoutSec = flag.Uint("backend_per_try_timeout_sec", 0,
+		`The backend timeout per retry attempt in second. A default value 0
+means it is unspecified and ESPv2 will use the "deadline" in the "x-google-backend"
+extension. Consequently, a request that times out will not be retried as the total
+timeout budget would have been exhausted.`)
 )
 
 func EnvoyConfigOptionsFromFlags() options.ConfigGeneratorOptions {

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -160,7 +160,7 @@ var (
         x-envoy-retry-grpc-on(https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-on).`)
 	BackendRetryNum = flag.Uint("backend_retry_num", 1,
 		`The allowed number of retries. Must be >= 0 and defaults to 1. This retry
-setting will be applied to all the backends if you have multiple ones.`)
+        setting will be applied to all the backends if you have multiple ones.`)
 	BackendPerTryTimeoutSec = flag.Uint("backend_per_try_timeout_sec", 0,
 		`The backend timeout per retry attempt in second. Please note the 
         "deadline"" in the "x-google-backend"" extension is the total time wait

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -161,11 +161,11 @@ var (
 	BackendRetryNum = flag.Uint("backend_retry_num", 1,
 		`The allowed number of retries. Must be >= 0 and defaults to 1. This retry
         setting will be applied to all the backends if you have multiple ones.`)
-	BackendPerTryTimeoutSec = flag.Uint("backend_per_try_timeout_sec", 0,
+	BackendPerTryTimeout = flag.Duration("backend_per_try_timeout", 0,
 		`The backend timeout per retry attempt in second. Please note the 
         "deadline"" in the "x-google-backend"" extension is the total time wait
         for a full response from one request, including all retries. By default,
-        backend_per_try_timeout_sec=0 means ESPv2 will use the  "deadline"" in
+        backend_per_try_timeout=0 means ESPv2 will use the  "deadline"" in
         the "x-google-backend" extension. Consequently, a request that times out
         will not be retried as the total timeout budget would have been exhausted.`)
 )
@@ -229,7 +229,7 @@ func EnvoyConfigOptionsFromFlags() options.ConfigGeneratorOptions {
 		JwksCacheDurationInS:                    *JwksCacheDurationInS,
 		BackendRetryOns:                         *BackendRetryOns,
 		BackendRetryNum:                         *BackendRetryNum,
-		BackendPerTryTimeoutSec:                 *BackendPerTryTimeoutSec,
+		BackendPerTryTimeout:                    *BackendPerTryTimeout,
 		ScCheckTimeoutMs:                        *ScCheckTimeoutMs,
 		ScQuotaTimeoutMs:                        *ScQuotaTimeoutMs,
 		ScReportTimeoutMs:                       *ScReportTimeoutMs,

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -161,6 +161,7 @@ var (
 	BackendRetryNum = flag.Uint("backend_retry_num", 1,
 		`The allowed number of retries. Must be >= 0 and defaults to 1. This retry
 	setting will be applied to all the backends if you have multiple ones.`)
+	BackendPerTryTimeoutSec = flag.Uint("backend_per_try_timeout_sec", 0, "The upstream timeout per retry attempt in second. If unspecified, a request that times out won't be retried.")
 )
 
 func EnvoyConfigOptionsFromFlags() options.ConfigGeneratorOptions {
@@ -222,6 +223,7 @@ func EnvoyConfigOptionsFromFlags() options.ConfigGeneratorOptions {
 		JwksCacheDurationInS:                    *JwksCacheDurationInS,
 		BackendRetryOns:                         *BackendRetryOns,
 		BackendRetryNum:                         *BackendRetryNum,
+		BackendPerTryTimeoutSec:                 *BackendPerTryTimeoutSec,
 		ScCheckTimeoutMs:                        *ScCheckTimeoutMs,
 		ScQuotaTimeoutMs:                        *ScQuotaTimeoutMs,
 		ScReportTimeoutMs:                       *ScReportTimeoutMs,

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -162,10 +162,11 @@ var (
 		`The allowed number of retries. Must be >= 0 and defaults to 1. This retry
 setting will be applied to all the backends if you have multiple ones.`)
 	BackendPerTryTimeoutSec = flag.Uint("backend_per_try_timeout_sec", 0,
-		`The backend timeout per retry attempt in second. A default value 0
-means it is unspecified and ESPv2 will use the "deadline" in the "x-google-backend"
-extension. Consequently, a request that times out will not be retried as the total
-timeout budget would have been exhausted.`)
+		`The backend timeout per retry attempt in second.  Please note the "deadline"
+in the "x-google-backend" extension is for the total timeout of request. By default,
+backend_per_try_timeout_sec=0 means it is unspecified and ESPv2 will use the
+"deadline" in the "x-google-backend" extension. Consequently, a request that
+times out will not be retried as the total timeout budget would have been exhausted.`)
 )
 
 func EnvoyConfigOptionsFromFlags() options.ConfigGeneratorOptions {

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -162,11 +162,12 @@ var (
 		`The allowed number of retries. Must be >= 0 and defaults to 1. This retry
 setting will be applied to all the backends if you have multiple ones.`)
 	BackendPerTryTimeoutSec = flag.Uint("backend_per_try_timeout_sec", 0,
-		`The backend timeout per retry attempt in second.  Please note the "deadline"
-in the "x-google-backend" extension is for the total timeout of request. By default,
-backend_per_try_timeout_sec=0 means it is unspecified and ESPv2 will use the
-"deadline" in the "x-google-backend" extension. Consequently, a request that
-times out will not be retried as the total timeout budget would have been exhausted.`)
+		`The backend timeout per retry attempt in second. Please note the 
+        "deadline"" in the "x-google-backend"" extension is the total time wait
+        for a full response from one request, including all retries. By default,
+        backend_per_try_timeout_sec=0 means ESPv2 will use the  "deadline"" in
+        the "x-google-backend" extension. Consequently, a request that times out
+        will not be retried as the total timeout budget would have been exhausted.`)
 )
 
 func EnvoyConfigOptionsFromFlags() options.ConfigGeneratorOptions {

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -161,7 +161,7 @@ var (
 	BackendRetryNum = flag.Uint("backend_retry_num", 1,
 		`The allowed number of retries. Must be >= 0 and defaults to 1. This retry
 	setting will be applied to all the backends if you have multiple ones.`)
-	BackendPerTryTimeoutSec = flag.Uint("backend_per_try_timeout_sec", 0, "The upstream timeout per retry attempt in second. If unspecified, a request that times out won't be retried.")
+	BackendPerTryTimeoutSec = flag.Uint("backend_per_try_timeout_sec", 0, "The upstream timeout per retry attempt in second. By default it is set with 0 and a request that times out won't be retried.")
 )
 
 func EnvoyConfigOptionsFromFlags() options.ConfigGeneratorOptions {

--- a/src/go/options/configgenerator.go
+++ b/src/go/options/configgenerator.go
@@ -109,11 +109,12 @@ type ConfigGeneratorOptions struct {
 	ScQuotaTimeoutMs  int
 	ScReportTimeoutMs int
 
-	BackendRetryOns string
-	BackendRetryNum uint
-	ScCheckRetries  int
-	ScQuotaRetries  int
-	ScReportRetries int
+	BackendRetryOns         string
+	BackendRetryNum         uint
+	BackendPerTryTimeoutSec uint
+	ScCheckRetries          int
+	ScQuotaRetries          int
+	ScReportRetries         int
 
 	ComputePlatformOverride string
 

--- a/src/go/options/configgenerator.go
+++ b/src/go/options/configgenerator.go
@@ -109,12 +109,12 @@ type ConfigGeneratorOptions struct {
 	ScQuotaTimeoutMs  int
 	ScReportTimeoutMs int
 
-	BackendRetryOns         string
-	BackendRetryNum         uint
-	BackendPerTryTimeoutSec uint
-	ScCheckRetries          int
-	ScQuotaRetries          int
-	ScReportRetries         int
+	BackendRetryOns      string
+	BackendRetryNum      uint
+	BackendPerTryTimeout time.Duration
+	ScCheckRetries       int
+	ScQuotaRetries       int
+	ScReportRetries      int
 
 	ComputePlatformOverride string
 

--- a/tests/env/platform/ports.go
+++ b/tests/env/platform/ports.go
@@ -44,14 +44,13 @@ const (
 	TestBackendAuthWithImdsIdTokenRetries
 	TestBackendAuthWithImdsIdTokenWhileAllowCors
 	TestBackendHttpProtocol
+	TestBackendPerTryTimeout
 	TestBackendRetry
 	TestCancellationReport
 	TestDeadlinesForDynamicRouting
 	TestDeadlinesForGrpcCatchAllBackend
 	TestDeadlinesForGrpcDynamicRouting
 	TestDeadlinesForLocalBackend
-	TestDifferentOriginPreflightCors
-	TestDifferentOriginSimpleCors
 	TestDnsResolver
 	TestDynamicBackendRoutingMutualTLS
 	TestDynamicBackendRoutingTLS

--- a/tests/integration_test/backend_retry_test/backend_retry_test.go
+++ b/tests/integration_test/backend_retry_test/backend_retry_test.go
@@ -344,8 +344,26 @@ func TestBackendPerTryTimeout(t *testing.T) {
 			// backend skip sleep after: 2
 			// route deadline: 5s
 			// retryNum: 2
-			// perRouteRetryTimeout: 2s
-			desc:                    "Successful request, `perRouteRetryTimeout` is set and `retryNum` is large enough",
+			// perRouteRetryTimeout: 4s
+			desc:                    "Successful request, `perRouteRetryTimeout` is set but too large",
+			backendRetryNumFlag:     2,
+			backendPerTryTimeoutSec: 4,
+			sleepLength:             "7s",
+			skipSleepAfter:          2,
+			wantError:               `504 Gateway Timeout, {"code":504,"message":"upstream request timeout"}`,
+			wantSpanNames: []string{
+				fmt.Sprintf("router backend-cluster-%v:BACKEND_PORT egress", platform.GetLoopbackAddress()),
+				fmt.Sprintf("router backend-cluster-%v:BACKEND_PORT egress", platform.GetLoopbackAddress()),
+				"ingress dynamic_routing_SleepDurationShort",
+			},
+		},
+		{
+			// backend sleep duration: 7s
+			// backend skip sleep after: 2
+			// route deadline: 5s
+			// retryNum: 2
+			// perRouteRetryTimeout: 1s
+			desc:                    "Successful request, `perRouteRetryTimeout` and `retryNum` are set appropriately",
 			backendRetryNumFlag:     2,
 			backendPerTryTimeoutSec: 1,
 			sleepLength:             "7s",
@@ -366,7 +384,7 @@ func TestBackendPerTryTimeout(t *testing.T) {
 				"--service_config_id=" + configId,
 				"--rollout_strategy=fixed",
 				"--suppress_envoy_headers",
-				"--backend_retry_ons=" +  defaultBackendRetryOns,
+				"--backend_retry_ons=" + defaultBackendRetryOns,
 				"--backend_retry_num=" + strconv.Itoa(tc.backendRetryNumFlag),
 				"--backend_per_try_timeout_sec=" + strconv.Itoa(tc.backendPerTryTimeoutSec),
 			}

--- a/tests/integration_test/backend_retry_test/backend_retry_test.go
+++ b/tests/integration_test/backend_retry_test/backend_retry_test.go
@@ -366,10 +366,10 @@ func TestBackendPerTryTimeout(t *testing.T) {
 				"--service_config_id=" + configId,
 				"--rollout_strategy=fixed",
 				"--suppress_envoy_headers",
+				"--backend_retry_ons=" +  defaultBackendRetryOns,
+				"--backend_retry_num=" + strconv.Itoa(tc.backendRetryNumFlag),
+				"--backend_per_try_timeout_sec=" + strconv.Itoa(tc.backendPerTryTimeoutSec),
 			}
-			args = append(args, fmt.Sprintf("--backend_retry_ons=%v", defaultBackendRetryOns))
-			args = append(args, fmt.Sprintf("--backend_retry_num=%v", tc.backendRetryNumFlag))
-			args = append(args, fmt.Sprintf("--backend_per_try_timeout_sec=%v", tc.backendPerTryTimeoutSec))
 
 			s := env.NewTestEnv(platform.TestBackendPerTryTimeout, platform.EchoRemote)
 			s.SetupFakeTraceServer(1)

--- a/tests/start_proxy/start_proxy_test.py
+++ b/tests/start_proxy/start_proxy_test.py
@@ -466,12 +466,12 @@ class TestStartProxy(unittest.TestCase):
               '--disable_tracing'
               ]),
             (['-R=managed',
-              '--http2_port=8079', '--backend_per_try_timeout_sec=10',
+              '--http2_port=8079', '--backend_per_try_timeout=10s',
               '--disable_tracing'],
              ['bin/configmanager', '--logtostderr', '--rollout_strategy', 'managed',
               '--backend_address', 'http://127.0.0.1:8082', '--v', '0',
               '--listener_port', '8079',
-              '--backend_per_try_timeout_sec', '10',
+              '--backend_per_try_timeout', '10s',
               '--disable_tracing'
               ]),
             # Service account key does not assume non-gcp

--- a/tests/start_proxy/start_proxy_test.py
+++ b/tests/start_proxy/start_proxy_test.py
@@ -465,6 +465,15 @@ class TestStartProxy(unittest.TestCase):
               '--backend_retry_num', '10',
               '--disable_tracing'
               ]),
+            (['-R=managed',
+              '--http2_port=8079', '--backend_per_try_timeout_sec=10',
+              '--disable_tracing'],
+             ['bin/configmanager', '--logtostderr', '--rollout_strategy', 'managed',
+              '--backend_address', 'http://127.0.0.1:8082', '--v', '0',
+              '--listener_port', '8079',
+              '--backend_per_try_timeout_sec', '10',
+              '--disable_tracing'
+              ]),
             # Service account key does not assume non-gcp
             # and does not disable tracing.
             (['--service=test_bookstore.gloud.run',


### PR DESCRIPTION
When the upstream times out, ESPv2 won't do retry currently as the route timeout has been exhausted. Add `per_try_timeout_sec` flag to allow doing retry in this case. Though this flag is related to the route timeout(set in the service config), there is no need to have it per API method/route and it is also more consistent to be together with other retry setting in deployment flags. 

**Context**: it is to fix https://github.com/GoogleCloudPlatform/esp-v2/issues/503, the response code detail of which is `upstream_response_timeout`.