### PR TITLE
b/188808823: Simplify CORS regex and fix brittle tests

### DIFF
--- a/src/go/configgenerator/route_generator_test.go
+++ b/src/go/configgenerator/route_generator_test.go
@@ -3487,7 +3487,7 @@ func getOverSizeRegexForTest() string {
 	overSizeRegex := ""
 	for i := 0; i < 333; i += 1 {
 		// Form regex in a way that it cannot be simplified.
-		overSizeRegex += "/**/a"
+		overSizeRegex += "[abc]+123"
 	}
 	return overSizeRegex
 }

--- a/src/go/configgenerator/route_generator_test.go
+++ b/src/go/configgenerator/route_generator_test.go
@@ -3236,7 +3236,7 @@ func TestMakeRouteConfigForCors(t *testing.T) {
 		{
 			desc:        "Oversize cors origin regex",
 			params:      []string{"cors_with_regex", "", getOverSizeRegexForTest(), "", "Origin,Content-Type,Accept", "", "2m"},
-			wantedError: `invalid cors origin regex: regex program size(1001) is larger than the max expected(1000)`,
+			wantedError: `invalid cors origin regex: regex program size`,
 		},
 		{
 			desc:   "Correct configured basic Cors, with allow methods",
@@ -3487,7 +3487,7 @@ func getOverSizeRegexForTest() string {
 	overSizeRegex := ""
 	for i := 0; i < 333; i += 1 {
 		// Use "/**" as it is a replacement token for wildcard uri template.
-		overSizeRegex += "/**"
+		overSizeRegex += "/**/a"
 	}
 	return overSizeRegex
 }

--- a/src/go/configgenerator/route_generator_test.go
+++ b/src/go/configgenerator/route_generator_test.go
@@ -3482,11 +3482,11 @@ func TestHeadersToAdd(t *testing.T) {
 	}
 }
 
-// Used to generate a oversize cors origin regex or a oversize wildcard uri template.
+// Used to generate a oversize cors origin regex or a oversize uri template.
 func getOverSizeRegexForTest() string {
 	overSizeRegex := ""
 	for i := 0; i < 333; i += 1 {
-		// Use "/**" as it is a replacement token for wildcard uri template.
+		// Form regex in a way that it cannot be simplified.
 		overSizeRegex += "/**/a"
 	}
 	return overSizeRegex

--- a/src/go/util/regex.go
+++ b/src/go/util/regex.go
@@ -25,7 +25,8 @@ func ValidateRegexProgramSize(regex string, maxProgramSize int) error {
 		return err
 	}
 
-	prog, err := syntax.Compile(regParse)
+	regSimple := regParse.Simplify()
+	prog, err := syntax.Compile(regSimple)
 	if err != nil {
 		return err
 	}

--- a/src/go/util/regex_test.go
+++ b/src/go/util/regex_test.go
@@ -16,6 +16,7 @@ package util
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -30,7 +31,7 @@ func TestValidateRegexProgramSize(t *testing.T) {
 			desc:        "oversize regex",
 			regex:       "/**",
 			programSize: 1,
-			wantError:   fmt.Errorf("regex program size(5) is larger than the max expected(1): /**"),
+			wantError:   fmt.Errorf("regex program size"),
 		},
 		{
 			desc:        "invalid regex",
@@ -43,7 +44,7 @@ func TestValidateRegexProgramSize(t *testing.T) {
 	for _, tc := range testData {
 		err := ValidateRegexProgramSize(tc.regex, tc.programSize)
 		if err != nil {
-			if tc.wantError == nil || err.Error() != tc.wantError.Error() {
+			if tc.wantError == nil || !strings.Contains(err.Error(), tc.wantError.Error()) {
 				t.Errorf("Test (%v): \n got %v \nwant %v", tc.desc, err, tc.wantError)
 			}
 		} else if tc.wantError != nil {


### PR DESCRIPTION
go/go-brittle-errors. Checking the exact size breaks with this code change or a new go version.

Signed-off-by: Teju Nareddy <nareddyt@google.com>