### PR TITLE
b/192247795: support backendRetryOnStatusCodes

### DIFF
--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -605,6 +605,15 @@ environment variable or by passing "-k" flag to this script.
         x-envoy-retry-grpc-on(https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-on).
         ''')
     parser.add_argument(
+        '--backend_retry_on_status_codes',
+        default=None,
+        help='''
+        The list of backend http status codes will be retried, in
+        addition to the status codes enabled for retry through other retry
+        policies set in `--backend_retry_ons`. 
+        The format is a comma-delimited String, like "501, 503".
+        ''')
+    parser.add_argument(
         '--backend_retry_num',
         default=None,
         help='''
@@ -1154,7 +1163,8 @@ def gen_proxy_config(args):
 
     if args.backend_retry_ons:
         proxy_conf.extend(["--backend_retry_ons", args.backend_retry_ons])
-
+    if args.backend_retry_on_status_codes:
+        proxy_conf.extend(["--backend_retry_on_status_codes", args.backend_retry_on_status_codes])
     if args.backend_retry_num:
         proxy_conf.extend(["--backend_retry_num", args.backend_retry_num])
 

--- a/src/go/configgenerator/route_generator.go
+++ b/src/go/configgenerator/route_generator.go
@@ -396,6 +396,7 @@ func makeRoute(routeMatcher *routepb.RouteMatch, method *configinfo.MethodInfo) 
 		NumRetries: &wrapperspb.UInt32Value{
 			Value: uint32(method.BackendInfo.RetryNum),
 		},
+		RetriableStatusCodes: method.BackendInfo.RetriableStatusCodes,
 	}
 
 	if method.BackendInfo.PerTryTimeout.Nanoseconds() > 0 {

--- a/src/go/configinfo/method_info.go
+++ b/src/go/configinfo/method_info.go
@@ -70,9 +70,10 @@ type backendInfo struct {
 	IdleTimeout time.Duration
 
 	// Retry setting on the backend.
-	RetryOns      string
-	RetryNum      uint
-	PerTryTimeout time.Duration
+	RetryOns             string
+	RetryNum             uint
+	RetriableStatusCodes []uint32
+	PerTryTimeout        time.Duration
 }
 
 type SnakeToJsonSegments = map[string]string

--- a/src/go/configinfo/service_info.go
+++ b/src/go/configinfo/service_info.go
@@ -645,7 +645,7 @@ func (s *ServiceInfo) processAllBackends() error {
 		backendInfo.PerTryTimeout = s.Options.BackendPerTryTimeout
 
 		if s.Options.BackendRetryOnStatusCodes != "" {
-			retriableStatusCodes, err := parseStatusCodes(s.Options.BackendRetryOnStatusCodes)
+			retriableStatusCodes, err := parseRetriableStatusCodes(s.Options.BackendRetryOnStatusCodes)
 			if err != nil {
 				return fmt.Errorf("invalid retriable status codes: %v", err)
 			}
@@ -923,12 +923,12 @@ func calculateStreamIdleTimeout(operationDeadline time.Duration, opts options.Co
 	return util.MaxDuration(operationIdleTimeout, opts.StreamIdleTimeout)
 }
 
-func parseStatusCodes(statusCodes string) ([]uint32, error) {
+func parseRetriableStatusCodes(statusCodes string) ([]uint32, error) {
 	codeList := strings.Split(statusCodes, ",")
 	var codes []uint32
 	for _, codeStr := range codeList {
-		if code, err := strconv.Atoi(codeStr); err != nil {
-			return nil, err
+		if code, err := strconv.Atoi(codeStr); err != nil || code < 100 || code >= 600 {
+			return nil, fmt.Errorf("invalid http status codes: %v, the valid one should be a number in [100, 600)", code)
 		} else {
 			codes = append(codes, uint32(code))
 		}

--- a/src/go/configinfo/service_info_test.go
+++ b/src/go/configinfo/service_info_test.go
@@ -2714,7 +2714,7 @@ func TestProcessBackendRuleForRetry(t *testing.T) {
 			wantBackendPerTryTimeout: time.Second * 60,
 		},
 		{
-			desc: "invalid retriable status codes",
+			desc: "invalid retriable status code in wrong format",
 			fakeServiceConfig: &confpb.Service{
 				Apis: []*apipb.Api{
 					{
@@ -2729,7 +2729,25 @@ func TestProcessBackendRuleForRetry(t *testing.T) {
 			},
 			backendRetryOns:          "",
 			backendRetryOnStatusCode: "invalid-status-code",
-			wantError:                "invalid retriable status codes",
+			wantError:                "invalid http status code",
+		},
+		{
+			desc: "invalid retriable status code in wrong range",
+			fakeServiceConfig: &confpb.Service{
+				Apis: []*apipb.Api{
+					{
+						Name: "abc.com",
+						Methods: []*apipb.Method{
+							{
+								Name: "api",
+							},
+						},
+					},
+				},
+			},
+			backendRetryOns:          "",
+			backendRetryOnStatusCode: "600",
+			wantError:                "invalid http status code",
 		},
 		{
 			desc: "set RetryOnStatusCodes and add `retriable-status-codes` to retryOns if it is empty",

--- a/src/go/configinfo/service_info_test.go
+++ b/src/go/configinfo/service_info_test.go
@@ -2732,7 +2732,7 @@ func TestProcessBackendRuleForRetry(t *testing.T) {
 			wantError:                "invalid retriable status codes",
 		},
 		{
-			desc: "add `retriable-status-codes` to retryOns when retriable status codes are set",
+			desc: "set RetryOnStatusCodes and add `retriable-status-codes` to retryOns if it is empty",
 			fakeServiceConfig: &confpb.Service{
 				Apis: []*apipb.Api{
 					{
@@ -2751,7 +2751,7 @@ func TestProcessBackendRuleForRetry(t *testing.T) {
 			wantBackendRetryOnStatusCodes: []uint32{500, 501},
 		},
 		{
-			desc: "add `retriable-status-codes` to retryOns when retriable status codes are set",
+			desc: "set RetryOnStatusCodes and add `retriable-status-codes` to retryOns if it is un-empty but doesn't have `retriable-status-codes`",
 			fakeServiceConfig: &confpb.Service{
 				Apis: []*apipb.Api{
 					{
@@ -2770,7 +2770,7 @@ func TestProcessBackendRuleForRetry(t *testing.T) {
 			wantBackendRetryOnStatusCodes: []uint32{500, 501},
 		},
 		{
-			desc: "no op when retriable status codes are set and `retriable-status-codes` is in retryOns ",
+			desc: "set RetryOnStatusCodes and no op on retryOns when it contains `retriable-status-codes`",
 			fakeServiceConfig: &confpb.Service{
 				Apis: []*apipb.Api{
 					{

--- a/src/go/configinfo/service_info_test.go
+++ b/src/go/configinfo/service_info_test.go
@@ -2678,6 +2678,151 @@ func TestProcessBackendRuleForJwtAudience(t *testing.T) {
 	}
 }
 
+func TestProcessBackendRuleForRetry(t *testing.T) {
+	testData := []struct {
+		desc                          string
+		fakeServiceConfig             *confpb.Service
+		backendRetryOns               string
+		backendRetryNum               uint
+		backendPerTryTimeout          time.Duration
+		backendRetryOnStatusCode      string
+		wantBackendRetryOns           string
+		wantBackendRetryNum           uint
+		wantBackendPerTryTimeout      time.Duration
+		wantBackendRetryOnStatusCodes []uint32
+		wantError                     string
+	}{
+		{
+			desc: "pass backend retry parameters",
+			fakeServiceConfig: &confpb.Service{
+				Apis: []*apipb.Api{
+					{
+						Name: "abc.com",
+						Methods: []*apipb.Method{
+							{
+								Name: "api",
+							},
+						},
+					},
+				},
+			},
+			backendRetryOns:          "foo,bar",
+			backendRetryNum:          5,
+			backendPerTryTimeout:     time.Second * 60,
+			wantBackendRetryOns:      "foo,bar",
+			wantBackendRetryNum:      5,
+			wantBackendPerTryTimeout: time.Second * 60,
+		},
+		{
+			desc: "invalid retriable status codes",
+			fakeServiceConfig: &confpb.Service{
+				Apis: []*apipb.Api{
+					{
+						Name: "abc.com",
+						Methods: []*apipb.Method{
+							{
+								Name: "api",
+							},
+						},
+					},
+				},
+			},
+			backendRetryOns:          "",
+			backendRetryOnStatusCode: "invalid-status-code",
+			wantError:                "invalid retriable status codes",
+		},
+		{
+			desc: "add `retriable-status-codes` to retryOns when retriable status codes are set",
+			fakeServiceConfig: &confpb.Service{
+				Apis: []*apipb.Api{
+					{
+						Name: "abc.com",
+						Methods: []*apipb.Method{
+							{
+								Name: "api",
+							},
+						},
+					},
+				},
+			},
+			backendRetryOns:               "",
+			backendRetryOnStatusCode:      "500,501",
+			wantBackendRetryOns:           "retriable-status-codes",
+			wantBackendRetryOnStatusCodes: []uint32{500, 501},
+		},
+		{
+			desc: "add `retriable-status-codes` to retryOns when retriable status codes are set",
+			fakeServiceConfig: &confpb.Service{
+				Apis: []*apipb.Api{
+					{
+						Name: "abc.com",
+						Methods: []*apipb.Method{
+							{
+								Name: "api",
+							},
+						},
+					},
+				},
+			},
+			backendRetryOns:               "foo,bar",
+			backendRetryOnStatusCode:      "500,501",
+			wantBackendRetryOns:           "foo,bar,retriable-status-codes",
+			wantBackendRetryOnStatusCodes: []uint32{500, 501},
+		},
+		{
+			desc: "no op when retriable status codes are set and `retriable-status-codes` is in retryOns ",
+			fakeServiceConfig: &confpb.Service{
+				Apis: []*apipb.Api{
+					{
+						Name: "abc.com",
+						Methods: []*apipb.Method{
+							{
+								Name: "api",
+							},
+						},
+					},
+				},
+			},
+			backendRetryOns:               "foo,bar,retriable-status-codes",
+			backendRetryOnStatusCode:      "500,501",
+			wantBackendRetryOns:           "foo,bar,retriable-status-codes",
+			wantBackendRetryOnStatusCodes: []uint32{500, 501},
+		},
+	}
+
+	for _, tc := range testData {
+		t.Run(tc.desc, func(t *testing.T) {
+			opts := options.DefaultConfigGeneratorOptions()
+			opts.BackendRetryOns = tc.backendRetryOns
+			opts.BackendRetryNum = tc.backendRetryNum
+			opts.BackendPerTryTimeout = tc.backendPerTryTimeout
+			opts.BackendRetryOnStatusCodes = tc.backendRetryOnStatusCode
+			s, err := NewServiceInfoFromServiceConfig(tc.fakeServiceConfig, testConfigID, opts)
+			if tc.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+					t.Fatalf("different error, want: %s, get: %v", tc.wantError, err)
+				}
+				return
+			}
+
+			for _, method := range s.Methods {
+				backendInfo := method.BackendInfo
+				if backendInfo.RetryOns != tc.wantBackendRetryOns {
+					t.Errorf("different RetryOns, want: %v, get: %v", tc.wantBackendRetryOns, backendInfo.RetryOns)
+				}
+				if backendInfo.RetryNum != tc.wantBackendRetryNum {
+					t.Errorf("different RetryNum, want: %v, get: %v", tc.wantBackendRetryNum, backendInfo.RetryNum)
+				}
+				if backendInfo.PerTryTimeout != tc.wantBackendPerTryTimeout {
+					t.Errorf("different PerTryTimeout, want: %v, get: %v", tc.wantBackendPerTryTimeout, backendInfo.PerTryTimeout)
+				}
+				if !reflect.DeepEqual(backendInfo.RetriableStatusCodes, tc.wantBackendRetryOnStatusCodes) {
+					t.Errorf("different RetriableStatusCodes, want: %v, get: %v", tc.wantBackendRetryOnStatusCodes, backendInfo.RetriableStatusCodes)
+				}
+			}
+		})
+	}
+}
 func TestBackendAddressOverride(t *testing.T) {
 	testData := []struct {
 		desc                         string

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -172,6 +172,11 @@ var (
         backend_per_try_timeout=0 means ESPv2 will use the  "deadline"" in
         the "x-google-backend" extension. Consequently, a request that times out
         will not be retried as the total timeout budget would have been exhausted.`)
+	BackendRetryOnStatusCodes = flag.String("backend_retry_on_status_codes", "",
+		`The list of backend http status codes will be retried, in
+        addition to the status codes enabled for retry through other retry
+        policies set in "--backend_retry_ons".
+        The format is a comma-delimited String, like "501, 503`)
 )
 
 func EnvoyConfigOptionsFromFlags() options.ConfigGeneratorOptions {
@@ -238,6 +243,7 @@ func EnvoyConfigOptionsFromFlags() options.ConfigGeneratorOptions {
 		BackendRetryOns:                         *BackendRetryOns,
 		BackendRetryNum:                         *BackendRetryNum,
 		BackendPerTryTimeout:                    *BackendPerTryTimeout,
+		BackendRetryOnStatusCodes:               *BackendRetryOnStatusCodes,
 		ScCheckTimeoutMs:                        *ScCheckTimeoutMs,
 		ScQuotaTimeoutMs:                        *ScQuotaTimeoutMs,
 		ScReportTimeoutMs:                       *ScReportTimeoutMs,

--- a/src/go/options/configgenerator.go
+++ b/src/go/options/configgenerator.go
@@ -114,12 +114,13 @@ type ConfigGeneratorOptions struct {
 	ScQuotaTimeoutMs  int
 	ScReportTimeoutMs int
 
-	BackendRetryOns      string
-	BackendRetryNum      uint
-	BackendPerTryTimeout time.Duration
-	ScCheckRetries       int
-	ScQuotaRetries       int
-	ScReportRetries      int
+	BackendRetryOns           string
+	BackendRetryNum           uint
+	BackendPerTryTimeout      time.Duration
+	BackendRetryOnStatusCodes string
+	ScCheckRetries            int
+	ScQuotaRetries            int
+	ScReportRetries           int
 
 	ComputePlatformOverride string
 

--- a/src/go/util/util.go
+++ b/src/go/util/util.go
@@ -74,6 +74,8 @@ const (
 	// System Parameter Name
 	ApiKeyParameterName = "api_key"
 
+	// retriable-status-codes retryOn policy
+	RetryOnRetriableStatusCodes = "retriable-status-codes"
 	// Default response deadline used if user does not specify one in the BackendRule.
 	DefaultResponseDeadline = 15 * time.Second
 

--- a/tests/start_proxy/start_proxy_test.py
+++ b/tests/start_proxy/start_proxy_test.py
@@ -490,6 +490,15 @@ class TestStartProxy(unittest.TestCase):
               '--backend_per_try_timeout', '10s',
               '--disable_tracing'
               ]),
+            (['-R=managed',
+              '--http2_port=8079', '--backend_retry_on_status_codes=500,501',
+              '--disable_tracing'],
+             ['bin/configmanager', '--logtostderr', '--rollout_strategy', 'managed',
+              '--backend_address', 'http://127.0.0.1:8082', '--v', '0',
+              '--listener_port', '8079',
+              '--backend_retry_on_status_codes', '500,501',
+              '--disable_tracing'
+              ]),
             # Service account key does not assume non-gcp
             # and does not disable tracing.
             (['--service=test_bookstore.gloud.run',


### PR DESCRIPTION
Support backend retry on status codes.

**implementation details**:
- add `--backend_retry_on_status_codes` to [config.route.v3.RetryPolicy.retriable_status_codes](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#config-route-v3-retrypolicy)
- add `retriabel-status-code` into [config.route.v3.RetryPolicy.retry_on](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#config-route-v3-retrypolicy) if it is not set.



