### PR TITLE
b/254093361: fix status comparison for py2->py3

### DIFF
--- a/tests/e2e/client/apiproxy_transcoding_fuzz_test.py
+++ b/tests/e2e/client/apiproxy_transcoding_fuzz_test.py
@@ -127,7 +127,7 @@ class ApiProxyTranscodingFuzzTest(object):
 
   def _check_for_crash(self):
     status = self._get_status()
-    if status != "LIVE":
+    if status != b'LIVE':
       print(status)
       sys.exit(utils.red(
           'ESPv2 crash'))


### PR DESCRIPTION
[Test failure before](https://screenshot.googleplex.com/5VyQ7oeovxfR6Vh)

[Test success now](https://screenshot.googleplex.com/3p7xhJrqXiQvfMs)