### PR TITLE
Fix python2 in scripts/release/release-stable.sh and space in scripts/release/release-stable.sh.

### DIFF
--- a/scripts/release/release-qualify.sh
+++ b/scripts/release/release-qualify.sh
@@ -53,7 +53,7 @@ function check_result() {
   local FILE=${1}
   local COMMIT=${2}
 
-  python - << EOF ${FILE} ${COMMIT}
+  python2 - << EOF ${FILE} ${COMMIT}
 import sys
 import json
 
@@ -117,7 +117,7 @@ echo "Downloading prow logs to '${LOGS}' directory."
 ${GSUTIL} -m -q cp -r "gs://apiproxy-continuous-long-run/${SHA}/logs/*" "${LOGS}/${SHA}/" 2>&1  \
  || error_exit "Failed to download logs from gs://apiproxy-continuous-long-run/${SHA}/logs/*"
 
-python "${ROOT}/scripts/release/validate_release.py"  \
+python2 "${ROOT}/scripts/release/validate_release.py"  \
  --commit_sha "${SHA}"  \
  --path "${LOGS}/${SHA}"  \
  || error_exit "Release is not qualified."

--- a/scripts/release/release-stable.sh
+++ b/scripts/release/release-stable.sh
@@ -48,7 +48,7 @@ while getopts :n: arg; do
 done
 set -x
 
-if [ "${VERSION}" = ""]; then
+if [ "${VERSION}" = "" ]; then
   VERSION="$(command cat ${ROOT}/VERSION)" \
     || usage "Cannot determine release version (${ROOT}/VERSION)."
 fi


### PR DESCRIPTION
- Change `python` to `python2` for `scripts/release/release-qualify.sh`
- Add a missing space for `scripts/release/release-stable.sh`