### PR TITLE
b/188906398: Reduce backoff initial latency

### DIFF
--- a/src/go/gcsrunner/fetch_config.go
+++ b/src/go/gcsrunner/fetch_config.go
@@ -107,13 +107,10 @@ func readBytes(opts FetchConfigOptions) ([]byte, error) {
 	}
 	ebo := backoff.NewExponentialBackOff()
 	ebo.InitialInterval = opts.FetchGCSObjectInitialInterval
-	var reader io.Reader
-	var retryErr error
+	var out []byte
 	op := func() error {
 		if err := ctx.Err(); err != nil {
-			retryErr = err
-			// return nil to end the backoff
-			return nil
+			return backoff.Permanent(err)
 		}
 		r, err := client.readObject(ctx, getObjectRequest{
 			Bucket: opts.BucketName,
@@ -123,19 +120,17 @@ func readBytes(opts FetchConfigOptions) ([]byte, error) {
 			glog.Errorf("error getting reader for object (retrying): %v", err)
 			return err
 		}
-		reader = r
+		if out, err = ioutil.ReadAll(r); err != nil {
+			glog.Errorf("error reading object bytes (retrying): %v", err)
+			return err
+		}
 		return nil
 	}
 
 	if err := backoff.Retry(op, ebo); err != nil {
 		return nil, err
 	}
-
-	if retryErr != nil {
-		return nil, retryErr
-	}
-
-	return ioutil.ReadAll(reader)
+	return out, nil
 }
 
 func writeFile(b []byte, opts FetchConfigOptions) error {

--- a/src/go/gcsrunner/main/runner.go
+++ b/src/go/gcsrunner/main/runner.go
@@ -40,8 +40,8 @@ import (
 
 const (
 	envoyConfigPath               = "envoy.json"
-	fetchGCSObjectInitialInterval = 10 * time.Second
-	fetchGCSObjectTimeout         = 5 * time.Minute
+	fetchGCSObjectInitialInterval = 100 * time.Millisecond
+	fetchGCSObjectTimeout         = 3 * time.Minute
 	terminateEnvoyTimeout         = time.Minute
 )
 


### PR DESCRIPTION
* If the first fetch fails, 10 seconds is way too long to try again.
* Also include reading bytes in retry logic.

This should significantly reduce startup latency and CreateGateway operation times. 

TESTED=Manual