### PR TITLE
b/223679580: Add option to enable strict request validation in transcoder

### DIFF
--- a/src/go/configgenerator/filterconfig/filter_generator.go
+++ b/src/go/configgenerator/filterconfig/filter_generator.go
@@ -283,6 +283,12 @@ func makeTranscoderFilter(serviceInfo *ci.ServiceInfo) (*hcmpb.HttpFilter, error
 				},
 				MatchUnregisteredCustomVerb: serviceInfo.Options.TranscodingMatchUnregisteredCustomVerb,
 			}
+			if serviceInfo.Options.TranscodingStrictRequestValidation {
+				transcodeConfig.RequestValidationOptions = &transcoderpb.GrpcJsonTranscoder_RequestValidationOptions{
+					RejectUnknownMethod:          true,
+					RejectUnknownQueryParameters: true,
+				}
+			}
 
 			transcodeConfig.Services = append(transcodeConfig.Services, serviceInfo.ApiNames...)
 

--- a/src/go/options/configgenerator.go
+++ b/src/go/options/configgenerator.go
@@ -143,6 +143,7 @@ type ConfigGeneratorOptions struct {
 	TranscodingIgnoreUnknownQueryParameters       bool
 	TranscodingQueryParametersDisableUnescapePlus bool
 	TranscodingMatchUnregisteredCustomVerb        bool
+	TranscodingStrictRequestValidation            bool
 	APIAllowList                                  []string
 	AllowDiscoveryAPIs                            bool
 }


### PR DESCRIPTION
Non-configurable in ESPv2, default to false

Signed-off-by: Teju Nareddy <nareddyt@google.com>