### PR TITLE
b/215322819: Support url templates with variables without wildcard

### DIFF
--- a/src/go/util/httppattern/uri_template.go
+++ b/src/go/util/httppattern/uri_template.go
@@ -175,11 +175,20 @@ func (u *UriTemplate) Regex(disallowColonInWildcardPathSegment bool) string {
 //    Variable = "{" FieldPath [ "=" Segments ] "}" ;
 func generateVariableBindingSyntax(segments []string, v *variable) string {
 	pathVar := bytes.Buffer{}
+	hasWildcard := false
 	for i := v.StartSegment; i < v.EndSegment; i += 1 {
 		pathVar.WriteString(segments[i])
 		if i != v.EndSegment-1 {
 			pathVar.WriteString("/")
 		}
+		if segments[i] == SingleWildCardKey || segments[i] == DoubleWildCardKey {
+			hasWildcard = true
+		}
+	}
+
+	// If a variable doesn't have any wildcard, just return its paths
+	if !hasWildcard {
+		return fmt.Sprintf("/%s", pathVar.String())
 	}
 
 	varName := bytes.Buffer{}

--- a/src/go/util/httppattern/uri_template_parser_test.go
+++ b/src/go/util/httppattern/uri_template_parser_test.go
@@ -78,6 +78,56 @@ func TestUriTemplateParse(t *testing.T) {
 `,
 		},
 		{
+			desc:        "ParseTest2a ",
+			UriTemplate: "/a/{var=b}",
+			wantUriTemplate: `
+{
+   "Origin":"/a/{var=b}",
+   "Segments":[
+      "a",
+      "b"
+   ],
+   "Variables":[
+     {
+       "EndSegment":2,
+       "FieldPath":[
+         "var"
+       ],
+       "HasDoubleWildCard":false,
+       "StartSegment":1
+     }
+   ],
+   "Verb":""
+}
+`,
+		},
+		{
+			desc:        "ParseTest2b",
+			UriTemplate: "/a/{var=b/c/d}",
+			wantUriTemplate: `
+{
+   "Origin":"/a/{var=b/c/d}",
+   "Segments":[
+      "a",
+      "b",
+      "c",
+      "d"
+   ],
+   "Variables":[
+      {
+        "EndSegment":4,
+        "FieldPath":[
+	   "var"
+        ],
+        "HasDoubleWildCard":false,
+        "StartSegment":1
+      }
+   ],
+   "Verb":""
+}
+`,
+		},
+		{
 			desc:        "ParseTest3a",
 			UriTemplate: "/**",
 			wantUriTemplate: `

--- a/src/go/util/httppattern/uri_template_test.go
+++ b/src/go/util/httppattern/uri_template_test.go
@@ -211,12 +211,24 @@ func TestReplaceVariableFieldInUriTemplate(t *testing.T) {
 			allowTrailingBackslash: true,
 			wantUriTemplate:        "/a/{BAR=c/**}/:verb",
 		},
+		{
+			desc:            "test ExactMatchString with variable without wildcard",
+			uriTemplate:     "/a/{x=b}",
+			wantUriTemplate: "/a/b",
+		},
+		{
+			desc:            "test ExactMatchString with variable without wildcard with multiple segments",
+			uriTemplate:     "/a/{x=b/c/d}",
+			wantUriTemplate: "/a/b/c/d",
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			uriTemplate, _ := ParseUriTemplate(tc.uriTemplate)
-			uriTemplate.ReplaceVariableField(tc.varReplace)
+			if tc.varReplace != nil {
+				uriTemplate.ReplaceVariableField(tc.varReplace)
+			}
 			if getUriTemplate := uriTemplate.ExactMatchString(tc.allowTrailingBackslash); getUriTemplate != tc.wantUriTemplate {
 				t.Errorf("fail to replace variable field, wante uriTemplate: %s, get uriTemplate: %s", tc.wantUriTemplate, getUriTemplate)
 			}

--- a/tests/env/testdata/fake_grpc_bookstore_service_config.go
+++ b/tests/env/testdata/fake_grpc_bookstore_service_config.go
@@ -142,6 +142,14 @@ var (
 					Pattern: &annotationspb.HttpRule_Get{
 						Get: "/v1/shelves/{shelf=*}",
 					},
+					// Add a additional binding to test a fixed variable
+					AdditionalBindings: []*annotationspb.HttpRule{
+						{
+							Pattern: &annotationspb.HttpRule_Get{
+								Get: "/v1/fixedshelves/{shelf=100}",
+							},
+						},
+					},
 				},
 				{
 					Selector: "endpoints.examples.bookstore.Bookstore.DeleteShelf",

--- a/tests/integration_test/transcoding_bindings_test/transcoding_bindings_test.go
+++ b/tests/integration_test/transcoding_bindings_test/transcoding_bindings_test.go
@@ -69,6 +69,15 @@ func TestTranscodingBindings(t *testing.T) {
 			method:         "/v1/shelves/100?key=api-key",
 			wantResp:       `{"id":"100","theme":"Kids"}`,
 		},
+		// HTTP template:
+		// GET /v1/fixedshelves/{shelf=100}
+		{
+			desc:           "Succeeded, made a ListShelf with a variable without wildcard",
+			clientProtocol: "http",
+			httpMethod:     "GET",
+			method:         "/v1/fixedshelves/100?key=api-key",
+			wantResp:       `{"id":"100","theme":"Kids"}`,
+		},
 		// Binding shelf=100 and book=<post body> in CreateBookRequest
 		// HTTP template:
 		// POST /shelves/{shelf}/books


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

To support following url template for grpc transcoding

```
/v1/{name=operations}
```

Supposedly,  a variable should have at least one wildcard * or double wildcard ** segment.  But above url template has a variable doesn't have any wildcard.  It is legal from the [syntax](https://github.com/googleapis/googleapis/blob/master/google/api/http.proto#L224-L232), hence add this pr to support it.

The details:
* url_template_parser is working fine,  added two cases to verifiy it in the url_template_parser_test.go
* The problem is in "ExactMatchString" function, when it see a variable it automaticadlly append `/{var=path}` which is wrong.  If there is not wildcard in the variable, just append `/path`
