### PR TITLE
start_proxy to pass SIGTERM signal to envoy and config_mgr 

### DIFF
--- a/docker/Dockerfile-proxy.tmpl
+++ b/docker/Dockerfile-proxy.tmpl
@@ -26,9 +26,9 @@ RUN pip3 install --no-cache --upgrade pip setuptools
 ENV PATH /bin:$PATH
 
 ADD docker/generic/* /apiproxy/
-RUN chmod +r /apiproxy/start_proxy.py
 ADD bin/bootstrap /bin/
 ADD bin/configmanager /bin/
+RUN chmod +rx /apiproxy/start_proxy.py /bin/envoy /bin/bootstrap /bin/configmanager
 
 # create envoy user and group
 RUN addgroup -S envoy && adduser --no-create-home -S envoy -G envoy

--- a/docker/Dockerfile-proxy.tmpl
+++ b/docker/Dockerfile-proxy.tmpl
@@ -26,6 +26,7 @@ RUN pip3 install --no-cache --upgrade pip setuptools
 ENV PATH /bin:$PATH
 
 ADD docker/generic/* /apiproxy/
+RUN chmod +r /apiproxy/start_proxy.py
 ADD bin/bootstrap /bin/
 ADD bin/configmanager /bin/
 

--- a/docker/Dockerfile-proxy.tmpl
+++ b/docker/Dockerfile-proxy.tmpl
@@ -28,7 +28,6 @@ ENV PATH /bin:$PATH
 ADD docker/generic/* /apiproxy/
 ADD bin/bootstrap /bin/
 ADD bin/configmanager /bin/
-RUN chmod +rx /apiproxy/start_proxy.py /bin/envoy /bin/bootstrap /bin/configmanager
 
 # create envoy user and group
 RUN addgroup -S envoy && adduser --no-create-home -S envoy -G envoy

--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -61,6 +61,9 @@ GOOGLE_CREDS_KEY = "GOOGLE_APPLICATION_CREDENTIALS"
 SERVERLESS_PLATFORM = "Cloud Run(ESPv2)"
 SERVERLESS_XFF_NUM_TRUSTED_HOPS = 0
 
+# child pid list
+pid_list = []
+
 def gen_bootstrap_conf(args):
     cmd = [BOOTSTRAP_CMD, "--logtostderr"]
 

--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -24,7 +24,6 @@ import subprocess
 import sys
 import threading
 import time
-from datetime import datetime
 
 # The command to generate Envoy bootstrap config
 BOOTSTRAP_CMD = "bin/bootstrap"
@@ -1522,7 +1521,7 @@ def start_envoy(args):
 def sigterm_handler(signum, frame):
     """ Handler for SIGTERM and SIGINT, pass the SIGTERM to all child processes. """
     signame = signal.Signals(signum).name
-    logging.warning("{}: got signal: {}".format(datetime.utcnow().isoformat(timespec='microseconds'), signame))
+    logging.warning("got signal: {}".format(signame))
 
     global pid_list
     for pid in pid_list:
@@ -1532,11 +1531,9 @@ def sigterm_handler(signum, frame):
         except OSError:
             logging.error("error sending TERM to PID={} continuing".format(pid))
 
-    logging.info("exiting...")
-    sys.exit(0)
 
 if __name__ == '__main__':
-    logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
+    logging.basicConfig(format='%(asctime)s: %(levelname)s: %(message)s', level=logging.INFO)
 
     parser = make_argparser()
     args = parser.parse_args()

--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -24,6 +24,7 @@ import subprocess
 import sys
 import threading
 import time
+from datetime import datetime
 
 # The command to generate Envoy bootstrap config
 BOOTSTRAP_CMD = "bin/bootstrap"
@@ -33,7 +34,7 @@ CONFIGMANAGER_BIN = "bin/configmanager"
 ENVOY_BIN = "bin/envoy"
 
 # Health check period in secs, for Config Manager and Envoy.
-HEALTH_CHECK_PERIOD = 60
+HEALTH_CHECK_PERIOD = 2
 
 # bootstrap config file will write here.
 # By default, envoy writes some logs to /tmp too
@@ -1520,7 +1521,7 @@ def start_envoy(args):
 
 def sigterm_handler(signum, frame):
     """ Handler for SIGTERM, pass the signal to all child processes. """
-    logging.warning("got SIGTERM")
+    logging.warning("{}: got SIGTERM".format(datetime.utcnow().isoformat(timespec='microseconds')))
 
     global pid_list
     for pid in pid_list:

--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -1548,6 +1548,8 @@ if __name__ == '__main__':
 
     while True:
         time.sleep(HEALTH_CHECK_PERIOD)
+        logging.info("poll cm_prc: {}".format(cm_proc.poll()))
+        logging.info("poll envoy_prc: {}".format(envoy_proc.poll()))
         if not cm_proc or cm_proc.poll():
             logging.fatal("Config Manager is down, killing all processes.")
             if envoy_proc:

--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -1521,7 +1521,11 @@ def start_envoy(args):
 
 def sigterm_handler(signum, frame):
     """ Handler for SIGTERM, pass the signal to all child processes. """
-    logging.warning("{}: got SIGTERM".format(datetime.utcnow().isoformat(timespec='microseconds')))
+    signame = signal.Signals(signum).name
+    logging.warning("{}: got signal: {}".format(datetime.utcnow().isoformat(timespec='microseconds'), signame))
+
+def shutdown():
+    """ shut down all child processes """
 
     global pid_list
     for pid in pid_list:
@@ -1543,6 +1547,10 @@ if __name__ == '__main__':
     pid_list.append(cm_proc.pid)
     pid_list.append(envoy_proc.pid)
     signal.signal(signal.SIGTERM, sigterm_handler)
+    signal.signal(signal.SIGINT, sigterm_handler)
+    signal.signal(signal.SIGHUP, sigterm_handler)
+    signal.signal(signal.SIGCHLD, sigterm_handler)
+    signal.signal(signal.SIGUSR1, sigterm_handler)
 
     while True:
         time.sleep(HEALTH_CHECK_PERIOD)

--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -1520,15 +1520,15 @@ def start_envoy(args):
 
 def sigterm_handler(signum, frame):
     """ Handler for SIGTERM, pass the signal to all child processes. """
-    logger.warning("got SIGTERM")
+    logging.warning("got SIGTERM")
 
     global pid_list
     for pid in pid_list:
-        logger.info("sending TERM to PID={}".format(pid))
+        logging.info("sending TERM to PID={}".format(pid))
         try:
             os.kill(pid, signal.SIGTERM)
         except OSError:
-            logger.error("error sending TERM to PID={} continuing".format(pid))
+            logging.error("error sending TERM to PID={} continuing".format(pid))
 
 if __name__ == '__main__':
     logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)

--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -1524,16 +1524,6 @@ def sigterm_handler(signum, frame):
     signame = signal.Signals(signum).name
     logging.warning("{}: got signal: {}".format(datetime.utcnow().isoformat(timespec='microseconds'), signame))
 
-    shutdown()
-
-def siginfo_handler(signum, frame):
-    """ Handler for other signals, just log the signals."""
-    signame = signal.Signals(signum).name
-    logging.warning("{}: got signal: {}".format(datetime.utcnow().isoformat(timespec='microseconds'), signame))
-
-def shutdown():
-    """ shut down all child processes """
-
     global pid_list
     for pid in pid_list:
         logging.info("sending TERM to PID={}".format(pid))
@@ -1558,9 +1548,6 @@ if __name__ == '__main__':
     pid_list.append(envoy_proc.pid)
     signal.signal(signal.SIGTERM, sigterm_handler)
     signal.signal(signal.SIGINT, sigterm_handler)
-    signal.signal(signal.SIGHUP, siginfo_handler)
-    signal.signal(signal.SIGCHLD, siginfo_handler)
-    signal.signal(signal.SIGUSR1, siginfo_handler)
 
     while True:
         time.sleep(HEALTH_CHECK_PERIOD)

--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -1550,6 +1550,10 @@ if __name__ == '__main__':
         time.sleep(HEALTH_CHECK_PERIOD)
         logging.info("poll cm_prc: {}".format(cm_proc.poll()))
         logging.info("poll envoy_prc: {}".format(envoy_proc.poll()))
+        for pid in pid_list:
+            ret_pid, exit_status = os.waitpid(pid, os.WNOHANG)
+            logging.info("===waitpid: pid={}: waitpid return: {}, {}".format(pid, ret_pid, exit_status))
+            
         if not cm_proc or cm_proc.poll():
             logging.fatal("Config Manager is down, killing all processes.")
             if envoy_proc:

--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -1535,11 +1535,18 @@ def child_process_is_alive(pid):
     """ Detect if a child process is still running. """
     try:
         ret_pid, exit_status = os.waitpid(pid, os.WNOHANG)
-        logging.info("===waitpid: pid={}: waitpid return: {}, {}".format(pid, ret_pid, exit_status))
         return True
     except ChildProcessError:
         logging.info("===waitpid: pid={}: doesn't exit".format(pid))
         return False
+
+def kill_child_process(pid):
+    """ Kill a child process. """
+    try:
+        logging.info("Killing process: pid={}".format(pid))
+        os.kill(pid, signal.SIGKILL)
+    except:
+        logging.error("The child process: pid={} may not exist.".format(pid))
 
 if __name__ == '__main__':
     logging.basicConfig(format='%(asctime)s: %(levelname)s: %(message)s', level=logging.INFO)
@@ -1558,13 +1565,13 @@ if __name__ == '__main__':
     while True:
         time.sleep(HEALTH_CHECK_PERIOD)
         if not cm_proc or not child_process_is_alive(cm_proc.pid):
-            logging.fatal("Config Manager is down, killing all processes.")
+            logging.fatal("Config Manager is down, killing envoy process.")
             if envoy_proc:
-               os.kill(envoy_proc.pid, signal.SIGKILL)
+                kill_child_process(envoy_proc.pid)
             sys.exit(1)
         if not envoy_proc or not child_process_is_alive(envoy_proc.pid):
-            logging.fatal("Envoy is down, killing all processes.")
+            logging.fatal("Envoy is down, killing Config Manager process.")
             if cm_proc:
-               os.kill(cm_proc.pid, signal.SIGKILL)
+                kill_child_process(cm_proc.pid)
             sys.exit(1)
 


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

To fix:  https://github.com/GoogleCloudPlatform/esp-v2/issues/743


start_proxy.py is the parent process starting envoy and config_mgr processes.   But it did not handle SIGTERM  signal, it cause the "kubectrl delete pod" needs to wait for `grace-peirod`.

