### PR TITLE
Fix service manage timeout

### DIFF
--- a/tests/env/env.go
+++ b/tests/env/env.go
@@ -34,7 +34,6 @@ import (
 
 const (
 	// Additional wait time after `TestEnv.Setup`
-	setupWaitTime = 1 * time.Second
 	initRolloutId = "test-rollout-id"
 )
 
@@ -80,6 +79,7 @@ type TestEnv struct {
 	skipHealthChecks                bool
 	skipEnvoyHealthChecks           bool
 	StatsVerifier                   *components.StatsVerifier
+	setupWaitTime                   time.Duration
 
 	// Only implemented for a subset of backends.
 	backendMTLSCertFile         string
@@ -107,12 +107,18 @@ func NewTestEnv(testId uint16, backend platform.Backend) *TestEnv {
 		healthRegistry:              components.NewHealthRegistry(),
 		FakeJwtService:              components.NewFakeJwtService(),
 		FakeStackdriverServer:       components.NewFakeStackdriver(),
+		setupWaitTime:               1 * time.Second,
 	}
 }
 
 // SetEnvoyDrainTimeInSec
 func (e *TestEnv) SetEnvoyDrainTimeInSec(envoyDrainTimeInSec int) {
 	e.envoyDrainTimeInSec = envoyDrainTimeInSec
+}
+
+// SetSetupWaitTime set the whole setup wait time
+func (e *TestEnv) SetSetupWaitTime(setupWaitTime time.Duration) {
+	e.setupWaitTime = setupWaitTime
 }
 
 // OverrideMockMetadata overrides mock metadata values given path to response map.
@@ -522,7 +528,7 @@ func (e *TestEnv) Setup(confArgs []string) error {
 		}
 	}
 
-	time.Sleep(setupWaitTime)
+	time.Sleep(e.setupWaitTime)
 
 	// Run health checks
 	if !e.skipHealthChecks {

--- a/tests/integration_test/managed_service_config_test/managed_service_config_test.go
+++ b/tests/integration_test/managed_service_config_test/managed_service_config_test.go
@@ -139,7 +139,7 @@ func TestRetryCallServiceManagement(t *testing.T) {
 		m:                  s.MockServiceManagementServer,
 		rejectWith429Times: 1,
 	}
-	// Since the first service fetch failed and retry, increase setup time to 3 seconds.
+	// Since the first service fetch failed and retry, increase setup wait time.
 	s.SetSetupWaitTime(5 * time.Second)
 
 	if err := s.Setup(args); err != nil {

--- a/tests/integration_test/managed_service_config_test/managed_service_config_test.go
+++ b/tests/integration_test/managed_service_config_test/managed_service_config_test.go
@@ -140,7 +140,8 @@ func TestRetryCallServiceManagement(t *testing.T) {
 		rejectWith429Times: 1,
 	}
 	// Since the first service fetch failed and retry, increase setup wait time.
-	s.SetSetupWaitTime(5 * time.Second)
+	// config_manager retry_interval is 10 seconds.
+	s.SetSetupWaitTime(15 * time.Second)
 
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)

--- a/tests/integration_test/managed_service_config_test/managed_service_config_test.go
+++ b/tests/integration_test/managed_service_config_test/managed_service_config_test.go
@@ -139,6 +139,8 @@ func TestRetryCallServiceManagement(t *testing.T) {
 		m:                  s.MockServiceManagementServer,
 		rejectWith429Times: 1,
 	}
+	// Since the first service fetch failed and retry, increase setup time to 3 seconds.
+	s.SetSetupWaitTime(5 * time.Second)
 
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)


### PR DESCRIPTION
Integration_test Managed_service_config_test has been flaky recently.   Increase its setup wait time.