### PR TITLE
b/198157523: Manually verify JWKS URI allows query param

### DIFF
--- a/src/go/configgenerator/filterconfig/filter_gen_jwt_authn_test.go
+++ b/src/go/configgenerator/filterconfig/filter_gen_jwt_authn_test.go
@@ -56,7 +56,7 @@ func TestJwtAuthnFilter(t *testing.T) {
 						{
 							Id:      "auth_provider",
 							Issuer:  "issuer-0",
-							JwksUri: "https://fake-jwks.com",
+							JwksUri: "https://fake-jwks.com?key=value",
 						},
 					},
 					Rules: []*confpb.AuthenticationRule{
@@ -101,7 +101,7 @@ func TestJwtAuthnFilter(t *testing.T) {
                     "httpUri": {
                         "cluster": "jwt-provider-cluster-fake-jwks.com:443",
                         "timeout": "30s",
-                        "uri": "https://fake-jwks.com"
+                        "uri": "https://fake-jwks.com?key=value"
                     },
                     "asyncFetch": {}
                 }

--- a/tests/env/testdata/fake_jwt.go
+++ b/tests/env/testdata/fake_jwt.go
@@ -76,7 +76,7 @@ var (
 			Id:               NonexistentProvider,
 			Issuer:           NonexistentIssuer,
 			IsNonexistent:    true,
-			HardcodedJwksUri: fmt.Sprintf("http://%v:55550/pkey", platform.GetLoopbackAddress()),
+			HardcodedJwksUri: fmt.Sprintf("http://%v:55550/pkey?key=value", platform.GetLoopbackAddress()),
 		},
 		{
 			Id:     ServiceControlProvider,

--- a/tests/integration_test/jwt_auth_integration_test/jwt_auth_integration_test.go
+++ b/tests/integration_test/jwt_auth_integration_test/jwt_auth_integration_test.go
@@ -166,24 +166,26 @@ func TestAsymmetricKeys(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		addr := fmt.Sprintf("%v:%v", platform.GetLoopbackAddress(), s.Ports().ListenerPort)
-		var resp string
-		var err error
-		if tc.queryInToken {
-			resp, err = client.MakeTokenInQueryCall(addr, tc.httpMethod, tc.method, tc.token)
-		} else {
-			resp, err = client.MakeCall(tc.clientProtocol, addr, tc.httpMethod, tc.method, tc.token, tc.headers)
-		}
-
-		if tc.wantError != "" && (err == nil || !strings.Contains(err.Error(), tc.wantError)) {
-			t.Errorf("Test (%s): failed, expected err: %v, got: %v", tc.desc, tc.wantError, err)
-		} else if tc.wantError == "" && err != nil {
-			t.Errorf("Test (%s): failed, expected no error, got error: %s", tc.desc, err)
-		} else {
-			if !strings.Contains(resp, tc.wantResp) {
-				t.Errorf("Test (%s): failed, expected: %s, got: %s", tc.desc, tc.wantResp, resp)
+		t.Run(tc.desc, func(t *testing.T) {
+			addr := fmt.Sprintf("%v:%v", platform.GetLoopbackAddress(), s.Ports().ListenerPort)
+			var resp string
+			var err error
+			if tc.queryInToken {
+				resp, err = client.MakeTokenInQueryCall(addr, tc.httpMethod, tc.method, tc.token)
+			} else {
+				resp, err = client.MakeCall(tc.clientProtocol, addr, tc.httpMethod, tc.method, tc.token, tc.headers)
 			}
-		}
+
+			if tc.wantError != "" && (err == nil || !strings.Contains(err.Error(), tc.wantError)) {
+				t.Errorf("Test (%s): failed, expected err: %v, got: %v", tc.desc, tc.wantError, err)
+			} else if tc.wantError == "" && err != nil {
+				t.Errorf("Test (%s): failed, expected no error, got error: %s", tc.desc, err)
+			} else {
+				if !strings.Contains(resp, tc.wantResp) {
+					t.Errorf("Test (%s): failed, expected: %s, got: %s", tc.desc, tc.wantResp, resp)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Integration test framework does not track JWKS URI as they are hardcoded. Instead, check Envoy debug logs to ensure correct request URI (with configured query params).

```
[2021-09-13 09:30:49.281][1489019][debug][jwt] [external/envoy/source/extensions/filters/http/jwt_authn/jwks_async_fetcher.cc:56] Jwks async fetching url=http://127.0.0.1:55550/pkey?key=value: started
[2021-09-13 09:30:49.281][1489019][debug][filter] [external/envoy/source/extensions/filters/http/common/jwks_fetcher.cc:117] fetch pubkey from [uri = http://127.0.0.1:55550/pkey?key=value]: start
[2021-09-13 09:30:49.281][1489019][debug][router] [external/envoy/source/common/router/router.cc:448] [C0][S748197045681916834] cluster 'jwt-provider-cluster-127.0.0.1:55550' match for URL '/pkey?key=value'
[2021-09-13 09:30:49.281][1489019][debug][router] [external/envoy/source/common/router/router.cc:635] [C0][S748197045681916834] router decoding headers:
':path', '/pkey?key=value'
':authority', '127.0.0.1:55550'
':method', 'GET'
':scheme', 'http'
'x-envoy-internal', 'true'
'x-forwarded-for', '100.117.29.170'
'x-envoy-expected-rq-timeout-ms', '30000'
```

Signed-off-by: Teju Nareddy <nareddyt@google.com>