### PR TITLE
Fix again for build_envoy_image

### DIFF
--- a/docker/Dockerfile-envoy
+++ b/docker/Dockerfile-envoy
@@ -40,11 +40,13 @@ RUN ALPINE_GLIBC_BASE_URL="https://github.com/sgerrand/alpine-pkg-glibc/releases
         "$ALPINE_GLIBC_BASE_URL/$ALPINE_GLIBC_PACKAGE_VERSION/$ALPINE_GLIBC_BASE_PACKAGE_FILENAME" \
         "$ALPINE_GLIBC_BASE_URL/$ALPINE_GLIBC_PACKAGE_VERSION/$ALPINE_GLIBC_BIN_PACKAGE_FILENAME" \
         "$ALPINE_GLIBC_BASE_URL/$ALPINE_GLIBC_PACKAGE_VERSION/$ALPINE_GLIBC_I18N_PACKAGE_FILENAME" && \
-    apk add --no-cache \
+    mv /etc/nsswitch.conf /etc/nsswitch.conf.bak && \
+    apk add --no-cache --force-overwrite \
         "$ALPINE_GLIBC_BASE_PACKAGE_FILENAME" \
         "$ALPINE_GLIBC_BIN_PACKAGE_FILENAME" \
         "$ALPINE_GLIBC_I18N_PACKAGE_FILENAME" && \
     \
+    mv /etc/nsswitch.conf.bak /etc/nsswitch.conf && \
     rm "/etc/apk/keys/sgerrand.rsa.pub" && \
     (/usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true) && \
     echo "export LANG=$LANG" > /etc/profile.d/locale.sh && \
@@ -61,8 +63,7 @@ RUN ALPINE_GLIBC_BASE_URL="https://github.com/sgerrand/alpine-pkg-glibc/releases
 
 
 # Update to the latest
-# pin to baselayout=3.2.0-r22 to workaround issue: https://github.com/sgerrand/alpine-pkg-glibc/issues/185
-RUN apk add alpine-baselayout=3.2.0-r22 && apk update && apk upgrade
+RUN apk update && apk upgrade
 
 # Set the default root CA for gRpc.
 # opensensus lib is using gRpc to call Stackdriver


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

The last [fix](https://github.com/GoogleCloudPlatform/esp-v2/pull/737)  is fragile.  It broke again.

This time, we copy the change from [here](https://github.com/Docker-Hub-frolvlad/docker-alpine-glibc/commit/564ac8eb814acaa18d1a9f0d006f8afb8f9cf291)

