### PR TITLE
Update help text for flag enable_strict_transport_security

### DIFF
--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -225,8 +225,7 @@ environment variable or by passing "-k" flag to this script.
 
     parser.add_argument('--enable_strict_transport_security', action='store_true',
         help='''Enable HSTS (HTTP Strict Transport Security). "Strict-Transport-Security" response header
-        with value "max-age=31536000; includeSubdomains;" is added for all responses from local backend.
-        Not valid for remote backends.''')
+        with value "max-age=31536000; includeSubdomains;" is added for all responses.''')
 
     parser.add_argument('--generate_self_signed_cert', action='store_true',
         help='''Generate a self-signed certificate and key at start, then

--- a/src/go/bootstrap/static/bootstrap_test.go
+++ b/src/go/bootstrap/static/bootstrap_test.go
@@ -91,6 +91,7 @@ func TestServiceToBootstrapConfig(t *testing.T) {
 				opt.AdminPort = 0
 				opt.BackendAddress = "grpc://127.0.0.1:8082"
 				opt.DisableTracing = true
+				opt.EnableHSTS = true
 			},
 			serviceConfigPath: platform.GetFilePath(platform.GrpcEchoServiceConfig),
 			envoyConfigPath:   platform.GetFilePath(platform.GrpcEchoEnvoyConfig),

--- a/src/go/bootstrap/static/bootstrap_test.go
+++ b/src/go/bootstrap/static/bootstrap_test.go
@@ -91,7 +91,6 @@ func TestServiceToBootstrapConfig(t *testing.T) {
 				opt.AdminPort = 0
 				opt.BackendAddress = "grpc://127.0.0.1:8082"
 				opt.DisableTracing = true
-				opt.EnableHSTS = true
 			},
 			serviceConfigPath: platform.GetFilePath(platform.GrpcEchoServiceConfig),
 			envoyConfigPath:   platform.GetFilePath(platform.GrpcEchoEnvoyConfig),


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

To fix: https://github.com/GoogleCloudPlatform/esp-v2/issues/641

The current help text states that the flag only applies to local backend.  It is wrong,  it applies to all backends.