### PR TITLE
Added SkipEnvoyHealthCheck to fix some flaky integration tests

### DIFF
--- a/tests/integration_test/backend_auth_using_iam_test/backend_auth_using_iam_test.go
+++ b/tests/integration_test/backend_auth_using_iam_test/backend_auth_using_iam_test.go
@@ -89,7 +89,7 @@ func TestBackendAuthWithIamIdTokenRetries(t *testing.T) {
 	s.SetBackendAuthIamServiceAccount(serviceAccount)
 
 	// Health checks prevent envoy from starting up due to bad responses from IAM for tokens.
-	s.SkipHealthChecks()
+	s.SkipEnvoyHealthChecks()
 
 	testData := []struct {
 		desc           string

--- a/tests/integration_test/backend_auth_using_imds_test/backend_auth_using_imds_test.go
+++ b/tests/integration_test/backend_auth_using_imds_test/backend_auth_using_imds_test.go
@@ -123,7 +123,7 @@ func TestBackendAuthWithImdsIdTokenRetries(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			s := env.NewTestEnv(platform.TestBackendAuthWithImdsIdTokenRetries, platform.EchoRemote)
 			// Health checks prevent envoy from starting up due to bad responses from IMDS for tokens.
-			s.SkipHealthChecks()
+			s.SkipEnvoyHealthChecks()
 			s.OverrideMockMetadata(
 				map[string]string{
 					fmt.Sprintf("%v?format=standard&audience=https://%v/bearertoken/constant", util.IdentityTokenPath, platform.GetLoopbackAddress()): "ya29.constant",

--- a/tests/integration_test/backend_auth_using_imds_test/backend_auth_using_imds_test.go
+++ b/tests/integration_test/backend_auth_using_imds_test/backend_auth_using_imds_test.go
@@ -134,9 +134,6 @@ func TestBackendAuthWithImdsIdTokenRetries(t *testing.T) {
 				t.Fatalf("fail to setup test env, %v", err)
 			}
 
-			// Sleep some time to allow Envoy to startup.
-			time.Sleep(2 * time.Second)
-
 			url := fmt.Sprintf("http://%v:%v%v", platform.GetLoopbackAddress(), s.Ports().ListenerPort, tc.path)
 
 			// The first call should fail since IMDS is responding with failures.

--- a/tests/integration_test/iam_imds_data_path_test/iam_imds_data_path_test.go
+++ b/tests/integration_test/iam_imds_data_path_test/iam_imds_data_path_test.go
@@ -18,14 +18,12 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/endpoints/echo/client"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/env/platform"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
-	"github.com/golang/glog"
 )
 
 func TestIamImdsDataPath(t *testing.T) {
@@ -134,12 +132,6 @@ func TestIamImdsDataPath(t *testing.T) {
 			defer s.TearDown(t)
 			if err := s.Setup(tc.confArgs); err != nil {
 				t.Fatalf("fail to setup test env, %v", err)
-			}
-
-			if tc.wantErr != "" {
-				// When health checks are skipped (above), we need to manually sleep some time. Otherwise Envoy will not have time to try starting up.
-				glog.Infof("Sleeping to ensure Envoy is starting")
-				time.Sleep(10 * time.Second)
 			}
 
 			url := fmt.Sprintf("http://%v:%v%v", platform.GetLoopbackAddress(), s.Ports().ListenerPort, "/bearertoken/constant/42")

--- a/tests/integration_test/iam_imds_data_path_test/iam_imds_data_path_test.go
+++ b/tests/integration_test/iam_imds_data_path_test/iam_imds_data_path_test.go
@@ -128,7 +128,7 @@ func TestIamImdsDataPath(t *testing.T) {
 
 			if tc.wantErr != "" {
 				// When we expect a Envoy startup error, we must skip health checks. Otherwise they will prevent the test from running.
-				s.SkipHealthChecks()
+				s.SkipEnvoyHealthChecks()
 			}
 
 			defer s.TearDown(t)


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

For some token subscriber integration tests, it just skip all health checks.  It will have race conditions that Envoy may not come up on time when the curl request is issued.   This will result in un-expected error message. cause test to fail.

One way to fix it, to only skip health check on Listener port, but not on admin port to make sure Envoy come up before issuing the request.

b/196461535