### PR TITLE
Enable jwks async fetch by default

### DIFF
--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -496,6 +496,16 @@ environment variable or by passing "-k" flag to this script.
         otherwise, it will be rejected. Default is `open`.
         ''')
     parser.add_argument(
+        '--enable_jwks_async_fetch',
+        action='store_true',
+        default=False,
+        help='''
+        Enable JWKS fetching for JWT authentication to be done before processing any requests.
+        If disabled, JWKS fetching is done when processing the requests. Recommended to
+        enable it. The default is disabled to use the old behaviors for not to break any
+        production systems.'''
+    )
+    parser.add_argument(
         '--jwks_cache_duration_in_s',
         default=None,
         help='''
@@ -964,6 +974,8 @@ def gen_proxy_config(args):
         proxy_conf.extend(["--envoy_xff_num_trusted_hops",
                            '{}'.format(SERVERLESS_XFF_NUM_TRUSTED_HOPS)])
 
+    if args.enable_jwks_async_fetch:
+        proxy_conf.append("--enable_jwks_async_fetch")
     if args.jwks_cache_duration_in_s:
          proxy_conf.extend(["--jwks_cache_duration_in_s", args.jwks_cache_duration_in_s])
 

--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -496,14 +496,13 @@ environment variable or by passing "-k" flag to this script.
         otherwise, it will be rejected. Default is `open`.
         ''')
     parser.add_argument(
-        '--enable_jwks_async_fetch',
+        '--disable_jwks_async_fetch',
         action='store_true',
         default=False,
         help='''
-        Enable JWKS fetching for JWT authentication to be done before processing any requests.
-        If disabled, JWKS fetching is done when processing the requests. Recommended to
-        enable it. The default is disabled to use the old behaviors for not to break any
-        production systems.'''
+        Disable fetching JWKS for JWT authentication to be done before processing any requests.
+        If disabled, JWKS fetching is done when authenticating the JWT, the fetching will add
+        to the request processing latency. Default is enabled.'''
     )
     parser.add_argument(
         '--jwks_cache_duration_in_s',
@@ -974,8 +973,8 @@ def gen_proxy_config(args):
         proxy_conf.extend(["--envoy_xff_num_trusted_hops",
                            '{}'.format(SERVERLESS_XFF_NUM_TRUSTED_HOPS)])
 
-    if args.enable_jwks_async_fetch:
-        proxy_conf.append("--enable_jwks_async_fetch")
+    if args.disable_jwks_async_fetch:
+        proxy_conf.append("--disable_jwks_async_fetch")
     if args.jwks_cache_duration_in_s:
          proxy_conf.extend(["--jwks_cache_duration_in_s", args.jwks_cache_duration_in_s])
 

--- a/examples/auth/envoy_config.json
+++ b/examples/auth/envoy_config.json
@@ -188,6 +188,7 @@
                             "issuer": "123456789-compute@developer.gserviceaccount.com",
                             "payloadInMetadata": "jwt_payloads",
                             "remoteJwks": {
+                              "asyncFetch": {},
                               "cacheDuration": "300s",
                               "httpUri": {
                                 "cluster": "jwt-provider-cluster-www.googleapis.com:443",
@@ -217,6 +218,7 @@
                             "issuer": "https://securetoken.google.com/apiproxy-231719",
                             "payloadInMetadata": "jwt_payloads",
                             "remoteJwks": {
+                              "asyncFetch": {},
                               "cacheDuration": "300s",
                               "httpUri": {
                                 "cluster": "jwt-provider-cluster-www.googleapis.com:443",
@@ -246,6 +248,7 @@
                             "issuer": "https://accounts.google.com",
                             "payloadInMetadata": "jwt_payloads",
                             "remoteJwks": {
+                              "asyncFetch": {},
                               "cacheDuration": "300s",
                               "httpUri": {
                                 "cluster": "jwt-provider-cluster-www.googleapis.com:443",

--- a/examples/grpc_dynamic_routing/envoy_config.json
+++ b/examples/grpc_dynamic_routing/envoy_config.json
@@ -231,6 +231,7 @@
                             "issuer": "e2e-client-jwk@cloudesf-testing.iam.gserviceaccount.com",
                             "payloadInMetadata": "jwt_payloads",
                             "remoteJwks": {
+                              "asyncFetch": {},
                               "cacheDuration": "300s",
                               "httpUri": {
                                 "cluster": "jwt-provider-cluster-www.googleapis.com:443",

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go/storage v1.10.0
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/census-instrumentation/opencensus-proto v0.2.1
-	github.com/envoyproxy/go-control-plane v0.9.9-0.20210511190911-87d352569d55
+	github.com/envoyproxy/go-control-plane v0.9.10-0.20210610164852-fb7341bf5fd0
 	github.com/envoyproxy/protoc-gen-validate v0.1.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210511190911-87d352569d55 h1:JrfVk5s8JgPiHVnissaQqxXTLTBSQ2GXYdX7eXJCfL0=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210511190911-87d352569d55/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
+github.com/envoyproxy/go-control-plane v0.9.10-0.20210610164852-fb7341bf5fd0 h1:QDmIMQgK4FKQLoJf0A4S1X+1+/xOeAtrNKZeGk/3jno=
+github.com/envoyproxy/go-control-plane v0.9.10-0.20210610164852-fb7341bf5fd0/go.mod h1:+baROYa9cKpDyN21rZlsSq5zgBrZOrMTNu78Lm3fFJQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -167,6 +169,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/src/go/configgenerator/filterconfig/filter_gen_jwt_authn.go
+++ b/src/go/configgenerator/filterconfig/filter_gen_jwt_authn.go
@@ -76,7 +76,7 @@ var jaFilterGenFunc = func(serviceInfo *ci.ServiceInfo) (*hcmpb.HttpFilter, []*c
 				Seconds: int64(serviceInfo.Options.JwksCacheDurationInS),
 			},
 		}
-		if serviceInfo.Options.EnableJwksAsyncFetch {
+		if !serviceInfo.Options.DisableJwksAsyncFetch {
 			jwks.AsyncFetch = &jwtpb.JwksAsyncFetch{}
 		}
 

--- a/src/go/configgenerator/filterconfig/filter_gen_jwt_authn.go
+++ b/src/go/configgenerator/filterconfig/filter_gen_jwt_authn.go
@@ -64,21 +64,26 @@ var jaFilterGenFunc = func(serviceInfo *ci.ServiceInfo) (*hcmpb.HttpFilter, []*c
 			return nil, nil, err
 		}
 
+		jwks := &jwtpb.RemoteJwks{
+			HttpUri: &corepb.HttpUri{
+				Uri: provider.GetJwksUri(),
+				HttpUpstreamType: &corepb.HttpUri_Cluster{
+					Cluster: clusterName,
+				},
+				Timeout: ptypes.DurationProto(serviceInfo.Options.HttpRequestTimeout),
+			},
+			CacheDuration: &durationpb.Duration{
+				Seconds: int64(serviceInfo.Options.JwksCacheDurationInS),
+			},
+		}
+		if serviceInfo.Options.EnableJwksAsyncFetch {
+			jwks.AsyncFetch = &jwtpb.JwksAsyncFetch{}
+		}
+
 		jp := &jwtpb.JwtProvider{
 			Issuer: provider.GetIssuer(),
 			JwksSourceSpecifier: &jwtpb.JwtProvider_RemoteJwks{
-				RemoteJwks: &jwtpb.RemoteJwks{
-					HttpUri: &corepb.HttpUri{
-						Uri: provider.GetJwksUri(),
-						HttpUpstreamType: &corepb.HttpUri_Cluster{
-							Cluster: clusterName,
-						},
-						Timeout: ptypes.DurationProto(serviceInfo.Options.HttpRequestTimeout),
-					},
-					CacheDuration: &durationpb.Duration{
-						Seconds: int64(serviceInfo.Options.JwksCacheDurationInS),
-					},
-				},
+				RemoteJwks: jwks,
 			},
 			FromHeaders:          fromHeaders,
 			FromParams:           fromParams,

--- a/src/go/configgenerator/filterconfig/filter_gen_jwt_authn_test.go
+++ b/src/go/configgenerator/filterconfig/filter_gen_jwt_authn_test.go
@@ -29,9 +29,10 @@ import (
 
 func TestJwtAuthnFilter(t *testing.T) {
 	testData := []struct {
-		desc               string
-		fakeServiceConfig  *confpb.Service
-		wantJwtAuthnFilter string
+		desc                 string
+		fakeServiceConfig    *confpb.Service
+		enableJwksAsyncFetch bool
+		wantJwtAuthnFilter   string
 	}{
 		{
 			desc: "Success. Generate jwt authn filter with default jwt locations",
@@ -102,6 +103,89 @@ func TestJwtAuthnFilter(t *testing.T) {
                         "timeout": "30s",
                         "uri": "https://fake-jwks.com"
                     }
+                }
+            }
+        },
+        "requirementMap": {
+            "testapi.foo": {
+                "providerName": "auth_provider"
+            }
+        }
+    }
+}
+`,
+		},
+		{
+			desc: "Success. Generate jwt authn filter with default locations and enableJwksAsyncFetch",
+			fakeServiceConfig: &confpb.Service{
+				Name: testProjectName,
+				Apis: []*apipb.Api{
+					{
+						Name: "testapi",
+						Methods: []*apipb.Method{
+							{
+								Name: "foo",
+							},
+						},
+					},
+				},
+				SourceInfo: &confpb.SourceInfo{
+					SourceFiles: []*anypb.Any{content},
+				},
+				Authentication: &confpb.Authentication{
+					Providers: []*confpb.AuthProvider{
+						{
+							Id:      "auth_provider",
+							Issuer:  "issuer-0",
+							JwksUri: "https://fake-jwks.com",
+						},
+					},
+					Rules: []*confpb.AuthenticationRule{
+						{
+							Selector: "testapi.foo",
+							Requirements: []*confpb.AuthRequirement{
+								{
+									ProviderId: "auth_provider",
+								},
+							},
+						},
+					},
+				},
+			},
+			enableJwksAsyncFetch: true,
+			wantJwtAuthnFilter: `{
+    "name": "envoy.filters.http.jwt_authn",
+    "typedConfig": {
+        "@type": "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication",
+        "providers": {
+            "auth_provider": {
+                "audiences": [
+                    "https://bookstore.endpoints.project123.cloud.goog"
+                ],
+                "forward": true,
+                "forwardPayloadHeader": "X-Endpoint-API-UserInfo",
+                "fromHeaders": [
+                    {
+                        "name": "Authorization",
+                        "valuePrefix": "Bearer "
+                    },
+                    {
+                        "name": "X-Goog-Iap-Jwt-Assertion"
+                    }
+                ],
+                "fromParams": [
+                    "access_token"
+                ],
+                "issuer": "issuer-0",
+                "payloadInMetadata": "jwt_payloads",
+                "remoteJwks": {
+                    "cacheDuration": "300s",
+                    "httpUri": {
+                        "cluster": "jwt-provider-cluster-fake-jwks.com:443",
+                        "timeout": "30s",
+                        "uri": "https://fake-jwks.com"
+                    },
+                    "asyncFetch": {}
                 }
             }
         },
@@ -219,6 +303,7 @@ func TestJwtAuthnFilter(t *testing.T) {
 	for i, tc := range testData {
 		opts := options.DefaultConfigGeneratorOptions()
 		opts.BackendAddress = "grpc://127.0.0.0:80"
+		opts.EnableJwksAsyncFetch = tc.enableJwksAsyncFetch
 		fakeServiceInfo, err := configinfo.NewServiceInfoFromServiceConfig(tc.fakeServiceConfig, testConfigID, opts)
 		if err != nil {
 			t.Fatal(err)

--- a/src/go/configgenerator/filterconfig/filter_gen_jwt_authn_test.go
+++ b/src/go/configgenerator/filterconfig/filter_gen_jwt_authn_test.go
@@ -29,10 +29,10 @@ import (
 
 func TestJwtAuthnFilter(t *testing.T) {
 	testData := []struct {
-		desc                 string
-		fakeServiceConfig    *confpb.Service
-		enableJwksAsyncFetch bool
-		wantJwtAuthnFilter   string
+		desc                  string
+		fakeServiceConfig     *confpb.Service
+		disableJwksAsyncFetch bool
+		wantJwtAuthnFilter    string
 	}{
 		{
 			desc: "Success. Generate jwt authn filter with default jwt locations",
@@ -102,7 +102,8 @@ func TestJwtAuthnFilter(t *testing.T) {
                         "cluster": "jwt-provider-cluster-fake-jwks.com:443",
                         "timeout": "30s",
                         "uri": "https://fake-jwks.com"
-                    }
+                    },
+                    "asyncFetch": {}
                 }
             }
         },
@@ -116,7 +117,7 @@ func TestJwtAuthnFilter(t *testing.T) {
 `,
 		},
 		{
-			desc: "Success. Generate jwt authn filter with default locations and enableJwksAsyncFetch",
+			desc: "Success. Generate jwt authn filter with default locations and disableJwksAsyncFetch",
 			fakeServiceConfig: &confpb.Service{
 				Name: testProjectName,
 				Apis: []*apipb.Api{
@@ -152,7 +153,7 @@ func TestJwtAuthnFilter(t *testing.T) {
 					},
 				},
 			},
-			enableJwksAsyncFetch: true,
+			disableJwksAsyncFetch: true,
 			wantJwtAuthnFilter: `{
     "name": "envoy.filters.http.jwt_authn",
     "typedConfig": {
@@ -184,8 +185,7 @@ func TestJwtAuthnFilter(t *testing.T) {
                         "cluster": "jwt-provider-cluster-fake-jwks.com:443",
                         "timeout": "30s",
                         "uri": "https://fake-jwks.com"
-                    },
-                    "asyncFetch": {}
+                    }
                 }
             }
         },
@@ -277,7 +277,8 @@ func TestJwtAuthnFilter(t *testing.T) {
                         "cluster": "jwt-provider-cluster-fake-jwks.com:443",
                         "timeout": "30s",
                         "uri": "https://fake-jwks.com"
-                    }
+                    },
+                    "asyncFetch": {}
                 }
             }
         },
@@ -303,7 +304,7 @@ func TestJwtAuthnFilter(t *testing.T) {
 	for i, tc := range testData {
 		opts := options.DefaultConfigGeneratorOptions()
 		opts.BackendAddress = "grpc://127.0.0.0:80"
-		opts.EnableJwksAsyncFetch = tc.enableJwksAsyncFetch
+		opts.DisableJwksAsyncFetch = tc.disableJwksAsyncFetch
 		fakeServiceInfo, err := configinfo.NewServiceInfoFromServiceConfig(tc.fakeServiceConfig, testConfigID, opts)
 		if err != nil {
 			t.Fatal(err)

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -127,8 +127,8 @@ var (
 	ConnectionBufferLimitBytes = flag.Int("connection_buffer_limit_bytes", -1, `Configure the maximum amount of data that is buffered for each request/response body. 
 			If not provided, Envoy will decide the default value.`)
 
-	EnableJwksAsyncFetch = flag.Bool("enable_jwks_async_fetch", false, `When false, Jwks is fetched on-demand when processing the requests. When true, Jwks is fetched before processing any requests.`)
-	JwksCacheDurationInS = flag.Int("jwks_cache_duration_in_s", 300, "Specify JWT public key cache duration in seconds. The default is 5 minutes.")
+	DisableJwksAsyncFetch = flag.Bool("disable_jwks_async_fetch", false, `When the feature is enabled, JWKS is fetched before processing any requests. When disabled, JWKS is fetched on-demand when processing the requests.`)
+	JwksCacheDurationInS  = flag.Int("jwks_cache_duration_in_s", 300, "Specify JWT public key cache duration in seconds. The default is 5 minutes.")
 
 	ScCheckTimeoutMs  = flag.Int("service_control_check_timeout_ms", 0, `Set the timeout in millisecond for service control Check request. Must be > 0 and the default is 1000 if not set.`)
 	ScQuotaTimeoutMs  = flag.Int("service_control_quota_timeout_ms", 0, `Set the timeout in millisecond for service control Quota request. Must be > 0 and the default is 1000 if not set.`)
@@ -231,7 +231,7 @@ func EnvoyConfigOptionsFromFlags() options.ConfigGeneratorOptions {
 		ServiceControlNetworkFailOpen:           *ServiceControlNetworkFailOpen,
 		EnableGrpcForHttp1:                      *EnableGrpcForHttp1,
 		ConnectionBufferLimitBytes:              *ConnectionBufferLimitBytes,
-		EnableJwksAsyncFetch:                    *EnableJwksAsyncFetch,
+		DisableJwksAsyncFetch:                   *DisableJwksAsyncFetch,
 		JwksCacheDurationInS:                    *JwksCacheDurationInS,
 		BackendRetryOns:                         *BackendRetryOns,
 		BackendRetryNum:                         *BackendRetryNum,

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -127,6 +127,7 @@ var (
 	ConnectionBufferLimitBytes = flag.Int("connection_buffer_limit_bytes", -1, `Configure the maximum amount of data that is buffered for each request/response body. 
 			If not provided, Envoy will decide the default value.`)
 
+	EnableJwksAsyncFetch = flag.Bool("enable_jwks_async_fetch", false, `When false, Jwks is fetched on-demand when processing the requests. When true, Jwks is fetched before processing any requests.`)
 	JwksCacheDurationInS = flag.Int("jwks_cache_duration_in_s", 300, "Specify JWT public key cache duration in seconds. The default is 5 minutes.")
 
 	ScCheckTimeoutMs  = flag.Int("service_control_check_timeout_ms", 0, `Set the timeout in millisecond for service control Check request. Must be > 0 and the default is 1000 if not set.`)
@@ -230,6 +231,7 @@ func EnvoyConfigOptionsFromFlags() options.ConfigGeneratorOptions {
 		ServiceControlNetworkFailOpen:           *ServiceControlNetworkFailOpen,
 		EnableGrpcForHttp1:                      *EnableGrpcForHttp1,
 		ConnectionBufferLimitBytes:              *ConnectionBufferLimitBytes,
+		EnableJwksAsyncFetch:                    *EnableJwksAsyncFetch,
 		JwksCacheDurationInS:                    *JwksCacheDurationInS,
 		BackendRetryOns:                         *BackendRetryOns,
 		BackendRetryNum:                         *BackendRetryNum,

--- a/src/go/configmanager/testdata/test_fetch_listeners.go
+++ b/src/go/configmanager/testdata/test_fetch_listeners.go
@@ -345,7 +345,8 @@ var (
                           "cluster": "jwt-provider-cluster-$JWKSURI:443",
                           "timeout": "30s",
                           "uri": "$JWKSURI"
-                        }
+                        },
+                        "asyncFetch": {}
                       }
                     }
                   }
@@ -618,7 +619,8 @@ var (
                           "cluster": "jwt-provider-cluster-$JWKSURI:443",
                           "timeout": "30s",
                           "uri": "$JWKSURI"
-                        }
+                        },
+                        "asyncFetch": {}
                       }
                     }
                   }
@@ -1121,7 +1123,8 @@ var (
                           "cluster": "jwt-provider-cluster-$JWKSURI:443",
                           "timeout": "30s",
                           "uri": "$JWKSURI"
-                        }
+                        },
+                        "asyncFetch": {}
                       }
                     },
                     "firebase2": {
@@ -1150,7 +1153,8 @@ var (
                           "cluster": "jwt-provider-cluster-$JWKSURI:443",
                           "timeout": "30s",
                           "uri": "$JWKSURI"
-                        }
+                        },
+                        "asyncFetch": {}
                       }
                     }
                   }
@@ -2091,7 +2095,8 @@ var (
                           "cluster": "jwt-provider-cluster-$JWKSURI:443",
                           "timeout": "30s",
                           "uri": "$JWKSURI"
-                        }
+                        },
+                        "asyncFetch": {}
                       }
                     }
                   }

--- a/src/go/options/configgenerator.go
+++ b/src/go/options/configgenerator.go
@@ -106,8 +106,8 @@ type ConfigGeneratorOptions struct {
 	ConnectionBufferLimitBytes    int
 
 	// JwtAuthn related flags
-	EnableJwksAsyncFetch bool
-	JwksCacheDurationInS int
+	DisableJwksAsyncFetch bool
+	JwksCacheDurationInS  int
 
 	ScCheckTimeoutMs  int
 	ScQuotaTimeoutMs  int
@@ -142,7 +142,7 @@ func DefaultConfigGeneratorOptions() ConfigGeneratorOptions {
 		ClusterConnectTimeout:            20 * time.Second,
 		StreamIdleTimeout:                util.DefaultIdleTimeout,
 		EnvoyXffNumTrustedHops:           2,
-		EnableJwksAsyncFetch:             false,
+		DisableJwksAsyncFetch:            false,
 		JwksCacheDurationInS:             300,
 		ListenerAddress:                  "0.0.0.0",
 		ListenerPort:                     8080,

--- a/src/go/options/configgenerator.go
+++ b/src/go/options/configgenerator.go
@@ -105,6 +105,8 @@ type ConfigGeneratorOptions struct {
 	EnableGrpcForHttp1            bool
 	ConnectionBufferLimitBytes    int
 
+	// JwtAuthn related flags
+	EnableJwksAsyncFetch bool
 	JwksCacheDurationInS int
 
 	ScCheckTimeoutMs  int
@@ -140,6 +142,7 @@ func DefaultConfigGeneratorOptions() ConfigGeneratorOptions {
 		ClusterConnectTimeout:            20 * time.Second,
 		StreamIdleTimeout:                util.DefaultIdleTimeout,
 		EnvoyXffNumTrustedHops:           2,
+		EnableJwksAsyncFetch:             false,
 		JwksCacheDurationInS:             300,
 		ListenerAddress:                  "0.0.0.0",
 		ListenerPort:                     8080,

--- a/tests/env/platform/ports.go
+++ b/tests/env/platform/ports.go
@@ -33,6 +33,7 @@ const (
 	TestAsymmetricKeys
 	TestAuthAllowMissing
 	TestAuthJwksCache
+	TestAuthJwksAsyncFetch
 	TestBackendAddressOverride
 	TestBackendAuthDisableAuth
 	TestBackendAuthUsingIamIdTokenWithDelegates

--- a/tests/integration_test/auth_pkey_cache_test/auth_pkey_cache_test.go
+++ b/tests/integration_test/auth_pkey_cache_test/auth_pkey_cache_test.go
@@ -55,7 +55,7 @@ func TestAuthJwksCache(t *testing.T) {
 			wantResp:               `{"aud":["admin.cloud.goog","bookstore_test_client.cloud.goog"],"exp":4698318999,"iat":1544718999,"iss":"api-proxy-testing@cloud.goog","sub":"api-proxy-testing@cloud.goog"}`,
 		},
 		{
-			desc:                   "Success, the customized jwks cache duration is 1s so 10 request to the jwks provider will be made",
+			desc:                   "Success, the customized jwks cache duration is 1s so 5 request to the jwks provider will be made",
 			path:                   "/auth/info/auth0",
 			apiKey:                 "api-key",
 			method:                 "GET",
@@ -78,7 +78,6 @@ func TestAuthJwksCache(t *testing.T) {
 			if err := s.Setup(args); err != nil {
 				t.Fatalf("fail to setup test env, %v", err)
 			}
-			s.FakeJwtService.ResetReqCnt(provider)
 
 			var resp []byte
 			for i := 0; i < 5; i++ {
@@ -101,6 +100,91 @@ func TestAuthJwksCache(t *testing.T) {
 					t.Errorf("Test (%s): failed, pubkey of %s shoud be fetched %v times instead of %v times.", tc.desc, tc.wantRequestsToProvider.key, tc.wantRequestsToProvider.cnt, realCnt)
 				}
 			}
+		}()
+	}
+}
+
+func TestAuthJwksAsyncFetch(t *testing.T) {
+	t.Parallel()
+
+	provider := testdata.GoogleJwtProvider
+	type expectedRequestCount struct {
+		key    string
+		minCnt int
+	}
+	testData := []struct {
+		desc                 string
+		path                 string
+		method               string
+		token                string
+		apiKey               string
+		jwksCacheDurationInS int
+		initProviderCnt      *expectedRequestCount
+		sleep                int
+		afterProviderCnt     *expectedRequestCount
+		wantResp             string
+	}{
+		{
+			desc:   "Success, the default jwks cache duration is 300s so only 1 request to the jwks provider will be made",
+			path:   "/auth/info/auth0",
+			apiKey: "api-key",
+			method: "GET",
+			token:  testdata.FakeCloudTokenMultiAudiences,
+			// one fetch should happen at init
+			initProviderCnt: &expectedRequestCount{provider, 1},
+			// default cache expiration is 5 minutes, still 1 fetch.
+			afterProviderCnt: &expectedRequestCount{provider, 1},
+			wantResp:         `{"aud":["admin.cloud.goog","bookstore_test_client.cloud.goog"],"exp":4698318999,"iat":1544718999,"iss":"api-proxy-testing@cloud.goog","sub":"api-proxy-testing@cloud.goog"}`,
+		},
+		{
+			desc:                 "Success, the customized jwks cache duration is 1s so at least 5 request to the jwks provider will be made",
+			path:                 "/auth/info/auth0",
+			apiKey:               "api-key",
+			method:               "GET",
+			jwksCacheDurationInS: 1,
+			token:                testdata.FakeCloudTokenMultiAudiences,
+			// one fetch should happen at init
+			initProviderCnt: &expectedRequestCount{provider, 1},
+			// Only sleep 5 seconds, so at least 5 fetch since cache expiration is 1s
+			afterProviderCnt: &expectedRequestCount{provider, 5},
+			wantResp:         `{"aud":["admin.cloud.goog","bookstore_test_client.cloud.goog"],"exp":4698318999,"iat":1544718999,"iss":"api-proxy-testing@cloud.goog","sub":"api-proxy-testing@cloud.goog"}`,
+		},
+	}
+	for _, tc := range testData {
+		func() {
+			args := utils.CommonArgs()
+
+			s := env.NewTestEnv(platform.TestAuthJwksAsyncFetch, platform.EchoSidecar)
+			args = append(args, "--enable_jwks_async_fetch=true")
+			if tc.jwksCacheDurationInS != 0 {
+				args = append(args, fmt.Sprintf("--jwks_cache_duration_in_s=%v", tc.jwksCacheDurationInS))
+			}
+
+			defer s.TearDown(t)
+			if err := s.Setup(args); err != nil {
+				t.Fatalf("fail to setup test env, %v", err)
+			}
+
+			verifyProviderCnt := func(expected *expectedRequestCount) {
+				provider, ok := s.FakeJwtService.ProviderMap[expected.key]
+				if !ok {
+					t.Errorf("Test (%s): failed, the provider is not inited.", tc.desc)
+				} else if realCnt := provider.GetReqCnt(); realCnt < expected.minCnt {
+					t.Errorf("Test (%s): failed, pubkey of %s shoud be fetched at least %v times, but got %v times.", tc.desc, expected.key, expected.minCnt, realCnt)
+				}
+			}
+			verifyProviderCnt(tc.initProviderCnt)
+
+			var resp []byte
+			resp, _ = client.DoJWT(fmt.Sprintf("http://%v:%v", platform.GetLoopbackAddress(), s.Ports().ListenerPort), tc.method, tc.path, tc.apiKey, "", tc.token)
+			if !strings.Contains(string(resp), tc.wantResp) {
+				t.Errorf("Test (%s): failed\nexpected: %s\ngot: %s", tc.desc, tc.wantResp, string(resp))
+			}
+
+			// sleep 5 seconds
+			time.Sleep(time.Duration(5) * time.Second)
+
+			verifyProviderCnt(tc.afterProviderCnt)
 		}()
 	}
 }

--- a/tests/start_proxy/start_proxy_test.py
+++ b/tests/start_proxy/start_proxy_test.py
@@ -102,6 +102,21 @@ class TestStartProxy(unittest.TestCase):
               '--check_metadata', '--underscores_in_headers',
               '--disable_tracing'
               ]),
+            # enable_jwks_async_fetch
+            (['-R=managed','--enable_jwks_async_fetch',
+              '--http_port=8079', '--service_control_quota_retries=3',
+              '--service_control_report_timeout_ms=300',
+              '--check_metadata',
+              '--disable_tracing', '--underscores_in_headers'],
+             ['bin/configmanager', '--logtostderr', '--rollout_strategy', 'managed',
+              '--backend_address', 'http://127.0.0.1:8082', '--v', '0',
+              '--enable_jwks_async_fetch',
+              '--listener_port', '8079',
+              '--service_control_quota_retries', '3',
+              '--service_control_report_timeout_ms', '300',
+              '--check_metadata', '--underscores_in_headers',
+              '--disable_tracing'
+              ]),
             # service_control_network_fail_policy=open
             (['-R=managed','--enable_strict_transport_security',
               '--http_port=8079', '--service_control_quota_retries=3',

--- a/tests/start_proxy/start_proxy_test.py
+++ b/tests/start_proxy/start_proxy_test.py
@@ -103,14 +103,14 @@ class TestStartProxy(unittest.TestCase):
               '--disable_tracing'
               ]),
             # enable_jwks_async_fetch
-            (['-R=managed','--enable_jwks_async_fetch',
+            (['-R=managed','--disable_jwks_async_fetch',
               '--http_port=8079', '--service_control_quota_retries=3',
               '--service_control_report_timeout_ms=300',
               '--check_metadata',
               '--disable_tracing', '--underscores_in_headers'],
              ['bin/configmanager', '--logtostderr', '--rollout_strategy', 'managed',
               '--backend_address', 'http://127.0.0.1:8082', '--v', '0',
-              '--enable_jwks_async_fetch',
+              '--disable_jwks_async_fetch',
               '--listener_port', '8079',
               '--service_control_quota_retries', '3',
               '--service_control_report_timeout_ms', '300',


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

Enable remote jwks async fetch by default and add a flag `disable_jwks_async_fetch` to allow disabling it.