### PR TITLE
b/187501317: Test gRPC streaming on Cloud Run

### DIFF
--- a/tests/e2e/client/grpc/grpc_stress_input.py
+++ b/tests/e2e/client/grpc/grpc_stress_input.py
@@ -144,15 +144,10 @@ if __name__ == "__main__":
 
     subtests = [
         SubtestEcho(),
+        SubtestEchoStream(),
+        SubtestEchoStreamAuthFail(),
+        SubtestEchoStreamNoApiKey(),
     ]
-
-    # TODO: When Cloud Run supports streaming RPCs, disable this check.
-    if not FLAGS.use_ssl:
-        subtests += [
-            SubtestEchoStream(),
-            SubtestEchoStreamAuthFail(),
-            SubtestEchoStreamNoApiKey(),
-        ]
 
     print json.dumps({
         'server_addr': FLAGS.server,

--- a/tests/e2e/scripts/cloud-run/deploy.sh
+++ b/tests/e2e/scripts/cloud-run/deploy.sh
@@ -149,7 +149,7 @@ function deployProxy() {
 
   case ${PROXY_PLATFORM} in
     "cloud-run")
-      args+=" --allow-unauthenticated --service-account=${PROXY_RUNTIME_SERVICE_ACCOUNT} --platform=managed"
+      args+=" --allow-unauthenticated --service-account=${PROXY_RUNTIME_SERVICE_ACCOUNT} --platform=managed --enable_debug"
       ;;
     "anthos-cloud-run")
       args+=" --platform=gke"

--- a/tests/e2e/scripts/cloud-run/deploy.sh
+++ b/tests/e2e/scripts/cloud-run/deploy.sh
@@ -149,7 +149,7 @@ function deployProxy() {
 
   case ${PROXY_PLATFORM} in
     "cloud-run")
-      args+=" --allow-unauthenticated --service-account=${PROXY_RUNTIME_SERVICE_ACCOUNT} --platform=managed --enable_debug"
+      args+=" --allow-unauthenticated --service-account=${PROXY_RUNTIME_SERVICE_ACCOUNT} --platform=managed"
       ;;
     "anthos-cloud-run")
       args+=" --platform=gke"
@@ -327,7 +327,7 @@ function setup() {
 
   # Redeploy ESPv2 to update the service config. Set flags as follows:
   # - Tracing: Support trace context propagation to the backend and from AppHosting.
-  proxy_args="^++^--tracing_sample_rate=0.05"
+  proxy_args="^++^--tracing_sample_rate=0.05++--enable_debug"
 
   if [[ ${PROXY_PLATFORM} == "cloud-run" ]];
   then


### PR DESCRIPTION
Cloud Run supports bidirectional streaming since earlier this year. Let's test it in our pre-existing e2e tests.