### PR TITLE
Expose `--ads_named_pipe`

### DIFF
--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -61,11 +61,14 @@ def gen_bootstrap_conf(args):
     cmd = [BOOTSTRAP_CMD, "--logtostderr"]
 
     cmd.extend(["--admin_port", str(args.status_port)])
+
     if args.http_request_timeout_s:
         cmd.extend(
             ["--http_request_timeout_s",
              str(args.http_request_timeout_s)])
 
+    if args.ads_named_pipe:
+        cmd.extend(["--ads_named_pipe", args.ads_named_pipe])
 
     bootstrap_file = DEFAULT_CONFIG_DIR + BOOTSTRAP_CONFIG
     cmd.append(bootstrap_file)
@@ -877,6 +880,13 @@ environment variable or by passing "-k" flag to this script.
         
         [1]https://github.com/googleapis/googleapis/blob/165280d3deea4d225a079eb5c34717b214a5b732/google/api/http.proto#L226-L252
         ''')
+    parser.add_argument(
+        '--ads_named_pipe', action=None,
+        help='''
+        Unix domain socket to use internally for xDs between config manager and 
+        envoy. Only change if running multiple ESPv2 instances on the same host.
+        '''
+    )
 
     # Start Deprecated Flags Section
 
@@ -1389,6 +1399,9 @@ def gen_proxy_config(args):
 
     if args.enable_backend_address_override:
         proxy_conf.append("--enable_backend_address_override")
+
+    if args.ads_named_pipe:
+        proxy_conf.extend(["--ads_named_pipe", args.ads_named_pipe])
 
     return proxy_conf
 

--- a/tests/start_proxy/start_proxy_test.py
+++ b/tests/start_proxy/start_proxy_test.py
@@ -34,6 +34,10 @@ class TestStartProxy(unittest.TestCase):
              ['bin/bootstrap', '--logtostderr', '--admin_port', '8001',
               '--http_request_timeout_s', '1',
               '/tmp/bootstrap.json']),
+            (["--ads_named_pipe=@espv2-named-pipe-9", "--disable_tracing", "--admin_port=8001"],
+             ['bin/bootstrap', '--logtostderr', '--admin_port', '8001',
+              '--ads_named_pipe', '@espv2-named-pipe-9',
+              '/tmp/bootstrap.json']),
             ([], ['bin/bootstrap',
                   '--logtostderr', '--admin_port', '0',
                   '/tmp/bootstrap.json']),
@@ -752,6 +756,18 @@ class TestStartProxy(unittest.TestCase):
               '--health_check_grpc_backend',
               '--v', '0',
               '--service', 'test_bookstore.gloud.run'
+              ]),
+            # passing the flag --ads_named_pipe
+            (['--service=test_bookstore.gloud.run',
+              '--backend=grpc://127.0.0.1:8000',
+              '--ads_named_pipe=@espv2-named-pipe-9'
+              ],
+             ['bin/configmanager', '--logtostderr',
+              '--rollout_strategy', 'fixed',
+              '--backend_address', 'grpc://127.0.0.1:8000',
+              '--v', '0',
+              '--service', 'test_bookstore.gloud.run',
+              '--ads_named_pipe', '@espv2-named-pipe-9'
               ]),
             # passing the flags: --health_check_grp_backend, --health_check_grp_backend_interval and --health_check_grp_backend_service
             (['--service=test_bookstore.gloud.run',


### PR DESCRIPTION
Allows the flag to be set by the user to run multiple ESPv2 instances in a single pod / host.

Closes #657

Signed-off-by: Teju Nareddy <nareddyt@google.com>