### PR TITLE
GCS Runner: Handle deadline exceeded properly

### DIFF
--- a/src/go/gcsrunner/fetch_config.go
+++ b/src/go/gcsrunner/fetch_config.go
@@ -110,15 +110,15 @@ func readBytes(opts FetchConfigOptions) ([]byte, error) {
 	var reader io.Reader
 	var retryErr error
 	op := func() error {
-		r, err := client.readObject(ctx, getObjectRequest{
-			Bucket: opts.BucketName,
-			Object: opts.ConfigFileName,
-		})
-		if err == context.DeadlineExceeded {
+		if err := ctx.Err(); err != nil {
 			retryErr = err
 			// return nil to end the backoff
 			return nil
 		}
+		r, err := client.readObject(ctx, getObjectRequest{
+			Bucket: opts.BucketName,
+			Object: opts.ConfigFileName,
+		})
 		if err != nil {
 			glog.Errorf("error getting reader for object (retrying): %v", err)
 			return err


### PR DESCRIPTION
Previous behavior did not identify DeadlineExceeded because the error was being wrapped by the GCS Reader code. New behavior checks the ctx.Err() properly so that retry behavior halts correctly.