### PR TITLE
Add two jwt_authn flags: "jwt_cache_size" and "jwks_async_fetch_fast_listener"

### DIFF
--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -581,7 +581,7 @@ environment variable or by passing "-k" flag to this script.
         action='store_true',
         default=False,
         help='''
-        Only apply when jwks_async_fetch is enabled. This flag determines if the envoy will wait
+        Only apply when --disable_jwks_async_fetch flag is not set. This flag determines if the envoy will wait
         for jwks_async_fetch to complete before binding the listener port. If false, it will wait.
         Default is false.'''
     )

--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -577,6 +577,22 @@ environment variable or by passing "-k" flag to this script.
         to the request processing latency. Default is enabled.'''
     )
     parser.add_argument(
+        '--jwks_async_fetch_fast_listener',
+        action='store_true',
+        default=False,
+        help='''
+        Only apply when jwks_async_fetch is enabled. This flag determines if the envoy will wait
+        for jwks_async_fetch to complete before binding the listener port. If false, it will wait.
+        Default is false.'''
+    )
+    parser.add_argument(
+        '--jwt_cache_size',
+        default=None,
+        help='''
+        Specify JWT cache size, the number of unique JWT tokens in the cache. The cache only stores
+        verified good tokens. If 0, JWT cache is disabled. The default is 0.'''
+    )
+    parser.add_argument(
         '--jwks_cache_duration_in_s',
         default=None,
         help='''
@@ -1146,6 +1162,10 @@ def gen_proxy_config(args):
 
     if args.disable_jwks_async_fetch:
         proxy_conf.append("--disable_jwks_async_fetch")
+    if args.jwks_async_fetch_fast_listener:
+        proxy_conf.append("--jwks_async_fetch_fast_listener")
+    if args.jwt_cache_size:
+         proxy_conf.extend(["--jwt_cache_size", args.jwt_cache_size])
     if args.jwks_cache_duration_in_s:
          proxy_conf.extend(["--jwks_cache_duration_in_s", args.jwks_cache_duration_in_s])
     if args.jwks_fetch_num_retries:

--- a/src/go/configgenerator/filterconfig/filter_gen_jwt_authn.go
+++ b/src/go/configgenerator/filterconfig/filter_gen_jwt_authn.go
@@ -78,7 +78,9 @@ var jaFilterGenFunc = func(serviceInfo *ci.ServiceInfo) (*hcmpb.HttpFilter, []*c
 			},
 		}
 		if !serviceInfo.Options.DisableJwksAsyncFetch {
-			jwks.AsyncFetch = &jwtpb.JwksAsyncFetch{}
+			jwks.AsyncFetch = &jwtpb.JwksAsyncFetch{
+				FastListener: serviceInfo.Options.JwksAsyncFetchFastListener,
+			}
 		}
 		if serviceInfo.Options.JwksFetchNumRetries > 0 {
 			// only create a retry policy, evenutally with a backoff if it is required.
@@ -116,6 +118,12 @@ var jaFilterGenFunc = func(serviceInfo *ci.ServiceInfo) (*hcmpb.HttpFilter, []*c
 			// See b/147834348 for more information on this default behavior.
 			defaultAudience := fmt.Sprintf("https://%v", serviceInfo.Name)
 			jp.Audiences = append(jp.Audiences, defaultAudience)
+		}
+
+		if serviceInfo.Options.JwtCacheSize > 0 {
+			jp.JwtCacheConfig = &jwtpb.JwtCacheConfig{
+				JwtCacheSize: uint32(serviceInfo.Options.JwtCacheSize),
+			}
 		}
 
 		// TODO(taoxuy): add unit test

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -136,7 +136,7 @@ var (
 			If not provided, Envoy will decide the default value.`)
 
 	DisableJwksAsyncFetch      = flag.Bool("disable_jwks_async_fetch", defaults.DisableJwksAsyncFetch, `When the feature is enabled, JWKS is fetched before processing any requests. When disabled, JWKS is fetched on-demand when processing the requests.`)
-	JwksAsyncFetchFastListener = flag.Bool("jwks_async_fetch_fast_listener", defaults.JwksAsyncFetchFastListener, `Only apply when jwks_async_fetch is enabled. This flag determines if the envoy will wait for jwks_async_fetch to complete before binding the listener port. If false, it will wait. Default is false.`)
+	JwksAsyncFetchFastListener = flag.Bool("jwks_async_fetch_fast_listener", defaults.JwksAsyncFetchFastListener, `Only apply when --disable_jwks_async_fetch flag is not set. This flag determines if the envoy will wait for jwks_async_fetch to complete before binding the listener port. If false, it will wait. Default is false.`)
 	JwksCacheDurationInS       = flag.Int("jwks_cache_duration_in_s", defaults.JwksCacheDurationInS, "Specify JWT public key cache duration in seconds. The default is 5 minutes.")
 
 	JwksFetchNumRetries                 = flag.Int("jwks_fetch_num_retries", defaults.JwksFetchNumRetries, `Specify the remote JWKS fetch retry policy's number of retries. The default is 0, meaning no retry policy applied.`)

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -135,14 +135,16 @@ var (
 	ConnectionBufferLimitBytes = flag.Int("connection_buffer_limit_bytes", defaults.ConnectionBufferLimitBytes, `Configure the maximum amount of data that is buffered for each request/response body. 
 			If not provided, Envoy will decide the default value.`)
 
-	DisableJwksAsyncFetch = flag.Bool("disable_jwks_async_fetch", defaults.DisableJwksAsyncFetch, `When the feature is enabled, JWKS is fetched before processing any requests. When disabled, JWKS is fetched on-demand when processing the requests.`)
-	JwksCacheDurationInS  = flag.Int("jwks_cache_duration_in_s", defaults.JwksCacheDurationInS, "Specify JWT public key cache duration in seconds. The default is 5 minutes.")
+	DisableJwksAsyncFetch      = flag.Bool("disable_jwks_async_fetch", defaults.DisableJwksAsyncFetch, `When the feature is enabled, JWKS is fetched before processing any requests. When disabled, JWKS is fetched on-demand when processing the requests.`)
+	JwksAsyncFetchFastListener = flag.Bool("jwks_async_fetch_fast_listener", defaults.JwksAsyncFetchFastListener, `Only apply when jwks_async_fetch is enabled. This flag determines if the envoy will wait for jwks_async_fetch to complete before binding the listener port. If false, it will wait. Default is false.`)
+	JwksCacheDurationInS       = flag.Int("jwks_cache_duration_in_s", defaults.JwksCacheDurationInS, "Specify JWT public key cache duration in seconds. The default is 5 minutes.")
 
 	JwksFetchNumRetries                 = flag.Int("jwks_fetch_num_retries", defaults.JwksFetchNumRetries, `Specify the remote JWKS fetch retry policy's number of retries. The default is 0, meaning no retry policy applied.`)
 	JwksFetchRetryBackOffBaseIntervalMs = flag.Int("jwks_fetch_retry_back_off_base_interval_ms", int(defaults.JwksFetchRetryBackOffBaseInterval.Milliseconds()), `Specify JWKS fetch retry exponential back off base interval in milliseconds. The default is 200 milliseconds.`)
 	JwksFetchRetryBackOffMaxIntervalMs  = flag.Int("jwks_fetch_retry_back_off_max_interval_ms", int(defaults.JwksFetchRetryBackOffMaxInterval.Milliseconds()), `Specify JWKS fetch retry exponential back off maximum interval in milliseconds. The default is 32 seconds.`)
 	JwtPatForwardPayloadHeader          = flag.Bool("jwt_pad_forward_payload_header", defaults.JwtPadForwardPayloadHeader, `For the JWT in request, the JWT payload is forwarded to backend in the "X-Endpoint-API-UserInfo"" header by default. 
 Normally JWT based64 encode doesn’t add padding. If this flag is true, the header will be padded.`)
+	JwtCacheSize = flag.Uint("jwt_cache_size", defaults.JwtCacheSize, `Specify JWT cache size, the number of unique JWT tokens in the cache. The cache only stores verified good tokens. If 0, JWT cache is disabled. The default is 0.`)
 
 	ScCheckTimeoutMs  = flag.Int("service_control_check_timeout_ms", defaults.ScCheckTimeoutMs, `Set the timeout in millisecond for service control Check request. Must be > 0 and the default is 1000 if not set.`)
 	ScQuotaTimeoutMs  = flag.Int("service_control_quota_timeout_ms", defaults.ScQuotaTimeoutMs, `Set the timeout in millisecond for service control Quota request. Must be > 0 and the default is 1000 if not set.`)
@@ -274,11 +276,13 @@ func EnvoyConfigOptionsFromFlags() options.ConfigGeneratorOptions {
 		EnableGrpcForHttp1:                            *EnableGrpcForHttp1,
 		ConnectionBufferLimitBytes:                    *ConnectionBufferLimitBytes,
 		DisableJwksAsyncFetch:                         *DisableJwksAsyncFetch,
+		JwksAsyncFetchFastListener:                    *JwksAsyncFetchFastListener,
 		JwksCacheDurationInS:                          *JwksCacheDurationInS,
 		JwksFetchNumRetries:                           *JwksFetchNumRetries,
 		JwksFetchRetryBackOffBaseInterval:             time.Duration(*JwksFetchRetryBackOffBaseIntervalMs) * time.Millisecond,
 		JwksFetchRetryBackOffMaxInterval:              time.Duration(*JwksFetchRetryBackOffMaxIntervalMs) * time.Millisecond,
 		JwtPadForwardPayloadHeader:                    *JwtPatForwardPayloadHeader,
+		JwtCacheSize:                                  *JwtCacheSize,
 		BackendRetryOns:                               *BackendRetryOns,
 		BackendRetryNum:                               *BackendRetryNum,
 		BackendPerTryTimeout:                          *BackendPerTryTimeout,

--- a/src/go/options/configgenerator.go
+++ b/src/go/options/configgenerator.go
@@ -115,11 +115,13 @@ type ConfigGeneratorOptions struct {
 
 	// JwtAuthn related flags
 	DisableJwksAsyncFetch             bool
+	JwksAsyncFetchFastListener        bool
 	JwksCacheDurationInS              int
 	JwksFetchNumRetries               int
 	JwksFetchRetryBackOffBaseInterval time.Duration
 	JwksFetchRetryBackOffMaxInterval  time.Duration
 	JwtPadForwardPayloadHeader        bool
+	JwtCacheSize                      uint
 
 	ScCheckTimeoutMs  int
 	ScQuotaTimeoutMs  int
@@ -165,10 +167,12 @@ func DefaultConfigGeneratorOptions() ConfigGeneratorOptions {
 		StreamIdleTimeout:                       util.DefaultIdleTimeout,
 		EnvoyXffNumTrustedHops:                  2,
 		DisableJwksAsyncFetch:                   false,
+		JwksAsyncFetchFastListener:              false,
 		JwksCacheDurationInS:                    300,
 		JwksFetchNumRetries:                     0,
 		JwksFetchRetryBackOffBaseInterval:       200 * time.Millisecond,
 		JwksFetchRetryBackOffMaxInterval:        32 * time.Second,
+		JwtCacheSize:                            0,
 		ListenerAddress:                         "0.0.0.0",
 		ListenerPort:                            8080,
 		TokenAgentPort:                          8791,

--- a/tests/start_proxy/start_proxy_test.py
+++ b/tests/start_proxy/start_proxy_test.py
@@ -108,7 +108,7 @@ class TestStartProxy(unittest.TestCase):
               '--check_metadata', '--underscores_in_headers',
               '--disable_tracing'
               ]),
-            # enable_jwks_async_fetch
+            # disable_jwks_async_fetch
             (['-R=managed','--disable_jwks_async_fetch',
               '--http_port=8079', '--service_control_quota_retries=3',
               '--service_control_report_timeout_ms=300',
@@ -117,6 +117,36 @@ class TestStartProxy(unittest.TestCase):
              ['bin/configmanager', '--logtostderr', '--rollout_strategy', 'managed',
               '--backend_address', 'http://127.0.0.1:8082', '--v', '0',
               '--disable_jwks_async_fetch',
+              '--listener_port', '8079',
+              '--service_control_quota_retries', '3',
+              '--service_control_report_timeout_ms', '300',
+              '--check_metadata', '--underscores_in_headers',
+              '--disable_tracing'
+              ]),
+            # jwks_async_fetch_fast_listener
+            (['-R=managed','--jwks_async_fetch_fast_listener',
+              '--http_port=8079', '--service_control_quota_retries=3',
+              '--service_control_report_timeout_ms=300',
+              '--check_metadata',
+              '--disable_tracing', '--underscores_in_headers'],
+             ['bin/configmanager', '--logtostderr', '--rollout_strategy', 'managed',
+              '--backend_address', 'http://127.0.0.1:8082', '--v', '0',
+              '--jwks_async_fetch_fast_listener',
+              '--listener_port', '8079',
+              '--service_control_quota_retries', '3',
+              '--service_control_report_timeout_ms', '300',
+              '--check_metadata', '--underscores_in_headers',
+              '--disable_tracing'
+              ]),
+            # jwt_cache_size
+            (['-R=managed','--jwt_cache_size=300',
+              '--http_port=8079', '--service_control_quota_retries=3',
+              '--service_control_report_timeout_ms=300',
+              '--check_metadata',
+              '--disable_tracing', '--underscores_in_headers'],
+             ['bin/configmanager', '--logtostderr', '--rollout_strategy', 'managed',
+              '--backend_address', 'http://127.0.0.1:8082', '--v', '0',
+              '--jwt_cache_size', '300',
               '--listener_port', '8079',
               '--service_control_quota_retries', '3',
               '--service_control_report_timeout_ms', '300',


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

The flag `--jwt_cache_size` can be used to enable jwt cache

The flag `--jwks_async_fetch_fast_listener` is useful in some rare cases where async_fetch first fetch is slow or it always fails and retrying.   