### PR TITLE
Fix service_management_config integration test

### DIFF
--- a/src/envoy/token/token_subscriber.cc
+++ b/src/envoy/token/token_subscriber.cc
@@ -132,6 +132,11 @@ void TokenSubscriber::refresh() {
   if (thread_local_cluster) {
     active_request_ = thread_local_cluster->httpAsyncClient().send(
         std::move(message), *this, options);
+  } else {
+    // This code doesn't handle the wrong cluster name case.
+    // Assume it is due to the cluster is not ready.
+    ENVOY_LOG(warn, "{}: the cluster {} is not ready.", debug_name_, token_cluster_);
+    handleFailResponse();
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

Previous fix https://github.com/GoogleCloudPlatform/esp-v2/pull/676  is wrong.   The actual issue is: metadata-cluster may not be ready when TokenSubscriber trying to use it.   TokenSubscriber did not handle it correctly when the metadata cluster is not ready.

Changes:
* rollback the https://github.com/GoogleCloudPlatform/esp-v2/pull/676
* calll handleFailResponse() which will retry it in 2 seconds when the cluster is not ready.
* 