### PR TITLE
Disable preserve downstream scheme

### DIFF
--- a/examples/auth/envoy_config.json
+++ b/examples/auth/envoy_config.json
@@ -5,7 +5,8 @@
       {
         "name": "static-runtime",
         "staticLayer": {
-          "envoy.reloadable_features.preserve_downstream_scheme": false
+          "envoy.reloadable_features.preserve_downstream_scheme": false,
+          "re2.max_program_size.error_level": 1000
         }
       }
     ]

--- a/examples/auth/envoy_config.json
+++ b/examples/auth/envoy_config.json
@@ -3,9 +3,9 @@
   "layeredRuntime": {
     "layers": [
       {
-        "name": "deprecation",
+        "name": "static-runtime",
         "staticLayer": {
-          "re2.max_program_size.error_level": 1000
+          "envoy.reloadable_features.preserve_downstream_scheme": false
         }
       }
     ]

--- a/examples/dynamic_routing/envoy_config.json
+++ b/examples/dynamic_routing/envoy_config.json
@@ -5,7 +5,8 @@
       {
         "name": "static-runtime",
         "staticLayer": {
-          "envoy.reloadable_features.preserve_downstream_scheme": false
+          "envoy.reloadable_features.preserve_downstream_scheme": false,
+          "re2.max_program_size.error_level": 1000
         }
       }
     ]

--- a/examples/dynamic_routing/envoy_config.json
+++ b/examples/dynamic_routing/envoy_config.json
@@ -3,9 +3,9 @@
   "layeredRuntime": {
     "layers": [
       {
-        "name": "deprecation",
+        "name": "static-runtime",
         "staticLayer": {
-          "re2.max_program_size.error_level": 1000
+          "envoy.reloadable_features.preserve_downstream_scheme": false
         }
       }
     ]

--- a/examples/grpc_dynamic_routing/envoy_config.json
+++ b/examples/grpc_dynamic_routing/envoy_config.json
@@ -5,7 +5,8 @@
       {
         "name": "static-runtime",
         "staticLayer": {
-          "envoy.reloadable_features.preserve_downstream_scheme": false
+          "envoy.reloadable_features.preserve_downstream_scheme": false,
+          "re2.max_program_size.error_level": 1000
         }
       }
     ]

--- a/examples/grpc_dynamic_routing/envoy_config.json
+++ b/examples/grpc_dynamic_routing/envoy_config.json
@@ -3,9 +3,9 @@
   "layeredRuntime": {
     "layers": [
       {
-        "name": "deprecation",
+        "name": "static-runtime",
         "staticLayer": {
-          "re2.max_program_size.error_level": 1000
+          "envoy.reloadable_features.preserve_downstream_scheme": false
         }
       }
     ]

--- a/examples/service_control/envoy_config.json
+++ b/examples/service_control/envoy_config.json
@@ -5,7 +5,8 @@
       {
         "name": "static-runtime",
         "staticLayer": {
-          "envoy.reloadable_features.preserve_downstream_scheme": false
+          "envoy.reloadable_features.preserve_downstream_scheme": false,
+          "re2.max_program_size.error_level": 1000
         }
       }
     ]

--- a/examples/service_control/envoy_config.json
+++ b/examples/service_control/envoy_config.json
@@ -3,9 +3,9 @@
   "layeredRuntime": {
     "layers": [
       {
-        "name": "deprecation",
+        "name": "static-runtime",
         "staticLayer": {
-          "re2.max_program_size.error_level": 1000
+          "envoy.reloadable_features.preserve_downstream_scheme": false
         }
       }
     ]

--- a/examples/testdata/route_match/envoy_config.json
+++ b/examples/testdata/route_match/envoy_config.json
@@ -5,7 +5,8 @@
       {
         "name": "static-runtime",
         "staticLayer": {
-          "envoy.reloadable_features.preserve_downstream_scheme": false
+          "envoy.reloadable_features.preserve_downstream_scheme": false,
+          "re2.max_program_size.error_level": 1000
         }
       }
     ]

--- a/examples/testdata/route_match/envoy_config.json
+++ b/examples/testdata/route_match/envoy_config.json
@@ -3,9 +3,9 @@
   "layeredRuntime": {
     "layers": [
       {
-        "name": "deprecation",
+        "name": "static-runtime",
         "staticLayer": {
-          "re2.max_program_size.error_level": 1000
+          "envoy.reloadable_features.preserve_downstream_scheme": false
         }
       }
     ]

--- a/examples/testdata/sidecar_backend/envoy_config.json
+++ b/examples/testdata/sidecar_backend/envoy_config.json
@@ -5,7 +5,8 @@
       {
         "name": "static-runtime",
         "staticLayer": {
-          "envoy.reloadable_features.preserve_downstream_scheme": false
+          "envoy.reloadable_features.preserve_downstream_scheme": false,
+          "re2.max_program_size.error_level": 1000
         }
       }
     ]

--- a/examples/testdata/sidecar_backend/envoy_config.json
+++ b/examples/testdata/sidecar_backend/envoy_config.json
@@ -3,9 +3,9 @@
   "layeredRuntime": {
     "layers": [
       {
-        "name": "deprecation",
+        "name": "static-runtime",
         "staticLayer": {
-          "re2.max_program_size.error_level": 1000
+          "envoy.reloadable_features.preserve_downstream_scheme": false
         }
       }
     ]

--- a/src/go/bootstrap/ads/bootstrap_test.go
+++ b/src/go/bootstrap/ads/bootstrap_test.go
@@ -68,9 +68,9 @@ func TestCreateBootstrapConfig(t *testing.T) {
    "layeredRuntime":{
       "layers":[
          {
-            "name":"deprecation",
-            "staticLayer":{
-               "re2.max_program_size.error_level":1000
+            "name": "static-runtime",
+            "staticLayer": {
+              "envoy.reloadable_features.preserve_downstream_scheme": false
             }
          }
       ]
@@ -159,9 +159,9 @@ func TestCreateBootstrapConfig(t *testing.T) {
    "layeredRuntime":{
       "layers":[
          {
-            "name":"deprecation",
-            "staticLayer":{
-               "re2.max_program_size.error_level":1000
+            "name": "static-runtime",
+            "staticLayer": {
+              "envoy.reloadable_features.preserve_downstream_scheme": false
             }
          }
       ]

--- a/src/go/bootstrap/ads/bootstrap_test.go
+++ b/src/go/bootstrap/ads/bootstrap_test.go
@@ -70,7 +70,8 @@ func TestCreateBootstrapConfig(t *testing.T) {
          {
             "name": "static-runtime",
             "staticLayer": {
-              "envoy.reloadable_features.preserve_downstream_scheme": false
+              "envoy.reloadable_features.preserve_downstream_scheme": false,
+              "re2.max_program_size.error_level":1000
             }
          }
       ]
@@ -161,7 +162,8 @@ func TestCreateBootstrapConfig(t *testing.T) {
          {
             "name": "static-runtime",
             "staticLayer": {
-              "envoy.reloadable_features.preserve_downstream_scheme": false
+              "envoy.reloadable_features.preserve_downstream_scheme": false,
+              "re2.max_program_size.error_level":1000
             }
          }
       ]

--- a/src/go/bootstrap/layer_runtime.go
+++ b/src/go/bootstrap/layer_runtime.go
@@ -26,13 +26,14 @@ func CreateLayeredRuntime() *bootstrappb.LayeredRuntime {
 		Layers: []*bootstrappb.RuntimeLayer{
 			//
 			{
-				Name: "deprecation",
+				Name: "static-runtime",
 				LayerSpecifier: &bootstrappb.RuntimeLayer_StaticLayer{
 					StaticLayer: &structpb.Struct{
 						Fields: map[string]*structpb.Value{
-							"re2.max_program_size.error_level": {
-								Kind: &structpb.Value_NumberValue{
-									NumberValue: 1000,
+							// b/191411628: disable envoy preserve_downstream_scheme
+							"envoy.reloadable_features.preserve_downstream_scheme": {
+								Kind: &structpb.Value_BoolValue{
+									BoolValue: false,
 								},
 							},
 						},

--- a/src/go/bootstrap/layer_runtime.go
+++ b/src/go/bootstrap/layer_runtime.go
@@ -30,6 +30,11 @@ func CreateLayeredRuntime() *bootstrappb.LayeredRuntime {
 				LayerSpecifier: &bootstrappb.RuntimeLayer_StaticLayer{
 					StaticLayer: &structpb.Struct{
 						Fields: map[string]*structpb.Value{
+							"re2.max_program_size.error_level": {
+								Kind: &structpb.Value_NumberValue{
+									NumberValue: 1000,
+								},
+							},
 							// b/191411628: disable envoy preserve_downstream_scheme
 							"envoy.reloadable_features.preserve_downstream_scheme": {
 								Kind: &structpb.Value_BoolValue{


### PR DESCRIPTION
This is to fix https://github.com/GoogleCloudPlatform/esp-v2/issues/545

Envoy new way is "preserve_downstream_scheme".  This is not working for ESPv2 deployed in Cloud-Run.  Especially if its backend is using IAP.   IAP requires ":scheme" to be https.   But "preserve_downstream_scheme" will change it to http since the connection between Cloud-Run app-sever and ESPv2 is http. 

