### PR TITLE
Expose the `--config-yaml` envoy flag 

### DIFF
--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -887,6 +887,17 @@ environment variable or by passing "-k" flag to this script.
         envoy. Only change if running multiple ESPv2 instances on the same host.
         '''
     )
+    parser.add_argument(
+        '--config_yaml',
+        default=None,
+        help='''
+            Specify an additional bootstrap configuration for Envoy in the form of a YAML string.
+            Values will override and merge with any bootstrap configuration loaded with '--config-path'.
+            This will not override any value which has been set dynamically.
+
+            For more details see:
+            https://www.envoyproxy.io/docs/envoy/latest/operations/cli
+            ''')
 
     # Start Deprecated Flags Section
 
@@ -1417,6 +1428,9 @@ def gen_envoy_args(args):
         # Enable debug logging, but not for everything... too noisy otherwise.
         cmd.append("-l debug")
         cmd.append("--component-log-level upstream:info,main:info")
+
+    if args.config_yaml:
+        cmd.append("--config-yaml {}".format(args.config_yaml))
 
     return cmd
 


### PR DESCRIPTION
Allows the flag to be set by the user.
Enables passing a config YAML string to Envoy, for better controlling the bootstrap configuration as described [here](https://www.envoyproxy.io/docs/envoy/latest/operations/cli).

