### PR TITLE
GCS Runner: Allow unknown static fields

### DIFF
--- a/src/go/gcsrunner/start_envoy.go
+++ b/src/go/gcsrunner/start_envoy.go
@@ -51,6 +51,7 @@ func StartEnvoyAndWait(signalChan chan os.Signal, opts StartEnvoyOptions) error 
 		"--log-path", opts.LogPath,
 		"--log-format", "%L%m%d %T.%e %t envoy] [%t][%n]%v",
 		"--log-format-escaped",
+		"--allow-unknown-static-fields",
 	}
 	if opts.ComponentLogLevel != "" {
 		startupFlags = append(startupFlags, "--component-log-level", opts.ComponentLogLevel)


### PR DESCRIPTION
This allows new fields to be consumed in accordance with standard SemVer
procedure. Otherwise, new features can become breaking changes.