### PR TITLE
Update release scripts to allow patch release

### DIFF
--- a/scripts/release/release-changelog.sh
+++ b/scripts/release/release-changelog.sh
@@ -66,7 +66,7 @@ if [ "${DIRECTORY}" != "." ]; then
   push_tool ${DIRECTORY}
 fi
 
-if [ "${VERSION}" = ""]; then
+if [ "${VERSION}" = "" ]; then
   VERSION="$(command cat ${ROOT}/VERSION)" \
     || usage "Cannot determine release version (${ROOT}/VERSION)."
 fi

--- a/scripts/release/release-changelog.sh
+++ b/scripts/release/release-changelog.sh
@@ -27,7 +27,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 function usage() {
   [[ -n "${1}" ]] && echo "${1}"
   cat <<EOF
-usage: ${BASH_SOURCE[0]} -s <commit sha> -l <last release sha or tag> -d <directory>
+usage: ${BASH_SOURCE[0]} -s <commit sha> -l <last release sha or tag> -d <directory> [-n <current version number>]
 
 Generates changelog for changes between last release and current release.
 EOF

--- a/scripts/release/release-changelog.sh
+++ b/scripts/release/release-changelog.sh
@@ -48,11 +48,12 @@ SHA=""
 LAST_COMMIT=""
 DIRECTORY="."
 
-while getopts :s:l:d: arg; do
+while getopts :s:l:d:n: arg; do
   case ${arg} in
     s) SHA="${OPTARG}";;
     l) LAST_COMMIT="${OPTARG}";;
     d) DIRECTORY="${OPTARG}";;
+    n) VERSION="${OPTARG}";;
     *) usage "Invalid option: -${OPTARG}";;
   esac
 done
@@ -65,7 +66,10 @@ if [ "${DIRECTORY}" != "." ]; then
   push_tool ${DIRECTORY}
 fi
 
-VERSION=$(command cat ${ROOT}/VERSION)
+if [ "${VERSION}" = ""]; then
+  VERSION="$(command cat ${ROOT}/VERSION)" \
+    || usage "Cannot determine release version (${ROOT}/VERSION)."
+fi
 
 echo $(pwd)
 

--- a/scripts/release/release-new-branch.sh
+++ b/scripts/release/release-new-branch.sh
@@ -73,7 +73,7 @@ git push upstream ${SHA}:refs/heads/${RELEASE_BRANCH} \
 
 
 # When NEXT_VERSION is not equal to the current one,
-# assum doing a minor release 2.x.y -> 2.{x+1}.0, so
+# assume doing a minor release 2.x.y -> 2.{x+1}.0, so
 # update the version number and push for review.
 # Otherwise, it is a patch release, no need to update the `VERSION` file.
 if [ "${NEXT_VERSION}" != "${VERSION}" ]; then

--- a/scripts/release/release-new-branch.sh
+++ b/scripts/release/release-new-branch.sh
@@ -67,7 +67,7 @@ git fetch upstream \
   || error_exit "Could not fetch upstream."
 git branch ${RELEASE_BRANCH} ${SHA} \
   || error_exit "Could not create a local release branch."
-git push upstream ${SHA}:refs/heads/${RELEASE_BRANCH} \
+git push upstream -f ${SHA}:refs/heads/${RELEASE_BRANCH} \
   || error_exit "Failed to create a remote release branch."
 
 

--- a/scripts/release/release-new-branch.sh
+++ b/scripts/release/release-new-branch.sh
@@ -70,14 +70,17 @@ git branch ${RELEASE_BRANCH} ${SHA} \
 git push upstream ${SHA}:refs/heads/${RELEASE_BRANCH} \
   || error_exit "Failed to create a remote release branch."
 
-# Update the version number and push for review.
 MASTER_BRANCH="${VERSION}-master"
 git checkout -b "${MASTER_BRANCH}" upstream/master
-echo "${NEXT_VERSION}" > ${ROOT}/VERSION
 
-git add ${ROOT}/VERSION
-git commit -m "Update version number to ${NEXT_VERSION}."
-git push --set-upstream origin "${MASTER_BRANCH}"
+# Update the version number and push for review.
+# This is the minor release case.
+if ["${NEXT_VERSION}" != "${VERSION}"]; then
+  echo "${NEXT_VERSION}" > ${ROOT}/VERSION
+  git add ${ROOT}/VERSION
+  git commit -m "Update version number to ${NEXT_VERSION}."
+  git push --set-upstream origin "${MASTER_BRANCH}"
+fi
 
 git checkout ${RELEASE_BRANCH}
 

--- a/scripts/release/release-new-branch.sh
+++ b/scripts/release/release-new-branch.sh
@@ -77,7 +77,7 @@ git checkout -b "${MASTER_BRANCH}" upstream/master
 # assum doing a minor release 2.x.y -> 2.{x+1}.0, so
 # update the version number and push for review.
 # Otherwise, it is a patch release, no need to update the `VERSION` file.
-if ["${NEXT_VERSION}" != "${VERSION}"]; then
+if [ "${NEXT_VERSION}" != "${VERSION}" ]; then
   echo "${NEXT_VERSION}" > ${ROOT}/VERSION
   git add ${ROOT}/VERSION
   git commit -m "Update version number to ${NEXT_VERSION}."

--- a/scripts/release/release-new-branch.sh
+++ b/scripts/release/release-new-branch.sh
@@ -48,8 +48,8 @@ done
 
 [[ -n "${NEXT_VERSION}" ]] \
   || usage "Please provide the next release version."
-# The version format is: 1.2.0
-[[ "${NEXT_VERSION}" =~ [0-9]+\.[0-9]+\.0 ]] \
+# The version format is: 1.2.3
+[[ "${NEXT_VERSION}" =~ [0-9]+\.[0-9]+\.[0-9] ]] \
   || usage "Invalid version number: ${NEXT_VERSION}."
 [[ -n "${SHA}" ]] \
   || usage "Please provide the release SHA."
@@ -60,8 +60,8 @@ VERSION="$(command cat ${ROOT}/VERSION)"
 RELEASE_BRANCH=v${VERSION%.0}.x
 echo "Current branch: ${CURRENT_BRANCH}."
 echo "New release branch: ${RELEASE_BRANCH}."
-[[ -z $(git diff --name-only) ]] \
-  || error_exit "Current branch is not clean."
+# [[ -z $(git diff --name-only) ]] \
+#   || error_exit "Current branch is not clean."
 
 git fetch upstream \
   || error_exit "Could not fetch upstream."
@@ -73,15 +73,16 @@ git push upstream ${SHA}:refs/heads/${RELEASE_BRANCH} \
 MASTER_BRANCH="${VERSION}-master"
 git checkout -b "${MASTER_BRANCH}" upstream/master
 
-# Update the version number and push for review.
-# This is the minor release case.
+# When NEXT_VERSION is not equal to the current one,
+# assum doing a minor release 2.x.y -> 2.{x+1}.0, so
+# update the version number and push for review.
+# Otherwise, it is a patch release, no need to update the `VERSION` file.
 if ["${NEXT_VERSION}" != "${VERSION}"]; then
   echo "${NEXT_VERSION}" > ${ROOT}/VERSION
   git add ${ROOT}/VERSION
   git commit -m "Update version number to ${NEXT_VERSION}."
   git push --set-upstream origin "${MASTER_BRANCH}"
 fi
-
 git checkout ${RELEASE_BRANCH}
 
 printf '\e[31m

--- a/scripts/release/release-new-branch.sh
+++ b/scripts/release/release-new-branch.sh
@@ -67,7 +67,7 @@ git fetch upstream \
   || error_exit "Could not fetch upstream."
 git branch ${RELEASE_BRANCH} ${SHA} \
   || error_exit "Could not create a local release branch."
-git push upstream -f ${SHA}:refs/heads/${RELEASE_BRANCH} \
+git push upstream ${SHA}:refs/heads/${RELEASE_BRANCH} \
   || error_exit "Failed to create a remote release branch."
 
 

--- a/scripts/release/release-new-branch.sh
+++ b/scripts/release/release-new-branch.sh
@@ -60,8 +60,8 @@ VERSION="$(command cat ${ROOT}/VERSION)"
 RELEASE_BRANCH=v${VERSION%.0}.x
 echo "Current branch: ${CURRENT_BRANCH}."
 echo "New release branch: ${RELEASE_BRANCH}."
-# [[ -z $(git diff --name-only) ]] \
-#   || error_exit "Current branch is not clean."
+[[ -z $(git diff --name-only) ]] \
+  || error_exit "Current branch is not clean."
 
 git fetch upstream \
   || error_exit "Could not fetch upstream."
@@ -70,14 +70,15 @@ git branch ${RELEASE_BRANCH} ${SHA} \
 git push upstream ${SHA}:refs/heads/${RELEASE_BRANCH} \
   || error_exit "Failed to create a remote release branch."
 
-MASTER_BRANCH="${VERSION}-master"
-git checkout -b "${MASTER_BRANCH}" upstream/master
+
 
 # When NEXT_VERSION is not equal to the current one,
 # assum doing a minor release 2.x.y -> 2.{x+1}.0, so
 # update the version number and push for review.
 # Otherwise, it is a patch release, no need to update the `VERSION` file.
 if [ "${NEXT_VERSION}" != "${VERSION}" ]; then
+  MASTER_BRANCH="${VERSION}-master"
+  git checkout -b "${MASTER_BRANCH}" upstream/master
   echo "${NEXT_VERSION}" > ${ROOT}/VERSION
   git add ${ROOT}/VERSION
   git commit -m "Update version number to ${NEXT_VERSION}."

--- a/scripts/release/release-publish.sh
+++ b/scripts/release/release-publish.sh
@@ -29,7 +29,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 function usage() {
   [[ -n "${1}" ]] && echo "${1}"
   cat <<EOF
-usage: ${BASH_SOURCE[0]} -s <commit sha> [options]"
+usage: ${BASH_SOURCE[0]} -s <commit sha> [options]  [-n <current version number>]"
 
 options are:
   -g <path_to_gcloud>

--- a/scripts/release/release-stable.sh
+++ b/scripts/release/release-stable.sh
@@ -22,7 +22,7 @@ function usage() {
   [[ -n "${1}" ]] && echo "${1}"
   cat << END_USAGE
 
-Usage: ${BASH_SOURCE[0]} -r <DIRECT_REPO>
+Usage: ${BASH_SOURCE[0]} [-n <CURRENT_VERSION>]
 
 This script will release stable ESPv2 docker image with format of:
   $(get_proxy_image_release_name):\${MINOR_BASE_VERSION}
@@ -38,9 +38,21 @@ where:
 END_USAGE
   exit 1
 }
+
+
+while getopts :n: arg; do
+  case ${arg} in
+    n) VERSION="${OPTARG}";;
+    *) usage "Invalid option: -${OPTARG}";;
+  esac
+done
 set -x
 
-VERSION="$(command cat ${ROOT}/VERSION)"
+if [ "${VERSION}" = ""]; then
+  VERSION="$(command cat ${ROOT}/VERSION)" \
+    || usage "Cannot determine release version (${ROOT}/VERSION)."
+fi
+
 # Minor base is 1.33  if version is 1.33.0
 MINOR_BASE_VERSION=${VERSION%.*}
 # Major base is 1  if version is 1.33.0

--- a/scripts/release/release-stable.sh
+++ b/scripts/release/release-stable.sh
@@ -22,7 +22,7 @@ function usage() {
   [[ -n "${1}" ]] && echo "${1}"
   cat << END_USAGE
 
-Usage: ${BASH_SOURCE[0]} [-n <CURRENT_VERSION>]
+Usage: ${BASH_SOURCE[0]}  [-n <current version number>]
 
 This script will release stable ESPv2 docker image with format of:
   $(get_proxy_image_release_name):\${MINOR_BASE_VERSION}

--- a/scripts/release/release-tag-git.sh
+++ b/scripts/release/release-tag-git.sh
@@ -22,7 +22,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 function usage() {
   [[ -n "${1}" ]] && echo "${1}"
   cat <<EOF
-usage: ${BASH_SOURCE[0]} -t <tag git ref> -b <build git ref>"
+usage: ${BASH_SOURCE[0]} -t <tag git ref> -b <build git ref>  [-n <current version number>]"
 
 tag git ref: commit which to tag with the release
     (typically release branch HEAD)

--- a/scripts/release/release-tag-git.sh
+++ b/scripts/release/release-tag-git.sh
@@ -41,10 +41,11 @@ EOF
 BUILD_REF=''
 TAG_REF=''
 
-while getopts :b:t: arg; do
+while getopts :b:t:n: arg; do
   case ${arg} in
     b) BUILD_REF="${OPTARG}";;
     t) TAG_REF="${OPTARG}";;
+    n) VERSION="${OPTARG}";;
     *) usage "Invalid option: -${OPTARG}";;
   esac
 done
@@ -59,8 +60,10 @@ BUILD_SHA=$(git rev-parse --verify "${BUILD_REF}") \
 TAG_SHA=$(git rev-parse --verify "${TAG_REF}") \
   || usage "Invalid Git reference \"${TAG_REF}\"."
 
-VERSION="$(command cat ${ROOT}/VERSION)" \
-  || usage "Cannot determine release version (${ROOT}/VERSION)."
+if [ "${VERSION}" = ""]; then
+  VERSION="$(command cat ${ROOT}/VERSION)" \
+    || usage "Cannot determine release version (${ROOT}/VERSION)."
+fi
 # Prefix 'v' for the tag name
 VERSION_TAG="v${VERSION}"
 


### PR DESCRIPTION
Update the scripts to support patch release. Our release manual has been updated and please review that also.

**Details:** currently scripts use `NEXT_VERSION_NUMBER` in `VERSION` to be the next version number and increment it each time as minor release. Pass `CURRENT_VERSION_NUMBER` to denote it is patch release and don't increment the version number.