### PR TITLE
Fix basic CORS with default cors_allow_origin=*

### DIFF
--- a/src/go/configgenerator/route_generator.go
+++ b/src/go/configgenerator/route_generator.go
@@ -172,8 +172,14 @@ func makeRouteCors(serviceInfo *configinfo.ServiceInfo) (*routepb.CorsPolicy, []
 				},
 			},
 		}
-		originMatcher.HeaderMatchSpecifier = &routepb.HeaderMatcher_ExactMatch{
-			ExactMatch: org,
+		if org == "*" {
+			originMatcher.HeaderMatchSpecifier = &routepb.HeaderMatcher_PresentMatch{
+				PresentMatch: true,
+			}
+		} else {
+			originMatcher.HeaderMatchSpecifier = &routepb.HeaderMatcher_ExactMatch{
+				ExactMatch: org,
+			}
 		}
 	case "cors_with_regex":
 		orgReg := serviceInfo.Options.CorsAllowOriginRegex

--- a/src/go/configgenerator/route_generator_test.go
+++ b/src/go/configgenerator/route_generator_test.go
@@ -2908,6 +2908,248 @@ func TestMakeFallbackRoute(t *testing.T) {
 `,
 		},
 		{
+			desc: "ensure the order of backend routes, 405 routes, cors default allow_origin=* routes, and 404 route",
+			fakeServiceConfig: &confpb.Service{
+				Name: testProjectName,
+				Apis: []*apipb.Api{
+					{
+						Name: testApiName,
+						Methods: []*apipb.Method{
+							{
+								Name: "Echo_Get",
+							},
+							{
+								Name: "Echo_Post",
+							},
+						},
+					},
+				},
+				Http: &annotationspb.Http{Rules: []*annotationspb.HttpRule{
+					{
+						Selector: fmt.Sprintf("%s.Echo_Get", testApiName),
+						Pattern: &annotationspb.HttpRule_Get{
+							Get: "/echo",
+						},
+					},
+					{
+						Selector: fmt.Sprintf("%s.Echo_Post", testApiName),
+						Pattern: &annotationspb.HttpRule_Post{
+							Post: "/echo",
+						},
+					},
+				},
+				},
+			},
+			params: []string{"basic", "*", "", "GET,POST,PUT,OPTIONS", "", "", "2m"},
+			wantRouteConfig: `
+{
+  "name": "local_route",
+  "virtualHosts": [
+    {
+      "cors": {
+        "allowCredentials": false,
+        "allowMethods": "GET,POST,PUT,OPTIONS",
+        "allowOriginStringMatch": [
+          {
+            "exact": "*"
+          }
+        ],
+        "maxAge": "120"
+      },
+      "domains": [
+        "*"
+      ],
+      "name": "backend",
+      "routes": [
+        {
+          "decorator": {
+            "operation": "ingress Echo_Get"
+          },
+          "match": {
+            "headers": [
+              {
+                "exactMatch": "GET",
+                "name": ":method"
+              }
+            ],
+            "path": "/echo"
+          },
+          "name": "endpoints.examples.bookstore.Bookstore.Echo_Get",
+          "route": {
+            "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "idleTimeout": "300s",
+            "retryPolicy": {
+              "numRetries": 1,
+              "retryOn": "reset,connect-failure,refused-stream"
+            },
+            "timeout": "15s"
+          }
+        },
+        {
+          "decorator": {
+            "operation": "ingress Echo_Get"
+          },
+          "match": {
+            "headers": [
+              {
+                "exactMatch": "GET",
+                "name": ":method"
+              }
+            ],
+            "path": "/echo/"
+          },
+          "name": "endpoints.examples.bookstore.Bookstore.Echo_Get",
+          "route": {
+            "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "idleTimeout": "300s",
+            "retryPolicy": {
+              "numRetries": 1,
+              "retryOn": "reset,connect-failure,refused-stream"
+            },
+            "timeout": "15s"
+          }
+        },
+        {
+          "decorator": {
+            "operation": "ingress Echo_Post"
+          },
+          "match": {
+            "headers": [
+              {
+                "exactMatch": "POST",
+                "name": ":method"
+              }
+            ],
+            "path": "/echo"
+          },
+          "name": "endpoints.examples.bookstore.Bookstore.Echo_Post",
+          "route": {
+            "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "idleTimeout": "300s",
+            "retryPolicy": {
+              "numRetries": 1,
+              "retryOn": "reset,connect-failure,refused-stream"
+            },
+            "timeout": "15s"
+          }
+        },
+        {
+          "decorator": {
+            "operation": "ingress Echo_Post"
+          },
+          "match": {
+            "headers": [
+              {
+                "exactMatch": "POST",
+                "name": ":method"
+              }
+            ],
+            "path": "/echo/"
+          },
+          "name": "endpoints.examples.bookstore.Bookstore.Echo_Post",
+          "route": {
+            "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local",
+            "idleTimeout": "300s",
+            "retryPolicy": {
+              "numRetries": 1,
+              "retryOn": "reset,connect-failure,refused-stream"
+            },
+            "timeout": "15s"
+          }
+        },
+        {
+          "decorator": {
+            "operation": "ingress"
+          },
+          "match": {
+            "headers": [
+              {
+                "exactMatch": "OPTIONS",
+                "name": ":method"
+              },
+              {
+                "name": "origin",
+                "presentMatch": true
+              },
+              {
+                "name": "access-control-request-method",
+                "presentMatch": true
+              }
+            ],
+            "prefix": "/"
+          },
+          "route": {
+            "cluster": "backend-cluster-bookstore.endpoints.project123.cloud.goog_local"
+          }
+        },
+        {
+          "decorator": {
+            "operation": "ingress"
+          },
+          "directResponse": {
+            "body": {
+              "inlineString": "The CORS preflight request is missing one (or more) of the following required headers [Origin, Access-Control-Request-Method] or has an unmatched Origin header."
+            },
+            "status": 400
+          },
+          "match": {
+            "headers": [
+              {
+                "exactMatch": "OPTIONS",
+                "name": ":method"
+              }
+            ],
+            "prefix": "/"
+          }
+        },
+        {
+          "decorator": {
+            "operation": "ingress UnknownHttpMethodForPath_/echo"
+          },
+          "directResponse": {
+            "body": {
+              "inlineString": "The current request is matched to the defined url template \"/echo\" but its http method is not allowed"
+            },
+            "status": 405
+          },
+          "match": {
+            "path": "/echo"
+          }
+        },
+        {
+          "decorator": {
+            "operation": "ingress UnknownHttpMethodForPath_/echo"
+          },
+          "directResponse": {
+            "body": {
+              "inlineString": "The current request is matched to the defined url template \"/echo\" but its http method is not allowed"
+            },
+            "status": 405
+          },
+          "match": {
+            "path": "/echo/"
+          }
+        },
+        {
+          "decorator": {
+            "operation": "ingress UnknownOperationName"
+          },
+          "directResponse": {
+            "body": {
+              "inlineString": "The current request is not defined by this API."
+            },
+            "status": 404
+          },
+          "match": {
+            "prefix": "/"
+          }
+        }
+      ]
+    }
+  ]
+}`,
+		},
+		{
 			desc: "ensure the order of backend routes, 405 routes, cors exact origin routes, and 404 route",
 			fakeServiceConfig: &confpb.Service{
 				Name: testProjectName,


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

To fix: https://github.com/GoogleCloudPlatform/esp-v2/issues/578

This is a bug introduced by https://github.com/GoogleCloudPlatform/esp-v2/pull/575.  
It added header match for OPTIONS to match "origin".  But it only added as ExactMatch.   For "*", it should use PresentMatch.
