### PR TITLE
Update gcloud_build_image script to be more safe.

### DIFF
--- a/docker/serverless/gcloud_build_image
+++ b/docker/serverless/gcloud_build_image
@@ -92,10 +92,12 @@ if [ -z "${ESP_FULL_VERSION}" ]; then
 fi
 echo "Building image for ESP version: ${ESP_FULL_VERSION}"
 
-cd "$(mktemp -d /tmp/docker.XXXX)"
+tempdir="$(mktemp -d /tmp/docker.XXXX)"
+cd "$tempdir"
 
 # Be careful about exposing the access token.
-curl --fail -o "service.json" -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+access_token="$(gcloud auth print-access-token)"
+curl --fail -o "service.json" -H "Authorization: Bearer ${access_token}" \
   "https://servicemanagement.googleapis.com/v1/services/${SERVICE}/configs/${CONFIG_ID}?view=FULL" \
   || error_exit "Failed to download service config"
 

--- a/docker/serverless/gcloud_build_image
+++ b/docker/serverless/gcloud_build_image
@@ -97,9 +97,10 @@ cd "${tempdir}"
 
 # Be careful about exposing the access token.
 access_token="$(gcloud auth print-access-token)"
-curl --fail -o "service.json" -H "Authorization: Bearer ${access_token}" \
-  "https://servicemanagement.googleapis.com/v1/services/${SERVICE}/configs/${CONFIG_ID}?view=FULL" \
-  || error_exit "Failed to download service config"
+curl --fail -o "service.json" -H @- \
+  "https://servicemanagement.googleapis.com/v1/services/${SERVICE}/configs/${CONFIG_ID}?view=FULL" <<EOF || error_exit "Failed to download service config"
+Authorization: Bearer ${access_token}
+EOF
 
 (
 set -x

--- a/docker/serverless/gcloud_build_image
+++ b/docker/serverless/gcloud_build_image
@@ -93,7 +93,7 @@ fi
 echo "Building image for ESP version: ${ESP_FULL_VERSION}"
 
 tempdir="$(mktemp -d /tmp/docker.XXXX)"
-cd "$tempdir"
+cd "${tempdir}"
 
 # Be careful about exposing the access token.
 access_token="$(gcloud auth print-access-token)"


### PR DESCRIPTION
To fix https://github.com/GoogleCloudPlatform/esp-v2/issues/712

To fix two issues:

1) includes the output of `gcloud auth print-access-token` on the command line 

2)  does not check the return value of `mktemp -d /tmp/docker.XXXX`, 