### PR TITLE
b/194502699: Properly set default StreamIdleTimeout when BackendRule is missing

### DIFF
--- a/src/go/configinfo/service_info.go
+++ b/src/go/configinfo/service_info.go
@@ -578,8 +578,8 @@ func (s *ServiceInfo) addBackendInfoToMethod(r *confpb.BackendRule, scheme strin
 	var idleTimeout time.Duration
 	if method.IsStreaming {
 		if r.Deadline <= 0 {
-			// User did not specify a deadline, use global stream idle timeout.
-			idleTimeout = s.Options.StreamIdleTimeout
+			// When the backend deadline is unspecified , calculate the streamIdleTimeout based on max{defaultTimeout, globalStreamIdleTimeout} .
+			idleTimeout = calculateStreamIdleTimeout(util.DefaultResponseDeadline, s.Options)
 		} else {
 			// User configured deadline serves as the stream idle timeout.
 			idleTimeout = deadline

--- a/tests/integration_test/grpc_deadline_test/grpc_deadline_test.go
+++ b/tests/integration_test/grpc_deadline_test/grpc_deadline_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
-
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
 )
 
@@ -370,14 +369,13 @@ plans {
 		t.Run(tc.desc, func(t *testing.T) {
 			s := env.NewTestEnv(platform.TestIdleTimeoutsForGrpcStreaming, platform.GrpcEchoSidecar)
 
-			if tc.methodDeadline != 0 {
-				s.AppendBackendRules([]*confpb.BackendRule{
-					{
-						Selector: "test.grpc.Test.EchoStream",
-						Deadline: tc.methodDeadline.Seconds(),
-					},
-				})
-			}
+			// b/194502699: Always create the backend rule, even if deadline is 0.
+			s.AppendBackendRules([]*confpb.BackendRule{
+				{
+					Selector: "test.grpc.Test.EchoStream",
+					Deadline: tc.methodDeadline.Seconds(),
+				},
+			})
 
 			defer s.TearDown(t)
 			if err := s.Setup(tc.confArgs); err != nil {


### PR DESCRIPTION
If the backend rule is specified but the deadline is unspecified, change how the stream idle timeout is set.

This should have no effect on end users, as it only matters when the `--stream_idle_timeout_test_only` flag is set to a lower value than the default deadline. It is for internal testing.

Signed-off-by: Teju Nareddy <nareddyt@google.com>