### PR TITLE
b/195940890: Improve gcsrunner remote dependency handling

### DIFF
--- a/src/go/gcsrunner/fetch_config.go
+++ b/src/go/gcsrunner/fetch_config.go
@@ -91,10 +91,10 @@ func newDefaultCredsGCSClient(ctx context.Context) (gcsReader, error) {
 	start = time.Now()
 	c, err := storage.NewClient(ctx, option.WithCredentials(creds))
 	if err != nil {
-		glog.Errorf("error creating new GCS client with credentials: %v", err)
+		glog.Errorf("error creating new GCS client with default credentials: %v", err)
 		return nil, err
 	}
-	glog.Infof("created new GCS client with credentials in %s", time.Since(start))
+	glog.Infof("created new GCS client with default credentials in %s", time.Since(start))
 	return &gcsClient{c}, nil
 }
 

--- a/src/go/gcsrunner/fetch_config.go
+++ b/src/go/gcsrunner/fetch_config.go
@@ -139,7 +139,7 @@ func readBytes(opts FetchConfigOptions) ([]byte, error) {
 		} else {
 			client, err = newGCS(ctx, opts.ServiceAccount)
 			if err != nil {
-				glog.Errorf("error getting GCS client (retrying): %v", err)
+				glog.Errorf("error getting GCS client using service account (retrying): %v", err)
 				return err
 			}
 		}

--- a/src/go/gcsrunner/fetch_config_test.go
+++ b/src/go/gcsrunner/fetch_config_test.go
@@ -84,6 +84,9 @@ func readerFactory(r *mockReader, err error, passAfterRetrying bool) func(contex
 		if passAfterRetrying && callCount > 2 {
 			return r, nil
 		}
+		if err != nil {
+			return nil, err
+		}
 		return r, err
 	}
 }
@@ -94,6 +97,9 @@ func defaultCredsReaderFactory(r *mockReader, err error, passAfterRetrying bool)
 		callCount++
 		if passAfterRetrying && callCount > 2 {
 			return r, nil
+		}
+		if err != nil {
+			return nil, err
 		}
 		return r, err
 	}

--- a/src/go/gcsrunner/fetch_config_test.go
+++ b/src/go/gcsrunner/fetch_config_test.go
@@ -77,14 +77,24 @@ func (m *mockFile) Write(b []byte) (int, error) {
 	return len(b), nil
 }
 
-func readerFactory(r *mockReader, err error) func(context.Context, string) (gcsReader, error) {
+func readerFactory(r *mockReader, err error, passAfterRetrying bool) func(context.Context, string) (gcsReader, error) {
+	callCount := 0
 	return func(context.Context, string) (gcsReader, error) {
+		callCount++
+		if passAfterRetrying && callCount > 2 {
+			return r, nil
+		}
 		return r, err
 	}
 }
 
-func defaultCredsReaderFactory(r *mockReader, err error) func(context.Context) (gcsReader, error) {
+func defaultCredsReaderFactory(r *mockReader, err error, passAfterRetrying bool) func(context.Context) (gcsReader, error) {
+	callCount := 0
 	return func(context.Context) (gcsReader, error) {
+		callCount++
+		if passAfterRetrying && callCount > 2 {
+			return r, nil
+		}
 		return r, err
 	}
 }
@@ -108,14 +118,15 @@ func TestReadBytes(t *testing.T) {
 	output := []byte("some output")
 	testError := fmt.Errorf("test error")
 	testCases := []struct {
-		name                  string
-		wantErr               error
-		wantTimeoutErr        bool
-		opts                  FetchConfigOptions
-		reader                *mockReader
-		readerErr             error
-		defaultCredsReader    *mockReader
-		defaultCredsReaderErr error
+		name                               string
+		wantErr                            error
+		wantTimeoutErr                     bool
+		opts                               FetchConfigOptions
+		reader                             *mockReader
+		readerErr                          error
+		defaultCredsReader                 *mockReader
+		defaultCredsReaderErr              error
+		passAfterRetryingGCSClientCreation bool
 	}{
 		{
 			name: "success",
@@ -143,21 +154,42 @@ func TestReadBytes(t *testing.T) {
 			},
 		},
 		{
-			name:                  "error creating client",
+			name: "success retrying newGCS()",
+			opts: optsSA,
+			reader: &mockReader{
+				readerReturns: &mockFile{content: output},
+			},
+			readerErr:                          testError,
+			defaultCredsReaderErr:              fmt.Errorf("expected defaultCredsReader not to be called"),
+			passAfterRetryingGCSClientCreation: true,
+		},
+		{
+			name:      "success retrying newDefaultCredsGCS()",
+			opts:      optsNoSA,
+			readerErr: fmt.Errorf("expected reader not to be called"),
+			defaultCredsReader: &mockReader{
+				readerReturns: &mockFile{content: output},
+			},
+			defaultCredsReaderErr:              testError,
+			passAfterRetryingGCSClientCreation: true,
+		},
+
+		{
+			name:                  "timeout retrying newGCS()",
+			wantTimeoutErr:        true,
 			opts:                  optsSA,
-			wantErr:               testError,
 			readerErr:             testError,
 			defaultCredsReaderErr: fmt.Errorf("expected defaultCredsReader not to be called"),
 		},
 		{
-			name:                  "error creating client with creds",
+			name:                  "timeout retrying newDefaultCredsGCS()",
+			wantTimeoutErr:        true,
 			opts:                  optsNoSA,
-			wantErr:               testError,
 			readerErr:             fmt.Errorf("expected reader not to be called"),
 			defaultCredsReaderErr: testError,
 		},
 		{
-			name:           "timeout retrying newGCS",
+			name:           "timeout retrying client.Reader()",
 			wantTimeoutErr: true,
 			opts:           optsSA,
 			reader: &mockReader{
@@ -180,8 +212,8 @@ func TestReadBytes(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			oldNewGCS := newGCS
 			oldNewDefaultCredsGCS := newDefaultCredsGCS
-			newGCS = readerFactory(tc.reader, tc.readerErr)
-			newDefaultCredsGCS = defaultCredsReaderFactory(tc.defaultCredsReader, tc.defaultCredsReaderErr)
+			newGCS = readerFactory(tc.reader, tc.readerErr, tc.passAfterRetryingGCSClientCreation)
+			newDefaultCredsGCS = defaultCredsReaderFactory(tc.defaultCredsReader, tc.defaultCredsReaderErr, tc.passAfterRetryingGCSClientCreation)
 			defer func() {
 				newGCS = oldNewGCS
 				newDefaultCredsGCS = oldNewDefaultCredsGCS

--- a/src/go/gcsrunner/main/runner.go
+++ b/src/go/gcsrunner/main/runner.go
@@ -98,6 +98,7 @@ func main() {
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
 
+	start := time.Now()
 	if err := gcsrunner.FetchConfigFromGCS(gcsrunner.FetchConfigOptions{
 		BucketName:                    bucketName,
 		ConfigFileName:                configFileName,
@@ -108,6 +109,7 @@ func main() {
 	}); err != nil {
 		glog.Fatalf("Failed to fetch config: %v", err)
 	}
+	glog.Infof("fetched config from GCS in %s", time.Since(start))
 
 	if err := gcsrunner.StartEnvoyAndWait(signalChan, gcsrunner.StartEnvoyOptions{
 		BinaryPath:        envoyBin,

--- a/src/go/gcsrunner/serviceaccount.go
+++ b/src/go/gcsrunner/serviceaccount.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
+	"github.com/golang/glog"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 )
@@ -49,23 +50,34 @@ func TokenSource(ctx context.Context, sa string) (oauth2.TokenSource, error) {
 		return nil, err
 	}
 
+	start := time.Now()
 	c, err := google.FindDefaultCredentials(ctx)
 	if err != nil {
+		glog.Errorf("error finding default credentials: %v", err)
 		return nil, err
 	}
+	glog.Infof("found default credentials in %s", time.Since(start))
+
+	start = time.Now()
 	token, err := c.TokenSource.Token()
 	if err != nil {
+		glog.Errorf("error getting token: %v", err)
 		return nil, err
 	}
+	glog.Infof("obtained token in %s", time.Since(start))
 	token.SetAuthHeader(req)
 
 	client := http.Client{
 		Timeout: time.Second * 5,
 	}
+	start = time.Now()
 	resp, err := client.Do(req)
 	if err != nil {
+		glog.Errorf("error completing iamcredentials request: %v", err)
 		return nil, err
 	}
+	glog.Infof("iamcredentials request completed in %s", time.Since(start))
+
 	if resp.StatusCode != http.StatusOK {
 		respBody, err := ioutil.ReadAll(resp.Body)
 		if err != nil {


### PR DESCRIPTION
-Moved IAM Creds fetching into the backoff/retry loop
-Added logging for the duration of each individual RPC in addition to the overall end-to-end latency.
-Added logging for every external dependency error