### PR TITLE
b/200210941: Update application log format

### DIFF
--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -1333,7 +1333,7 @@ def gen_envoy_args(args):
            "--disable-hot-restart",
            # This will print logs in `glog` format.
            # Stackdriver logging integrates nicely with this format.
-           "--log-format %L%m%d %T.%e %t envoy] [%t][%n]%v",
+           "--log-format %L%m%d %T.%e %t %@] [%t][%n]%v",
            "--log-format-escaped"]
 
     if args.enable_debug:

--- a/src/go/gcsrunner/start_envoy.go
+++ b/src/go/gcsrunner/start_envoy.go
@@ -49,7 +49,7 @@ func StartEnvoyAndWait(signalChan chan os.Signal, opts StartEnvoyOptions) error 
 		"--config-path", opts.ConfigPath,
 		"--log-level", opts.LogLevel,
 		"--log-path", opts.LogPath,
-		"--log-format", "%L%m%d %T.%e %t envoy] [%t][%n]%v",
+		"--log-format", "%L%m%d %T.%e %t %@] [%t][%n]%v",
 		"--log-format-escaped",
 		"--allow-unknown-static-fields",
 	}

--- a/tests/start_proxy/start_proxy_test.py
+++ b/tests/start_proxy/start_proxy_test.py
@@ -777,7 +777,7 @@ class TestStartProxy(unittest.TestCase):
               [],
               ["bin/envoy", "-c", "/tmp/bootstrap.json",
                "--disable-hot-restart",
-               "--log-format %L%m%d %T.%e %t envoy] [%t][%n]%v",
+               "--log-format %L%m%d %T.%e %t %@] [%t][%n]%v",
                "--log-format-escaped"]
           ),
           # Debug mode enabled
@@ -785,7 +785,7 @@ class TestStartProxy(unittest.TestCase):
               ["--enable_debug"],
               ["bin/envoy", "-c", "/tmp/bootstrap.json",
                "--disable-hot-restart",
-               "--log-format %L%m%d %T.%e %t envoy] [%t][%n]%v",
+               "--log-format %L%m%d %T.%e %t %@] [%t][%n]%v",
                "--log-format-escaped",
                "-l debug",
                "--component-log-level upstream:info,main:info"]


### PR DESCRIPTION
Allows Cloud Logging to parse as glog format.

https://www.envoyproxy.io/docs/envoy/latest/operations/cli#operations-cli:

> `%@` = Source file and line (“my_file.cc:123”)

Testing Done: Manual log verification after e2e test, logs severity is parsed by Cloud Logging correctly.

![image](https://user-images.githubusercontent.com/11142171/133825580-a50d46fb-a358-4977-b1ac-37a71913ca76.png)

Signed-off-by: Teju Nareddy <nareddyt@google.com>