### PR TITLE
Add flag to enable operation name header

### DIFF
--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -256,6 +256,36 @@ environment variable or by passing "-k" flag to this script.
         For example: --append_response_header=key1=value1 --append_response_header=key2=value2.''')
 
     parser.add_argument(
+        '--enable_operation_name_header',
+        action='store_true',
+        help='''
+        When enabled, ESPv2 will attach the operation name of the matched route
+        in the request to the backend.
+        
+        The operation name:
+        - For OpenAPI: Is derived from the `operationId` field.
+        - For gRPC: Is the fully-qualified name of the RPC.
+        
+        The header will be attached with key `X-Endpoint-API-Operation-Name`.
+        
+        NOTE: We do NOT recommend relying on this feature. There are no
+        guarantees that the operation name will remain consistent across
+        multiple service configuration IDs.
+        
+        NOTE: If you are using this feature with OpenAPI,
+        please only use the last segment of the operation name. For example:
+        
+        `1.echo_api_endpoints_cloudesf_testing_cloud_goog.EchoHeader`
+        Your backend should parse past the last `.` and only use `EchoHeader`.
+        
+        NOTE: For OpenAPI, the operation name may not match the `operationId`
+        field exactly. For example, some sanitization may occur that only allows
+        alphanumeric characters. The exact sanitization is internal
+        implementation detail and is not guaranteed to be consistent.
+        '''
+    )
+
+    parser.add_argument(
         '-R',
         '--rollout_strategy',
         default=DEFAULT_ROLLOUT_STRATEGY,
@@ -1029,6 +1059,9 @@ def gen_proxy_config(args):
         proxy_conf.extend(["--add_response_headers", ";".join(args.add_response_header)])
     if args.append_response_header:
         proxy_conf.extend(["--append_response_headers", ";".join(args.append_response_header)])
+
+    if args.enable_operation_name_header:
+        proxy_conf.append("--enable_operation_name_header")
 
     # Generate self-signed cert if needed
     if args.generate_self_signed_cert:

--- a/src/go/configgenerator/route_generator.go
+++ b/src/go/configgenerator/route_generator.go
@@ -361,6 +361,21 @@ func makeRouteTable(serviceInfo *configinfo.ServiceInfo) ([]*routepb.Route, []*r
 					},
 				}
 			}
+
+			if serviceInfo.Options.EnableOperationNameHeader {
+				r.RequestHeadersToAdd = []*corepb.HeaderValueOption{
+					{
+						Header: &corepb.HeaderValue{
+							Key:   serviceInfo.Options.GeneratedHeaderPrefix + util.OperationHeaderSuffix,
+							Value: operation,
+						},
+						Append: &wrapperspb.BoolValue{
+							Value: false,
+						},
+					},
+				}
+			}
+
 			backendRoutes = append(backendRoutes, r)
 
 			jsonStr, err := util.ProtoToJson(r)

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -77,6 +77,7 @@ var (
          For example --add_response_headers=key1=value1;key2=value2. If a header is already in the response, its value will be replaced with the new one.`)
 	AppendResponseHeaders = flag.String("append_response_headers", "", `Append HTTP headers to the response before sent to the upstream backend. Multiple headers are separated by ';'.
          For example --append_response_headers=key1=value1;key2=value2. If a header is already in the response, the new value will be append.`)
+	EnableOperationNameHeader = flag.Bool("enable_operation_name_header", false, "If enabled, the operation name for the matched route will be sent to the upstream as a request header.")
 
 	// Flags for non_gcp deployment.
 	ServiceAccountKey = flag.String("service_account_key", "", `Use the service account key JSON file to access the service control and the
@@ -210,6 +211,7 @@ func EnvoyConfigOptionsFromFlags() options.ConfigGeneratorOptions {
 		AppendRequestHeaders:                    *AppendRequestHeaders,
 		AddResponseHeaders:                      *AddResponseHeaders,
 		AppendResponseHeaders:                   *AppendResponseHeaders,
+		EnableOperationNameHeader:               *EnableOperationNameHeader,
 		ServiceAccountKey:                       *ServiceAccountKey,
 		TokenAgentPort:                          *TokenAgentPort,
 		DisableOidcDiscovery:                    *DisableOidcDiscovery,

--- a/src/go/options/configgenerator.go
+++ b/src/go/options/configgenerator.go
@@ -67,10 +67,11 @@ type ConfigGeneratorOptions struct {
 	DnsResolverAddresses             string
 
 	// Headers manipulation:
-	AddRequestHeaders     string
-	AppendRequestHeaders  string
-	AddResponseHeaders    string
-	AppendResponseHeaders string
+	AddRequestHeaders         string
+	AppendRequestHeaders      string
+	AddResponseHeaders        string
+	AppendResponseHeaders     string
+	EnableOperationNameHeader bool
 
 	// Flags for non_gcp deployment.
 	ServiceAccountKey string

--- a/src/go/util/util.go
+++ b/src/go/util/util.go
@@ -124,6 +124,9 @@ const (
 
 	// The stat prefix.
 	StatPrefix = "ingress_http"
+
+	// The suffix that forms the operation name header.
+	OperationHeaderSuffix = "Api-Operation-Name"
 )
 
 type BackendProtocol int32

--- a/tests/start_proxy/start_proxy_test.py
+++ b/tests/start_proxy/start_proxy_test.py
@@ -626,6 +626,16 @@ class TestStartProxy(unittest.TestCase):
               '--service_json_path', '/tmp/service_config.json',
               '--disallow_escaped_slashes_in_path',
               ]),
+            # Operation name header.
+            (['--rollout_strategy=fixed',
+              '--service_json_path=/tmp/service_config.json',
+              '--enable_operation_name_header'
+              ],
+             ['bin/configmanager',  '--logtostderr', '--rollout_strategy', 'fixed',
+              '--backend_address', 'http://127.0.0.1:8082', '--v', '0',
+              '--enable_operation_name_header',
+              '--service_json_path', '/tmp/service_config.json',
+              ]),
         ]
 
         i = 0


### PR DESCRIPTION
**Description**: Add a flag `--enable_operation_name_header` that will include the matched operation in the request headers to the backend. I hardcoded the header name to be consistent with the other `X-Endpoint-*` headers, I do not see any need for users to configure the name of the header. By default is it turned off. When enabled, it will look like:

```
X-Endpoint-API-Operation-Name: 1.echo_api_endpoints_cloudesf_testing_cloud_goog.EchoHeader
```

**Testing**: Integration tests

Fixes #524
Signed-off-by: Teju Nareddy <nareddyt@google.com>