### PR TITLE
Increase health check time

### DIFF
--- a/tests/env/components/health_check_helpers.go
+++ b/tests/env/components/health_check_helpers.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	// Max number of retries for a health check.
-	healthCheckRetries = 10
+	healthCheckRetries = 20
 
 	// Time to wait between each linear retry.
 	healthCheckRetryBackoff = 3 * time.Second


### PR DESCRIPTION
`TestRetryCallServiceManagement` fails because health checks exit too early

Signed-off-by: Teju Nareddy <nareddyt@google.com>