### PR TITLE
b/213477382: Add option to allow discovery APIs

### DIFF
--- a/src/go/configinfo/service_info.go
+++ b/src/go/configinfo/service_info.go
@@ -945,7 +945,7 @@ func (s *ServiceInfo) processAuthRequirement() error {
 
 func (s *ServiceInfo) isAPIAllowed(str string) bool {
 	// TODO(b/184393425): API discovery is not supported yet.
-	if strings.HasPrefix(str, "google.discovery") {
+	if strings.HasPrefix(str, "google.discovery") && !s.Options.AllowDiscoveryAPIs {
 		return false
 	}
 	if len(s.Options.APIAllowList) == 0 {

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -292,7 +292,10 @@ func EnvoyConfigOptionsFromFlags() options.ConfigGeneratorOptions {
 		TranscodingIgnoreUnknownQueryParameters:       *TranscodingIgnoreUnknownQueryParameters,
 		TranscodingQueryParametersDisableUnescapePlus: *TranscodingQueryParametersDisableUnescapePlus,
 		TranscodingMatchUnregisteredCustomVerb:        *TranscodingMatchUnregisteredCustomVerb,
-		APIAllowList:                                  []string{},
+
+		// These options are not for ESPv2 users. They are overridden internally.
+		APIAllowList:       []string{},
+		AllowDiscoveryAPIs: false,
 	}
 
 	glog.Infof("Config Generator options: %+v", opts)

--- a/src/go/options/configgenerator.go
+++ b/src/go/options/configgenerator.go
@@ -143,6 +143,7 @@ type ConfigGeneratorOptions struct {
 	TranscodingQueryParametersDisableUnescapePlus bool
 	TranscodingMatchUnregisteredCustomVerb        bool
 	APIAllowList                                  []string
+	AllowDiscoveryAPIs                            bool
 }
 
 // DefaultConfigGeneratorOptions returns ConfigGeneratorOptions with default values.
@@ -188,5 +189,6 @@ func DefaultConfigGeneratorOptions() ConfigGeneratorOptions {
 		HealthCheckGrpcBackendInterval:          1 * time.Second,
 		HealthCheckGrpcBackendNoTrafficInterval: 60 * time.Second,
 		APIAllowList:                            []string{},
+		AllowDiscoveryAPIs:                      false,
 	}
 }


### PR DESCRIPTION
There is no behavior change for ESPv2 users.
I will enable the option internally.

Signed-off-by: Teju Nareddy <nareddyt@google.com>