### PR TITLE
b/189965239: Allow using another service account for GCS fetches.

### DIFF
--- a/src/go/gcsrunner/fetch_config.go
+++ b/src/go/gcsrunner/fetch_config.go
@@ -64,31 +64,28 @@ type FetchConfigOptions struct {
 	FetchGCSObjectTimeout         time.Duration
 }
 
-var (
-	// can be overwritten in unit tests
-	newGCSClient = func(ctx context.Context, sa string) (gcsReader, error) {
-		ts, err := TokenSource(ctx, sa)
-		if err != nil {
-			return nil, err
-		}
-		client, err := storage.NewClient(ctx, option.WithTokenSource(ts))
-		if err != nil {
-			return nil, err
-		}
-		return &gcsClient{client}, nil
+func newGCSClient(ctx context.Context, sa string) (gcsReader, error) {
+	ts, err := TokenSource(ctx, sa)
+	if err != nil {
+		return nil, err
 	}
-	newDefaultCredsGCSClient = func(ctx context.Context) (gcsReader, error) {
-		creds, err := google.FindDefaultCredentials(ctx)
-		if err != nil {
-			return nil, err
-		}
-		c, err := storage.NewClient(ctx, option.WithCredentials(creds))
-		if err != nil {
-			return nil, err
-		}
-		return &gcsClient{c}, nil
+	client, err := storage.NewClient(ctx, option.WithTokenSource(ts))
+	if err != nil {
+		return nil, err
 	}
-)
+	return &gcsClient{client}, nil
+}
+func newDefaultCredsGCSClient(ctx context.Context) (gcsReader, error) {
+	creds, err := google.FindDefaultCredentials(ctx)
+	if err != nil {
+		return nil, err
+	}
+	c, err := storage.NewClient(ctx, option.WithCredentials(creds))
+	if err != nil {
+		return nil, err
+	}
+	return &gcsClient{c}, nil
+}
 
 // FetchConfigFromGCS handles fetching a config from GCS, applying any transformation,
 // and writing it to file.

--- a/src/go/gcsrunner/fetch_config_test.go
+++ b/src/go/gcsrunner/fetch_config_test.go
@@ -157,7 +157,7 @@ func TestReadBytes(t *testing.T) {
 			defaultCredsReaderErr: testError,
 		},
 		{
-			name:           "timeout retrying newGSC",
+			name:           "timeout retrying newGCS",
 			wantTimeoutErr: true,
 			opts:           optsSA,
 			reader: &mockReader{

--- a/src/go/gcsrunner/fetch_config_test.go
+++ b/src/go/gcsrunner/fetch_config_test.go
@@ -15,17 +15,14 @@
 package gcsrunner
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"testing"
 	"time"
 
+	"github.com/cenkalti/backoff"
 	"github.com/google/go-cmp/cmp"
-	"google.golang.org/api/option"
-
-	google_oauth "golang.org/x/oauth2/google"
 )
 
 const (
@@ -33,45 +30,75 @@ const (
 	fetchTimeout         = time.Second
 )
 
-var ()
-
-type mockObjectReader struct {
-	newReaderReturns       io.Reader
-	newReaderErr           error
-	newReaderCallCount     int
+type mockReader struct {
+	readerReturns          io.Reader
+	readerErr              error
+	readerCallCount        int
 	passAfterMultipleCalls bool
 }
 
-func (m *mockObjectReader) readObject(ctx context.Context, _ getObjectRequest) (io.Reader, error) {
+func (m *mockReader) Reader(ctx context.Context, _, _ string) (io.Reader, error) {
 	if deadline, ok := ctx.Deadline(); ok {
 		if time.Now().After(deadline) {
 			return nil, context.DeadlineExceeded
 		}
 	}
-	m.newReaderCallCount++
-	if m.passAfterMultipleCalls && m.newReaderCallCount > 2 {
-		return m.newReaderReturns, nil
+	m.readerCallCount++
+	if m.passAfterMultipleCalls && m.readerCallCount > 2 {
+		return m.readerReturns, nil
 	}
-	return m.newReaderReturns, m.newReaderErr
+	return m.readerReturns, m.readerErr
 }
 
 type mockFile struct {
 	closeCalled bool
+	readErr     error
 	writeErr    error
-	gotBytes    []byte
+	content     []byte
 }
 
 func (m *mockFile) Close() error {
 	m.closeCalled = true
 	return nil
 }
+
+func (m *mockFile) Read(b []byte) (int, error) {
+	if m.readErr != nil {
+		return 0, m.readErr
+	}
+	return copy(b, m.content), io.EOF
+}
+
 func (m *mockFile) Write(b []byte) (int, error) {
-	m.gotBytes = b
-	return len(b), m.writeErr
+	if m.writeErr != nil {
+		return 0, m.writeErr
+	}
+	m.content = b
+	return len(b), nil
+}
+
+func readerFactory(r *mockReader, err error) func(context.Context, string) (gcsReader, error) {
+	return func(context.Context, string) (gcsReader, error) {
+		return r, err
+	}
+}
+
+func defaultCredsReaderFactory(r *mockReader, err error) func(context.Context) (gcsReader, error) {
+	return func(context.Context) (gcsReader, error) {
+		return r, err
+	}
 }
 
 func TestReadBytes(t *testing.T) {
-	opts := FetchConfigOptions{
+	optsNoSA := FetchConfigOptions{
+		BucketName:                    "bucket",
+		ConfigFileName:                "file",
+		WriteFilePath:                 "path/file",
+		FetchGCSObjectInitialInterval: fetchInitialInterval,
+		FetchGCSObjectTimeout:         fetchTimeout,
+	}
+	optsSA := FetchConfigOptions{
+		ServiceAccount:                "some-service@account",
 		BucketName:                    "bucket",
 		ConfigFileName:                "file",
 		WriteFilePath:                 "path/file",
@@ -79,83 +106,102 @@ func TestReadBytes(t *testing.T) {
 		FetchGCSObjectTimeout:         fetchTimeout,
 	}
 	output := []byte("some output")
-	goodFindDefaultCredentials := func(context.Context, ...string) (*google_oauth.Credentials, error) {
-		return nil, nil
-	}
-	badFindDefaultCredentials := func(context.Context, ...string) (*google_oauth.Credentials, error) {
-		return nil, fmt.Errorf("default creds failure")
-	}
+	testError := fmt.Errorf("test error")
 	testCases := []struct {
-		name                    string
-		wantErr                 bool
-		wantMultipleReaderCalls bool
-		passMultipleReaderCalls bool
-		wantBytes               []byte
-		credsFunc               func(context.Context, ...string) (*google_oauth.Credentials, error)
-		newClientErr            error
-		newReaderReturns        io.Reader
-		newReaderErr            error
+		name                  string
+		wantErr               error
+		wantTimeoutErr        bool
+		opts                  FetchConfigOptions
+		reader                *mockReader
+		readerErr             error
+		defaultCredsReader    *mockReader
+		defaultCredsReaderErr error
 	}{
 		{
-			name:      "error getting default creds",
-			wantErr:   true,
-			credsFunc: badFindDefaultCredentials,
+			name: "success",
+			opts: optsSA,
+			reader: &mockReader{
+				readerReturns: &mockFile{content: output},
+			},
+			defaultCredsReaderErr: fmt.Errorf("expected defaultCredsReader not to be called"),
 		},
 		{
-			name:         "error creating client with creds",
-			wantErr:      true,
-			newClientErr: fmt.Errorf("client error"),
-			credsFunc:    goodFindDefaultCredentials,
+			name: "success with retries",
+			opts: optsSA,
+			reader: &mockReader{
+				readerReturns:          &mockFile{content: output},
+				passAfterMultipleCalls: true,
+			},
+			defaultCredsReaderErr: fmt.Errorf("expected defaultCredsReader not to be called"),
 		},
 		{
-			name:                    "timeout retrying NewReader()",
-			wantErr:                 true,
-			wantMultipleReaderCalls: true,
-			newReaderErr:            fmt.Errorf("reader error"),
-			credsFunc:               goodFindDefaultCredentials,
+			name:      "success with defaultCreds",
+			opts:      optsNoSA,
+			readerErr: fmt.Errorf("expected reader not to be called"),
+			defaultCredsReader: &mockReader{
+				readerReturns: &mockFile{content: output},
+			},
 		},
 		{
-			name:             "success",
-			wantBytes:        output,
-			newReaderReturns: bytes.NewReader(output),
-			credsFunc:        goodFindDefaultCredentials,
+			name:                  "error creating client",
+			opts:                  optsSA,
+			wantErr:               testError,
+			readerErr:             testError,
+			defaultCredsReaderErr: fmt.Errorf("expected defaultCredsReader not to be called"),
 		},
 		{
-			name:                    "success with retries",
-			wantBytes:               output,
-			wantMultipleReaderCalls: true,
-			passMultipleReaderCalls: true,
-			newReaderReturns:        bytes.NewReader(output),
-			newReaderErr:            fmt.Errorf("temporary reader error should resolve"),
-			credsFunc:               goodFindDefaultCredentials,
+			name:                  "error creating client with creds",
+			opts:                  optsNoSA,
+			wantErr:               testError,
+			readerErr:             fmt.Errorf("expected reader not to be called"),
+			defaultCredsReaderErr: testError,
+		},
+		{
+			name:           "timeout retrying newGSC",
+			wantTimeoutErr: true,
+			opts:           optsSA,
+			reader: &mockReader{
+				readerErr: fmt.Errorf("permanent error"),
+			},
+			defaultCredsReaderErr: fmt.Errorf("expected defaultCredsReader not to be called"),
+		},
+		{
+			name:           "timeout retrying ReadAll()",
+			wantTimeoutErr: true,
+			opts:           optsSA,
+			reader: &mockReader{
+				readerReturns: &mockFile{readErr: fmt.Errorf("permmanent error")},
+			},
+			defaultCredsReaderErr: fmt.Errorf("expected defaultCredsReader not to be called"),
 		},
 	}
 
 	for _, tc := range testCases {
-		findDefaultCredentials = tc.credsFunc
-		m := &mockObjectReader{
-			newReaderReturns:       tc.newReaderReturns,
-			newReaderErr:           tc.newReaderErr,
-			passAfterMultipleCalls: tc.passMultipleReaderCalls,
-		}
-		newStorageObjectReader = func(ctx context.Context, opts ...option.ClientOption) (storageObjectReader, error) {
-			if tc.newClientErr != nil {
-				return nil, tc.newClientErr
+		t.Run(tc.name, func(t *testing.T) {
+			oldNewGCS := newGCS
+			oldNewDefaultCredsGCS := newDefaultCredsGCS
+			newGCS = readerFactory(tc.reader, tc.readerErr)
+			newDefaultCredsGCS = defaultCredsReaderFactory(tc.defaultCredsReader, tc.defaultCredsReaderErr)
+			defer func() {
+				newGCS = oldNewGCS
+				newDefaultCredsGCS = oldNewDefaultCredsGCS
+			}()
+			b, err := readBytes(tc.opts)
+			if err != tc.wantErr {
+				if tc.wantTimeoutErr {
+					if _, ok := err.(*backoff.PermanentError); tc.wantTimeoutErr == ok {
+						t.Errorf("readBytes() wanted %v=PermanentError to be %v", err, tc.wantTimeoutErr)
+					}
+				} else {
+					t.Errorf("readBytes() = %v, wanted %v", err, tc.wantErr)
+				}
 			}
-			return m, nil
-		}
-		b, err := readBytes(opts)
-		if err != nil != tc.wantErr {
-			t.Errorf("readBytes() wanted %v!=nil to be %v", err, tc.wantErr)
-		}
-		if m.newReaderCallCount > 1 != tc.wantMultipleReaderCalls {
-			t.Errorf("NewReader() wanted %d>1 to be %v", m.newReaderCallCount, tc.wantMultipleReaderCalls)
-		}
-		if !tc.wantErr {
-			if diff := bytes.Compare(b, tc.wantBytes); diff != 0 {
-				t.Errorf("readBytes() = %s, _, want %s", string(b), string(tc.wantBytes))
+			if tc.wantErr == nil && !tc.wantTimeoutErr {
+				if diff := cmp.Diff(string(output), string(b)); diff != "" {
+					t.Errorf("readBytes() got unexpected value (-want/+got): %s", diff)
+				}
 			}
-		}
+		})
 	}
 }
 
@@ -200,23 +246,30 @@ func TestWriteFile(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		osCreate = func(got string) (file, error) {
-			if got != tc.createWant {
-				t.Errorf("osCreate called with %s, want %s", got, tc.createWant)
+		t.Run(tc.name, func(t *testing.T) {
+			oldOSCreate := osCreate
+			osCreate = func(got string) (io.WriteCloser, error) {
+				if got != tc.createWant {
+					t.Errorf("osCreate called with %s, want %s", got, tc.createWant)
+				}
+				return tc.createReturns, tc.createErr
 			}
-			return tc.createReturns, tc.createErr
-		}
-		err := writeFile(tc.input, opts)
-		if err != nil != tc.wantErr {
-			t.Errorf("writeFile() wanted %v!=nil to be %v", err, tc.wantErr)
-		}
-		if !tc.createReturns.closeCalled {
-			t.Errorf("Created file was not closed")
-		}
-		if !tc.wantErr {
-			if diff := cmp.Diff(string(tc.createReturns.gotBytes), tc.wantOutput); diff != "" {
-				t.Errorf("WriteString() unexpected output (-got,+want): %s", diff)
+			defer func() {
+				osCreate = oldOSCreate
+			}()
+			err := writeFile(tc.input, opts)
+			if err != nil != tc.wantErr {
+				t.Errorf("writeFile() wanted %v!=nil to be %v", err, tc.wantErr)
+
 			}
-		}
+			if !tc.createReturns.closeCalled {
+				t.Errorf("Created file was not closed")
+			}
+			if !tc.wantErr {
+				if diff := cmp.Diff(string(tc.createReturns.content), tc.wantOutput); diff != "" {
+					t.Errorf("WriteString() unexpected output (-got,+want): %s", diff)
+				}
+			}
+		})
 	}
 }

--- a/src/go/gcsrunner/main/runner.go
+++ b/src/go/gcsrunner/main/runner.go
@@ -55,7 +55,7 @@ var (
 	envoyLogPath = flag.String("envoy_log_path", "",
 		"Envoy application logging path. Default is to write to stderr.")
 	envoyComponentLogLevel = flag.String("envoy_component_log_level", "", "Mapping for Envoy log level by component.")
-	sa                     = flag.String("run_as_service_account", "", "If provided, use this account when fetching the config from GCS.")
+	sa                     = flag.String("run_as_service_account", "", "If provided, use this account when fetching the config from GCS. If not provided, the container's default credentials are used.")
 )
 
 func main() {

--- a/src/go/gcsrunner/serviceaccount.go
+++ b/src/go/gcsrunner/serviceaccount.go
@@ -1,0 +1,87 @@
+package gcsrunner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+// staticTokenSource implements oath2.TokenSource
+type staticTokenSource struct {
+	accessToken string    `json:"access_token"`
+	tokenType   string    `json:"token_type,omitempty"`
+	expiry      time.Time `json:"expiry,omitempty"`
+}
+
+func (s staticTokenSource) Token() (*oauth2.Token, error) {
+	return &oauth2.Token{
+		AccessToken: s.accessToken,
+		Expiry:      s.expiry,
+	}, nil
+}
+
+type iamcredentialsResponse struct {
+	AccessToken string `json:accessToken`
+	ExpireTime  string `json:expireTime`
+}
+
+// TokenSource returns an oauth2.TokenSource which provides a short-lived token
+// for impersonating the provided service account.
+//
+// Because this token should only be used in the start-up script, this token cannot be refreshed.
+func TokenSource(ctx context.Context, sa string) (oauth2.TokenSource, error) {
+	url := fmt.Sprintf("https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateAccessToken", sa)
+	bodyBytes, err := json.Marshal(map[string][]string{
+		"scope": []string{storage.ScopeReadOnly},
+	})
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := google.FindDefaultCredentials(ctx)
+	if err != nil {
+		return nil, err
+	}
+	token, err := c.TokenSource.Token()
+	if err != nil {
+		return nil, err
+	}
+	token.SetAuthHeader(req)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed iamcredentials request: %v", resp.Status)
+	}
+
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var iamCredsResp iamcredentialsResponse
+	if err := json.Unmarshal(respBody, &iamCredsResp); err != nil {
+		return nil, err
+	}
+	expiry, err := time.Parse(time.RFC3339, iamCredsResp.ExpireTime)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse expiry: %v", err)
+	}
+	return &staticTokenSource{
+		accessToken: iamCredsResp.AccessToken,
+		expiry:      expiry,
+	}, nil
+}


### PR DESCRIPTION
- Allow choosing between default credentials or a provided service account.
- Use IAM Credentials API to impersonate the provided service account.

Some additional refactoring:
- Streamline client interfaces for easier testing.
- Cover some testing edge cases which were missed.