### PR TITLE
Add missing space in scripts/release/release-tag-git.sh

### DIFF
--- a/scripts/release/release-tag-git.sh
+++ b/scripts/release/release-tag-git.sh
@@ -60,7 +60,7 @@ BUILD_SHA=$(git rev-parse --verify "${BUILD_REF}") \
 TAG_SHA=$(git rev-parse --verify "${TAG_REF}") \
   || usage "Invalid Git reference \"${TAG_REF}\"."
 
-if [ "${VERSION}" = ""]; then
+if [ "${VERSION}" = "" ]; then
   VERSION="$(command cat ${ROOT}/VERSION)" \
     || usage "Cannot determine release version (${ROOT}/VERSION)."
 fi


### PR DESCRIPTION
Similar issue as https://github.com/GoogleCloudPlatform/esp-v2/pull/526. Otherwise it will complain
```
scripts/release/release-tag-git.sh: line 63: [: : unary operator expecte
```