### PR TITLE
b/235088060: Add option to enable verbose tracing (not enabled, not exposed)

### DIFF
--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 # Copyright 2019 Google LLC
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -1341,6 +1344,8 @@ def gen_proxy_config(args):
         elif args.tracing_sample_rate:
             proxy_conf.extend(["--tracing_sample_rate",
                                str(args.tracing_sample_rate)])
+        if args.enable_debug:
+            proxy_conf.append("--tracing_enable_verbose_timing")
 
     if args.transcoding_always_print_primitive_fields:
         proxy_conf.append("--transcoding_always_print_primitive_fields")

--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -1345,7 +1345,7 @@ def gen_proxy_config(args):
             proxy_conf.extend(["--tracing_sample_rate",
                                str(args.tracing_sample_rate)])
         if args.enable_debug:
-            proxy_conf.append("--tracing_enable_verbose_timing")
+            proxy_conf.append("--tracing_enable_verbose_annotations")
 
     if args.transcoding_always_print_primitive_fields:
         proxy_conf.append("--transcoding_always_print_primitive_fields")

--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -1344,8 +1344,9 @@ def gen_proxy_config(args):
         elif args.tracing_sample_rate:
             proxy_conf.extend(["--tracing_sample_rate",
                                str(args.tracing_sample_rate)])
-        if args.enable_debug:
-            proxy_conf.append("--tracing_enable_verbose_annotations")
+        # TODO(nareddyt): Enable if we find it's helpful for gRPC streaming.
+        # if args.enable_debug:
+        #     proxy_conf.append("--tracing_enable_verbose_annotations")
 
     if args.transcoding_always_print_primitive_fields:
         proxy_conf.append("--transcoding_always_print_primitive_fields")

--- a/src/go/commonflags/flags.go
+++ b/src/go/commonflags/flags.go
@@ -27,24 +27,24 @@ var (
 	// Any flags in this file are used by both the ADS Bootstrapper (startup) and Config Generation via the static bootstrapper or config manager.
 	defaults = options.DefaultCommonOptions()
 
-	AdminAddress               = flag.String("admin_address", defaults.AdminAddress, "Address that envoy should serve the admin page on. Supports both ipv4 and ipv6 addresses.")
-	AdsNamedPipe               = flag.String("ads_named_pipe", defaults.AdsNamedPipe, "Unix domain socket to use internally for xDs between config manager and envoy.")
-	DisableTracing             = flag.Bool("disable_tracing", defaults.DisableTracing, `Disable stackdriver tracing`)
-	AdminPort                  = flag.Int("admin_port", defaults.AdminPort, "Enables envoy's admin interface on this port if it is not 0. Not recommended for production use-cases, as the admin port is unauthenticated.")
-	HttpRequestTimeoutS        = flag.Int("http_request_timeout_s", int(defaults.HttpRequestTimeout.Seconds()), `Set the timeout in second for all requests. Must be > 0 and the default is 30 seconds if not set.`)
-	Node                       = flag.String("node", defaults.Node, "envoy node id")
-	NonGCP                     = flag.Bool("non_gcp", defaults.NonGCP, `By default, the proxy tries to talk to GCP metadata server to get VM location in the first few requests. Setting this flag to true to skip this step`)
-	GeneratedHeaderPrefix      = flag.String("generated_header_prefix", defaults.GeneratedHeaderPrefix, "Set the header prefix for the generated headers. By default, it is `X-Endpoint-`")
-	TracingProjectId           = flag.String("tracing_project_id", defaults.TracingProjectId, "The Google project id required for Stack driver tracing. If not set, will automatically use fetch it from GCP Metadata server")
-	TracingStackdriverAddress  = flag.String("tracing_stackdriver_address", defaults.TracingStackdriverAddress, "By default, the Stackdriver exporter will connect to production Stackdriver. If this is non-empty, it will connect to this address. It must be in the gRPC format and implement the cloud trace v2 RPCs.")
-	TracingSamplingRate        = flag.Float64("tracing_sample_rate", defaults.TracingSamplingRate, "tracing sampling rate from 0.0 to 1.0")
-	TracingIncomingContext     = flag.String("tracing_incoming_context", defaults.TracingIncomingContext, "comma separated incoming trace contexts (traceparent|grpc-trace-bin|x-cloud-trace-context)")
-	TracingOutgoingContext     = flag.String("tracing_outgoing_context", defaults.TracingOutgoingContext, "comma separated outgoing trace contexts (traceparent|grpc-trace-bin|x-cloud-trace-context)")
-	TracingMaxNumAttributes    = flag.Int64("tracing_max_num_attributes", defaults.TracingMaxNumAttributes, "Sets the maximum number of attributes that each span can contain. Defaults to the maximum allowed by Stackdriver. In practice, the number of attributes published will be much less.")
-	TracingMaxNumAnnotations   = flag.Int64("tracing_max_num_annotations", defaults.TracingMaxNumAnnotations, "Sets the maximum number of annotations that each span can contain. Defaults to the maximum allowed by Stackdriver. In practice, the number of annotations published will be much less.")
-	TracingMaxNumMessageEvents = flag.Int64("tracing_max_num_message_events", defaults.TracingMaxNumMessageEvents, "Sets the maximum number of message events that each span can contain. Defaults to the maximum allowed by Stackdriver. In practice, the number of message events published will be much less.")
-	TracingMaxNumLinks         = flag.Int64("tracing_max_num_links", defaults.TracingMaxNumLinks, "Sets the maximum number of links that each span can contain. Defaults to the maximum allowed by Stackdriver. In practice, the number of links published will be much less.")
-	TracingEnableVerboseTiming = flag.Bool("tracing_enable_verbose_timing", defaults.TracingEnableVerboseTiming, "If enabled, spans are annotated with timing events on when the request/response started/ended")
+	AdminAddress                    = flag.String("admin_address", defaults.AdminAddress, "Address that envoy should serve the admin page on. Supports both ipv4 and ipv6 addresses.")
+	AdsNamedPipe                    = flag.String("ads_named_pipe", defaults.AdsNamedPipe, "Unix domain socket to use internally for xDs between config manager and envoy.")
+	DisableTracing                  = flag.Bool("disable_tracing", defaults.DisableTracing, `Disable stackdriver tracing`)
+	AdminPort                       = flag.Int("admin_port", defaults.AdminPort, "Enables envoy's admin interface on this port if it is not 0. Not recommended for production use-cases, as the admin port is unauthenticated.")
+	HttpRequestTimeoutS             = flag.Int("http_request_timeout_s", int(defaults.HttpRequestTimeout.Seconds()), `Set the timeout in second for all requests. Must be > 0 and the default is 30 seconds if not set.`)
+	Node                            = flag.String("node", defaults.Node, "envoy node id")
+	NonGCP                          = flag.Bool("non_gcp", defaults.NonGCP, `By default, the proxy tries to talk to GCP metadata server to get VM location in the first few requests. Setting this flag to true to skip this step`)
+	GeneratedHeaderPrefix           = flag.String("generated_header_prefix", defaults.GeneratedHeaderPrefix, "Set the header prefix for the generated headers. By default, it is `X-Endpoint-`")
+	TracingProjectId                = flag.String("tracing_project_id", defaults.TracingProjectId, "The Google project id required for Stack driver tracing. If not set, will automatically use fetch it from GCP Metadata server")
+	TracingStackdriverAddress       = flag.String("tracing_stackdriver_address", defaults.TracingStackdriverAddress, "By default, the Stackdriver exporter will connect to production Stackdriver. If this is non-empty, it will connect to this address. It must be in the gRPC format and implement the cloud trace v2 RPCs.")
+	TracingSamplingRate             = flag.Float64("tracing_sample_rate", defaults.TracingSamplingRate, "tracing sampling rate from 0.0 to 1.0")
+	TracingIncomingContext          = flag.String("tracing_incoming_context", defaults.TracingIncomingContext, "comma separated incoming trace contexts (traceparent|grpc-trace-bin|x-cloud-trace-context)")
+	TracingOutgoingContext          = flag.String("tracing_outgoing_context", defaults.TracingOutgoingContext, "comma separated outgoing trace contexts (traceparent|grpc-trace-bin|x-cloud-trace-context)")
+	TracingMaxNumAttributes         = flag.Int64("tracing_max_num_attributes", defaults.TracingMaxNumAttributes, "Sets the maximum number of attributes that each span can contain. Defaults to the maximum allowed by Stackdriver. In practice, the number of attributes published will be much less.")
+	TracingMaxNumAnnotations        = flag.Int64("tracing_max_num_annotations", defaults.TracingMaxNumAnnotations, "Sets the maximum number of annotations that each span can contain. Defaults to the maximum allowed by Stackdriver. In practice, the number of annotations published will be much less.")
+	TracingMaxNumMessageEvents      = flag.Int64("tracing_max_num_message_events", defaults.TracingMaxNumMessageEvents, "Sets the maximum number of message events that each span can contain. Defaults to the maximum allowed by Stackdriver. In practice, the number of message events published will be much less.")
+	TracingMaxNumLinks              = flag.Int64("tracing_max_num_links", defaults.TracingMaxNumLinks, "Sets the maximum number of links that each span can contain. Defaults to the maximum allowed by Stackdriver. In practice, the number of links published will be much less.")
+	TracingEnableVerboseAnnotations = flag.Bool("tracing_enable_verbose_annotations", defaults.TracingEnableVerboseAnnotations, "If enabled, spans are annotated with timing events on when the request/response started/ended")
 
 	//Suspected Envoy has listener initialization bug: if a http filter needs to use
 	//a cluster with DSN lookup for initialization, e.g. fetching a remote access
@@ -84,7 +84,7 @@ func DefaultCommonOptionsFromFlags() options.CommonOptions {
 		TracingMaxNumAnnotations:           *TracingMaxNumAnnotations,
 		TracingMaxNumMessageEvents:         *TracingMaxNumMessageEvents,
 		TracingMaxNumLinks:                 *TracingMaxNumLinks,
-		TracingEnableVerboseTiming:         *TracingEnableVerboseTiming,
+		TracingEnableVerboseAnnotations:    *TracingEnableVerboseAnnotations,
 		MetadataURL:                        *MetadataURL,
 		IamURL:                             *IamURL,
 		DisallowColonInWildcardPathSegment: *DisallowColonInWildcardPathSegment,

--- a/src/go/commonflags/flags.go
+++ b/src/go/commonflags/flags.go
@@ -44,6 +44,7 @@ var (
 	TracingMaxNumAnnotations   = flag.Int64("tracing_max_num_annotations", defaults.TracingMaxNumAnnotations, "Sets the maximum number of annotations that each span can contain. Defaults to the maximum allowed by Stackdriver. In practice, the number of annotations published will be much less.")
 	TracingMaxNumMessageEvents = flag.Int64("tracing_max_num_message_events", defaults.TracingMaxNumMessageEvents, "Sets the maximum number of message events that each span can contain. Defaults to the maximum allowed by Stackdriver. In practice, the number of message events published will be much less.")
 	TracingMaxNumLinks         = flag.Int64("tracing_max_num_links", defaults.TracingMaxNumLinks, "Sets the maximum number of links that each span can contain. Defaults to the maximum allowed by Stackdriver. In practice, the number of links published will be much less.")
+	TracingEnableVerboseTiming = flag.Bool("tracing_enable_verbose_timing", defaults.TracingEnableVerboseTiming, "If enabled, spans are annotated with timing events on when the request/response started/ended")
 
 	//Suspected Envoy has listener initialization bug: if a http filter needs to use
 	//a cluster with DSN lookup for initialization, e.g. fetching a remote access
@@ -83,6 +84,7 @@ func DefaultCommonOptionsFromFlags() options.CommonOptions {
 		TracingMaxNumAnnotations:           *TracingMaxNumAnnotations,
 		TracingMaxNumMessageEvents:         *TracingMaxNumMessageEvents,
 		TracingMaxNumLinks:                 *TracingMaxNumLinks,
+		TracingEnableVerboseTiming:         *TracingEnableVerboseTiming,
 		MetadataURL:                        *MetadataURL,
 		IamURL:                             *IamURL,
 		DisallowColonInWildcardPathSegment: *DisallowColonInWildcardPathSegment,

--- a/src/go/options/common.go
+++ b/src/go/options/common.go
@@ -39,6 +39,7 @@ type CommonOptions struct {
 	TracingMaxNumAnnotations   int64
 	TracingMaxNumMessageEvents int64
 	TracingMaxNumLinks         int64
+	TracingEnableVerboseTiming bool
 
 	// Flags for metadata
 	NonGCP             bool

--- a/src/go/options/common.go
+++ b/src/go/options/common.go
@@ -29,17 +29,17 @@ type CommonOptions struct {
 	GeneratedHeaderPrefix string
 
 	// Flags for tracing
-	DisableTracing             bool
-	TracingProjectId           string
-	TracingStackdriverAddress  string
-	TracingSamplingRate        float64
-	TracingIncomingContext     string
-	TracingOutgoingContext     string
-	TracingMaxNumAttributes    int64
-	TracingMaxNumAnnotations   int64
-	TracingMaxNumMessageEvents int64
-	TracingMaxNumLinks         int64
-	TracingEnableVerboseTiming bool
+	DisableTracing                  bool
+	TracingProjectId                string
+	TracingStackdriverAddress       string
+	TracingSamplingRate             float64
+	TracingIncomingContext          string
+	TracingOutgoingContext          string
+	TracingMaxNumAttributes         int64
+	TracingMaxNumAnnotations        int64
+	TracingMaxNumMessageEvents      int64
+	TracingMaxNumLinks              int64
+	TracingEnableVerboseAnnotations bool
 
 	// Flags for metadata
 	NonGCP             bool

--- a/src/go/tracing/tracing.go
+++ b/src/go/tracing/tracing.go
@@ -144,5 +144,6 @@ func CreateTracing(opts options.CommonOptions) (*hcmpb.HttpConnectionManager_Tra
 			Name:       "envoy.tracers.opencensus",
 			ConfigType: &tracepb.Tracing_Http_TypedConfig{TypedConfig: typedConfig},
 		},
+		Verbose: opts.TracingEnableVerboseTiming,
 	}, nil
 }

--- a/src/go/tracing/tracing.go
+++ b/src/go/tracing/tracing.go
@@ -144,6 +144,6 @@ func CreateTracing(opts options.CommonOptions) (*hcmpb.HttpConnectionManager_Tra
 			Name:       "envoy.tracers.opencensus",
 			ConfigType: &tracepb.Tracing_Http_TypedConfig{TypedConfig: typedConfig},
 		},
-		Verbose: opts.TracingEnableVerboseTiming,
+		Verbose: opts.TracingEnableVerboseAnnotations,
 	}, nil
 }

--- a/tests/start_proxy/start_proxy_test.py
+++ b/tests/start_proxy/start_proxy_test.py
@@ -544,6 +544,23 @@ class TestStartProxy(unittest.TestCase):
               '--tracing_stackdriver_address', 'localhost:9990',
               '--tracing_sample_rate', '1',
               ]),
+            # Enable debug affects tracing.
+            (['--service=test_bookstore.gloud.run',
+              '--backend=grpc://127.0.0.1:8000',
+              '--tracing_sample_rate=1',
+              '--version=2019-11-09r0',
+              '--enable_debug',
+              ],
+             ['bin/configmanager', '--logtostderr',
+              '--rollout_strategy', 'fixed',
+              '--backend_address', 'grpc://127.0.0.1:8000',
+              '--v', '1',
+              '--service', 'test_bookstore.gloud.run',
+              '--service_config_id', '2019-11-09r0',
+              '--tracing_sample_rate', '1',
+              '--tracing_enable_verbose_timing',
+              '--suppress_envoy_headers=false',
+              ]),
             # --disable_cloud_trace_auto_sampling overrides --tracing_sample_rate
             (['--service=test_bookstore.gloud.run',
               '--backend=grpc://127.0.0.1:8000',
@@ -837,7 +854,7 @@ class TestStartProxy(unittest.TestCase):
             print("==== checking flags [{}]".format(', '.join(flags)))
             gotArgs = gen_proxy_config(self.parser.parse_args(flags))
             self.assertEqual(gotArgs, wantedArgs,
-                             msg="Fail for input #{} [{}] : got != want".format(i, ', '.join(flags)))
+                             msg="Fail for input #{}: \ngot  {} \nwant {}".format(i, gotArgs, wantedArgs))
             i += 1
 
     def test_gen_proxy_config_error(self):

--- a/tests/start_proxy/start_proxy_test.py
+++ b/tests/start_proxy/start_proxy_test.py
@@ -558,7 +558,7 @@ class TestStartProxy(unittest.TestCase):
               '--service', 'test_bookstore.gloud.run',
               '--service_config_id', '2019-11-09r0',
               '--tracing_sample_rate', '1',
-              '--tracing_enable_verbose_timing',
+              '--tracing_enable_verbose_annotations',
               '--suppress_envoy_headers=false',
               ]),
             # --disable_cloud_trace_auto_sampling overrides --tracing_sample_rate

--- a/tests/start_proxy/start_proxy_test.py
+++ b/tests/start_proxy/start_proxy_test.py
@@ -558,7 +558,7 @@ class TestStartProxy(unittest.TestCase):
               '--service', 'test_bookstore.gloud.run',
               '--service_config_id', '2019-11-09r0',
               '--tracing_sample_rate', '1',
-              '--tracing_enable_verbose_annotations',
+              # '--tracing_enable_verbose_annotations',
               '--suppress_envoy_headers=false',
               ]),
             # --disable_cloud_trace_auto_sampling overrides --tracing_sample_rate


### PR DESCRIPTION
Unfortunately it is not looking very helpful from ESPv2 e2e tests. But I would like to expose this setting so we can test with streaming calls in Cloud ESF.

It is **disabled by default** and not exposed to ESPv2 users

Example:

![image](https://user-images.githubusercontent.com/11142171/179075499-eb28ae6b-cd2b-49e3-8f46-5b520e310527.png)

Signed-off-by: nareddyt <tejunareddy@gmail.com>