### PR TITLE
Revert "Fix service manage timeout (#676)"

### DIFF
--- a/tests/env/env.go
+++ b/tests/env/env.go
@@ -34,6 +34,7 @@ import (
 
 const (
 	// Additional wait time after `TestEnv.Setup`
+	setupWaitTime = 1 * time.Second
 	initRolloutId = "test-rollout-id"
 )
 
@@ -79,7 +80,6 @@ type TestEnv struct {
 	skipHealthChecks                bool
 	skipEnvoyHealthChecks           bool
 	StatsVerifier                   *components.StatsVerifier
-	setupWaitTime                   time.Duration
 
 	// Only implemented for a subset of backends.
 	backendMTLSCertFile         string
@@ -107,18 +107,12 @@ func NewTestEnv(testId uint16, backend platform.Backend) *TestEnv {
 		healthRegistry:              components.NewHealthRegistry(),
 		FakeJwtService:              components.NewFakeJwtService(),
 		FakeStackdriverServer:       components.NewFakeStackdriver(),
-		setupWaitTime:               1 * time.Second,
 	}
 }
 
 // SetEnvoyDrainTimeInSec
 func (e *TestEnv) SetEnvoyDrainTimeInSec(envoyDrainTimeInSec int) {
 	e.envoyDrainTimeInSec = envoyDrainTimeInSec
-}
-
-// SetSetupWaitTime set the whole setup wait time
-func (e *TestEnv) SetSetupWaitTime(setupWaitTime time.Duration) {
-	e.setupWaitTime = setupWaitTime
 }
 
 // OverrideMockMetadata overrides mock metadata values given path to response map.
@@ -528,7 +522,7 @@ func (e *TestEnv) Setup(confArgs []string) error {
 		}
 	}
 
-	time.Sleep(e.setupWaitTime)
+	time.Sleep(setupWaitTime)
 
 	// Run health checks
 	if !e.skipHealthChecks {

--- a/tests/integration_test/managed_service_config_test/managed_service_config_test.go
+++ b/tests/integration_test/managed_service_config_test/managed_service_config_test.go
@@ -139,9 +139,6 @@ func TestRetryCallServiceManagement(t *testing.T) {
 		m:                  s.MockServiceManagementServer,
 		rejectWith429Times: 1,
 	}
-	// Since the first service fetch failed and retry, increase setup wait time.
-	// config_manager retry_interval is 10 seconds.
-	s.SetSetupWaitTime(15 * time.Second)
 
 	if err := s.Setup(args); err != nil {
 		t.Fatalf("fail to setup test env, %v", err)


### PR DESCRIPTION
This reverts commit 71ca6d12f544f29eca24847a4097360fc74834f8.

The actual fix is:  https://github.com/GoogleCloudPlatform/esp-v2/pull/677