### PR TITLE
b/213477382: Correctly escape user-provided regex paths

### DIFF
--- a/src/go/util/httppattern/uri_template.go
+++ b/src/go/util/httppattern/uri_template.go
@@ -17,6 +17,7 @@ package httppattern
 import (
 	"bytes"
 	"fmt"
+	"regexp"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -158,7 +159,10 @@ func (u *UriTemplate) Regex(disallowColonInWildcardPathSegment bool) string {
 		case DoubleWildCardKey:
 			regex.WriteString(doubleWildcardReplacementRegex(disallowColonInWildcardPathSegment))
 		default:
-			regex.WriteString(segment)
+			// Segment provided by user may have regex special characters.
+			// Escape them to prevent incorrect path matching.
+			escapedSegment := regexp.QuoteMeta(segment)
+			regex.WriteString(escapedSegment)
 		}
 	}
 	regex.WriteString(optionalTrailingSlashRegex)

--- a/src/go/util/httppattern/uri_template_test.go
+++ b/src/go/util/httppattern/uri_template_test.go
@@ -295,6 +295,11 @@ func TestUriTemplateRegex(t *testing.T) {
 			includeColonInWildcard: true,
 			wantMatcher:            `^/v1/a/b/[^\/:]+/route/shelves/[^\/:]+/books/[^:]*\/?:upload$`,
 		},
+		{
+			desc:        "Paths with special characters are escaped",
+			uri:         "/$discovery",
+			wantMatcher: `^/\$discovery\/?$`,
+		},
 	}
 
 	for _, tc := range testData {


### PR DESCRIPTION
Signed-off-by: Teju Nareddy <nareddyt@google.com>