### PR TITLE
fix flaky integration tests  by dynamic allocating token_agent_port

### DIFF
--- a/src/go/configgenerator/filterconfig/filter_generator.go
+++ b/src/go/configgenerator/filterconfig/filter_generator.go
@@ -58,9 +58,9 @@ type FilterGenerator struct {
 
 // The function type to generate filter config.
 // Return
-//  - the filter config
-//  - the methods needed to add per route config
-//  - the error
+//   - the filter config
+//   - the methods needed to add per route config
+//   - the error
 type FilterGenFunc func(sc *ci.ServiceInfo) (*hcmpb.HttpFilter, []*ci.MethodInfo, error)
 
 // MakeFilterGenerators provide of a slice of FilterGenerator in sequence.

--- a/src/go/configgenerator/listener_generator.go
+++ b/src/go/configgenerator/listener_generator.go
@@ -66,8 +66,8 @@ func AddPerRouteConfigGenToMethods(methods []*sc.MethodInfo, filterGen *filterco
 }
 
 // GetFilterConfigAndAddPerRouteConfigGen does two things
-//   * Return all http filter configs in a list
-//   * In place add the perRouteConfigGen function to all methods defined in serviceInfo
+//   - Return all http filter configs in a list
+//   - In place add the perRouteConfigGen function to all methods defined in serviceInfo
 func GetFilterConfigAndAddPerRouteConfigGen(serviceInfo *sc.ServiceInfo, filterGenerators []*filterconfig.FilterGenerator) ([]*hcmpb.HttpFilter, error) {
 	httpFilters := []*hcmpb.HttpFilter{}
 

--- a/src/go/tokengenerator/token_generator.go
+++ b/src/go/tokengenerator/token_generator.go
@@ -100,10 +100,11 @@ func generateAccessToken(keyData []byte) (string, time.Duration, error) {
 // It follows the following scheme:
 // Request: GET /local/access_token.
 // Response: access token response is a JSON payload in the format:
-// {
-//   "access_token": "string",
-//   "expires_in": uint
-// }
+//
+//	{
+//	  "access_token": "string",
+//	  "expires_in": uint
+//	}
 func MakeTokenAgentHandler(serviceAccountKey string) http.Handler {
 	r := mux.NewRouter()
 

--- a/src/go/util/httppattern/sort.go
+++ b/src/go/util/httppattern/sort.go
@@ -27,6 +27,7 @@ type MethodSlice []*Method
 // It will raise errors:
 //   - methods with duplicate http pattern
 //   - invalid uri template
+//
 // The time complexity is O(W * L), where W is the size of slice
 // and L is the size of uri template segments
 func Sort(methods *MethodSlice) error {

--- a/src/go/util/httppattern/uri_template.go
+++ b/src/go/util/httppattern/uri_template.go
@@ -176,7 +176,8 @@ func (u *UriTemplate) Regex(disallowColonInWildcardPathSegment bool) string {
 
 // `generateVariableBindingSyntax` tries to recover the following syntax with
 // replacement of fieldPathName.
-//    Variable = "{" FieldPath [ "=" Segments ] "}" ;
+//
+//	Variable = "{" FieldPath [ "=" Segments ] "}" ;
 func generateVariableBindingSyntax(segments []string, v *variable) string {
 	pathVar := bytes.Buffer{}
 	hasWildcard := false

--- a/tests/endpoints/bookstore_grpc/client/client.go
+++ b/tests/endpoints/bookstore_grpc/client/client.go
@@ -142,7 +142,7 @@ var MakeHttpCallWithDecode = func(addr, httpMethod, method, token string, header
 	return string(content), encoding, nil
 }
 
-//TODO(b/162626126): cleanup duplicate call methods.
+// TODO(b/162626126): cleanup duplicate call methods.
 func makeHTTP2Call(addr, httpMethod, method, token string, header http.Header) (string, error) {
 	cli := http.Client{
 		// Skip TLS dial

--- a/tests/endpoints/health_check/server.go
+++ b/tests/endpoints/health_check/server.go
@@ -70,11 +70,11 @@ func NewServer() (*Server, error) {
 // HealthyTime is the amount of time it takes for the service to be considered healthy.
 //
 // Example: startTime = 2 sec, healthyTime = 3 sec
+//
 //	Tick 0: Server not running
 //	Tick 1: Server not running
 //	Tick 2: Server running but unhealthy
 //	Tick 3: Server running and healthy
-//
 func (s *Server) StartServer(startTime time.Duration, healthyTime time.Duration) {
 
 	// Start a timer in the background to set the healthy status

--- a/tests/env/env.go
+++ b/tests/env/env.go
@@ -382,6 +382,7 @@ func (e *TestEnv) Setup(confArgs []string) error {
 
 	confArgs = append(confArgs, fmt.Sprintf("--listener_port=%v", e.ports.ListenerPort))
 	confArgs = append(confArgs, fmt.Sprintf("--service=%v", e.fakeServiceConfig.Name))
+	confArgs = append(confArgs, fmt.Sprintf("--token_agent_port=%v", e.ports.TokenAgentPort))
 
 	// Tracing configuration.
 	if e.enableTracing {

--- a/tests/env/platform/ports.go
+++ b/tests/env/platform/ports.go
@@ -170,7 +170,7 @@ const (
 	portBase uint16 = 20000
 
 	// Maximum number of ports used by non-jwt components.
-	portNum uint16 = 6
+	portNum uint16 = 7
 )
 
 const (
@@ -201,6 +201,7 @@ type Ports struct {
 	FakeStackdriverPort       uint16
 	DnsResolverPort           uint16
 	JwtRangeBase              uint16
+	TokenAgentPort            uint16
 	TestId                    uint16
 }
 
@@ -263,6 +264,7 @@ func NewPorts(testId uint16) *Ports {
 		FakeStackdriverPort:       base + 5,
 		DnsResolverPort:           base + 6,
 		JwtRangeBase:              base + 7,
+		TokenAgentPort:            base + 8,
 		TestId:                    testId,
 	}
 	glog.Infof(fmt.Sprintf("Ports generated for test(%v) are: %+v", testId, ports))


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

Integration tests are flaky due to token_agent port is fixed.   If tests are running in parallel,  or port is not released on-time, token_agent_server could not bind to the port.

Allocate a new port for token_agent. 