### PR TITLE
fix build_envoy_image failure

### DIFF
--- a/docker/Dockerfile-envoy
+++ b/docker/Dockerfile-envoy
@@ -21,7 +21,7 @@ ENV LANG=C.UTF-8
 # Here we install GNU libc (aka glibc) and set C.UTF-8 locale as default.
 
 RUN ALPINE_GLIBC_BASE_URL="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" && \
-    ALPINE_GLIBC_PACKAGE_VERSION="2.35-r0" && \
+    ALPINE_GLIBC_PACKAGE_VERSION="2.34-r0" && \
     ALPINE_GLIBC_BASE_PACKAGE_FILENAME="glibc-$ALPINE_GLIBC_PACKAGE_VERSION.apk" && \
     ALPINE_GLIBC_BIN_PACKAGE_FILENAME="glibc-bin-$ALPINE_GLIBC_PACKAGE_VERSION.apk" && \
     ALPINE_GLIBC_I18N_PACKAGE_FILENAME="glibc-i18n-$ALPINE_GLIBC_PACKAGE_VERSION.apk" && \

--- a/docker/Dockerfile-envoy
+++ b/docker/Dockerfile-envoy
@@ -61,7 +61,7 @@ RUN ALPINE_GLIBC_BASE_URL="https://github.com/sgerrand/alpine-pkg-glibc/releases
 
 
 # Update to the latest
-# ping to baselayout=3.2.0-r22 to workaround issue: https://github.com/sgerrand/alpine-pkg-glibc/issues/185
+# pin to baselayout=3.2.0-r22 to workaround issue: https://github.com/sgerrand/alpine-pkg-glibc/issues/185
 RUN apk add alpine-baselayout=3.2.0-r22 && apk update && apk upgrade
 
 # Set the default root CA for gRpc.

--- a/docker/Dockerfile-envoy
+++ b/docker/Dockerfile-envoy
@@ -21,7 +21,7 @@ ENV LANG=C.UTF-8
 # Here we install GNU libc (aka glibc) and set C.UTF-8 locale as default.
 
 RUN ALPINE_GLIBC_BASE_URL="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" && \
-    ALPINE_GLIBC_PACKAGE_VERSION="2.34-r0" && \
+    ALPINE_GLIBC_PACKAGE_VERSION="2.35-r0" && \
     ALPINE_GLIBC_BASE_PACKAGE_FILENAME="glibc-$ALPINE_GLIBC_PACKAGE_VERSION.apk" && \
     ALPINE_GLIBC_BIN_PACKAGE_FILENAME="glibc-bin-$ALPINE_GLIBC_PACKAGE_VERSION.apk" && \
     ALPINE_GLIBC_I18N_PACKAGE_FILENAME="glibc-i18n-$ALPINE_GLIBC_PACKAGE_VERSION.apk" && \
@@ -61,7 +61,8 @@ RUN ALPINE_GLIBC_BASE_URL="https://github.com/sgerrand/alpine-pkg-glibc/releases
 
 
 # Update to the latest
-RUN apk update && apk upgrade
+# ping to baselayout=3.2.0-r22 to workaround issue: https://github.com/sgerrand/alpine-pkg-glibc/issues/185
+RUN apk add alpine-baselayout=3.2.0-r22 && apk update && apk upgrade
 
 # Set the default root CA for gRpc.
 # opensensus lib is using gRpc to call Stackdriver

--- a/tests/integration_test/service_control_access_token_test/service_control_access_token_test.go
+++ b/tests/integration_test/service_control_access_token_test/service_control_access_token_test.go
@@ -40,7 +40,7 @@ func TestServiceControlAccessTokenFromIam(t *testing.T) {
 
 	s.SetIamResps(
 		map[string]string{
-			fmt.Sprintf("/v1/projects/-/serviceAccounts/%s:generateAccessToken", serviceAccount): `{"accessToken":  "access-token-from-iam", "expireTime": "2022-10-02T15:01:23.045123456Z"}`,
+			fmt.Sprintf("/v1/projects/-/serviceAccounts/%s:generateAccessToken", serviceAccount): `{"accessToken":  "access-token-from-iam", "expireTime": "2124-10-02T15:01:23.045123456Z"}`,
 		}, 0, 0)
 
 	defer s.TearDown(t)


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

It failed with error:
```
Step #0 - "build-envoy-image": ERROR: alpine-baselayout-data-3.2.0-r23: trying to overwrite etc/nsswitch.conf owned by glibc-2.35-r0.
```

Not to upgrade to glic2.35,  our envoy binary doesn't compatible with it, it failed to load with errors:

```
Error relocating /lib/ld-linux-x86-64.so.2: unsupported relocation type 37
```

