### PR TITLE
Enable jwt cache by default for jwt authentication.

### DIFF
--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -589,8 +589,9 @@ environment variable or by passing "-k" flag to this script.
         '--jwt_cache_size',
         default=None,
         help='''
-        Specify JWT cache size, the number of unique JWT tokens in the cache. The cache only stores
-        verified good tokens. If 0, JWT cache is disabled. The default is 0.'''
+        Specify JWT cache size, the number of unique JWT tokens in the cache. The cache only stores verified
+        good tokens. If 0, JWT cache is disabled. It limits the memory usage. The cache used memory
+        is roughly (token size + 64 bytes) per token. If not specified, the default is 100000.'''
     )
     parser.add_argument(
         '--jwks_cache_duration_in_s',

--- a/examples/auth/envoy_config.json
+++ b/examples/auth/envoy_config.json
@@ -187,6 +187,9 @@
                               "access_token"
                             ],
                             "issuer": "123456789-compute@developer.gserviceaccount.com",
+                            "jwtCacheConfig": {
+                              "jwtCacheSize": 1000
+                            },
                             "payloadInMetadata": "jwt_payloads",
                             "remoteJwks": {
                               "asyncFetch": {},
@@ -217,6 +220,9 @@
                               "access_token"
                             ],
                             "issuer": "https://securetoken.google.com/apiproxy-231719",
+                            "jwtCacheConfig": {
+                              "jwtCacheSize": 1000
+                            },
                             "payloadInMetadata": "jwt_payloads",
                             "remoteJwks": {
                               "asyncFetch": {},
@@ -247,6 +253,9 @@
                               "access_token"
                             ],
                             "issuer": "https://accounts.google.com",
+                            "jwtCacheConfig": {
+                              "jwtCacheSize": 1000
+                            },
                             "payloadInMetadata": "jwt_payloads",
                             "remoteJwks": {
                               "asyncFetch": {},

--- a/examples/auth/envoy_config.json
+++ b/examples/auth/envoy_config.json
@@ -188,7 +188,7 @@
                             ],
                             "issuer": "123456789-compute@developer.gserviceaccount.com",
                             "jwtCacheConfig": {
-                              "jwtCacheSize": 1000
+                              "jwtCacheSize": 100000
                             },
                             "payloadInMetadata": "jwt_payloads",
                             "remoteJwks": {
@@ -221,7 +221,7 @@
                             ],
                             "issuer": "https://securetoken.google.com/apiproxy-231719",
                             "jwtCacheConfig": {
-                              "jwtCacheSize": 1000
+                              "jwtCacheSize": 100000
                             },
                             "payloadInMetadata": "jwt_payloads",
                             "remoteJwks": {
@@ -254,7 +254,7 @@
                             ],
                             "issuer": "https://accounts.google.com",
                             "jwtCacheConfig": {
-                              "jwtCacheSize": 1000
+                              "jwtCacheSize": 100000
                             },
                             "payloadInMetadata": "jwt_payloads",
                             "remoteJwks": {

--- a/examples/grpc_dynamic_routing/envoy_config.json
+++ b/examples/grpc_dynamic_routing/envoy_config.json
@@ -269,6 +269,9 @@
                               "access_token"
                             ],
                             "issuer": "e2e-client-jwk@cloudesf-testing.iam.gserviceaccount.com",
+                            "jwtCacheConfig": {
+                              "jwtCacheSize": 1000
+                            },
                             "payloadInMetadata": "jwt_payloads",
                             "remoteJwks": {
                               "asyncFetch": {},

--- a/examples/grpc_dynamic_routing/envoy_config.json
+++ b/examples/grpc_dynamic_routing/envoy_config.json
@@ -270,7 +270,7 @@
                             ],
                             "issuer": "e2e-client-jwk@cloudesf-testing.iam.gserviceaccount.com",
                             "jwtCacheConfig": {
-                              "jwtCacheSize": 1000
+                              "jwtCacheSize": 100000
                             },
                             "payloadInMetadata": "jwt_payloads",
                             "remoteJwks": {

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -144,7 +144,7 @@ var (
 	JwksFetchRetryBackOffMaxIntervalMs  = flag.Int("jwks_fetch_retry_back_off_max_interval_ms", int(defaults.JwksFetchRetryBackOffMaxInterval.Milliseconds()), `Specify JWKS fetch retry exponential back off maximum interval in milliseconds. The default is 32 seconds.`)
 	JwtPatForwardPayloadHeader          = flag.Bool("jwt_pad_forward_payload_header", defaults.JwtPadForwardPayloadHeader, `For the JWT in request, the JWT payload is forwarded to backend in the "X-Endpoint-API-UserInfo"" header by default. 
 Normally JWT based64 encode doesn’t add padding. If this flag is true, the header will be padded.`)
-	JwtCacheSize = flag.Uint("jwt_cache_size", defaults.JwtCacheSize, `Specify JWT cache size, the number of unique JWT tokens in the cache. The cache only stores verified good tokens. If 0, JWT cache is disabled. The default is 1000.`)
+	JwtCacheSize = flag.Uint("jwt_cache_size", defaults.JwtCacheSize, `Specify JWT cache size, the number of unique JWT tokens in the cache. The cache only stores verified good tokens. If 0, JWT cache is disabled. It limits the memory usage. The cache used memory is roughly (token size + 64 bytes) per token. If not specified, the default is 100000.`)
 
 	ScCheckTimeoutMs  = flag.Int("service_control_check_timeout_ms", defaults.ScCheckTimeoutMs, `Set the timeout in millisecond for service control Check request. Must be > 0 and the default is 1000 if not set.`)
 	ScQuotaTimeoutMs  = flag.Int("service_control_quota_timeout_ms", defaults.ScQuotaTimeoutMs, `Set the timeout in millisecond for service control Quota request. Must be > 0 and the default is 1000 if not set.`)

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -144,7 +144,7 @@ var (
 	JwksFetchRetryBackOffMaxIntervalMs  = flag.Int("jwks_fetch_retry_back_off_max_interval_ms", int(defaults.JwksFetchRetryBackOffMaxInterval.Milliseconds()), `Specify JWKS fetch retry exponential back off maximum interval in milliseconds. The default is 32 seconds.`)
 	JwtPatForwardPayloadHeader          = flag.Bool("jwt_pad_forward_payload_header", defaults.JwtPadForwardPayloadHeader, `For the JWT in request, the JWT payload is forwarded to backend in the "X-Endpoint-API-UserInfo"" header by default. 
 Normally JWT based64 encode doesn’t add padding. If this flag is true, the header will be padded.`)
-	JwtCacheSize = flag.Uint("jwt_cache_size", defaults.JwtCacheSize, `Specify JWT cache size, the number of unique JWT tokens in the cache. The cache only stores verified good tokens. If 0, JWT cache is disabled. The default is 0.`)
+	JwtCacheSize = flag.Uint("jwt_cache_size", defaults.JwtCacheSize, `Specify JWT cache size, the number of unique JWT tokens in the cache. The cache only stores verified good tokens. If 0, JWT cache is disabled. The default is 1000.`)
 
 	ScCheckTimeoutMs  = flag.Int("service_control_check_timeout_ms", defaults.ScCheckTimeoutMs, `Set the timeout in millisecond for service control Check request. Must be > 0 and the default is 1000 if not set.`)
 	ScQuotaTimeoutMs  = flag.Int("service_control_quota_timeout_ms", defaults.ScQuotaTimeoutMs, `Set the timeout in millisecond for service control Quota request. Must be > 0 and the default is 1000 if not set.`)

--- a/src/go/configmanager/testdata/test_fetch_listeners.go
+++ b/src/go/configmanager/testdata/test_fetch_listeners.go
@@ -352,7 +352,7 @@ var (
                       ],
                       "issuer": "https://test_issuer.google.com/",
                       "jwtCacheConfig": {
-                        "jwtCacheSize": 1000
+                        "jwtCacheSize": 100000
                       },
                       "payloadInMetadata": "jwt_payloads",
                       "remoteJwks": {
@@ -637,7 +637,7 @@ var (
                       ],
                       "issuer": "https://test_issuer.google.com/",
                       "jwtCacheConfig": {
-                        "jwtCacheSize": 1000
+                        "jwtCacheSize": 100000
                       },
                       "payloadInMetadata": "jwt_payloads",
                       "remoteJwks": {
@@ -1157,7 +1157,7 @@ var (
                       ],
                       "issuer": "https://test_issuer.google.com/",
                       "jwtCacheConfig": {
-                        "jwtCacheSize": 1000
+                        "jwtCacheSize": 100000
                       },
                       "payloadInMetadata": "jwt_payloads",
                       "remoteJwks": {
@@ -1190,7 +1190,7 @@ var (
                       ],
                       "issuer": "https://test_issuer.google.com/",
                       "jwtCacheConfig": {
-                        "jwtCacheSize": 1000
+                        "jwtCacheSize": 100000
                       },
                       "payloadInMetadata": "jwt_payloads",
                       "remoteJwks": {
@@ -2161,7 +2161,7 @@ var (
                       ],
                       "issuer": "https://test_issuer.google.com/",
                       "jwtCacheConfig": {
-                        "jwtCacheSize": 1000
+                        "jwtCacheSize": 100000
                       },
                       "payloadInMetadata": "jwt_payloads",
                       "remoteJwks": {

--- a/src/go/configmanager/testdata/test_fetch_listeners.go
+++ b/src/go/configmanager/testdata/test_fetch_listeners.go
@@ -351,6 +351,9 @@ var (
                         "access_token"
                       ],
                       "issuer": "https://test_issuer.google.com/",
+                      "jwtCacheConfig": {
+                        "jwtCacheSize": 1000
+                      },
                       "payloadInMetadata": "jwt_payloads",
                       "remoteJwks": {
                         "cacheDuration": "300s",
@@ -633,6 +636,9 @@ var (
                         "access_token"
                       ],
                       "issuer": "https://test_issuer.google.com/",
+                      "jwtCacheConfig": {
+                        "jwtCacheSize": 1000
+                      },
                       "payloadInMetadata": "jwt_payloads",
                       "remoteJwks": {
                         "cacheDuration": "300s",
@@ -1150,6 +1156,9 @@ var (
                         "access_token"
                       ],
                       "issuer": "https://test_issuer.google.com/",
+                      "jwtCacheConfig": {
+                        "jwtCacheSize": 1000
+                      },
                       "payloadInMetadata": "jwt_payloads",
                       "remoteJwks": {
                         "cacheDuration": "300s",
@@ -1180,6 +1189,9 @@ var (
                         "access_token"
                       ],
                       "issuer": "https://test_issuer.google.com/",
+                      "jwtCacheConfig": {
+                        "jwtCacheSize": 1000
+                      },
                       "payloadInMetadata": "jwt_payloads",
                       "remoteJwks": {
                         "cacheDuration": "300s",
@@ -2148,6 +2160,9 @@ var (
                         "access_token"
                       ],
                       "issuer": "https://test_issuer.google.com/",
+                      "jwtCacheConfig": {
+                        "jwtCacheSize": 1000
+                      },
                       "payloadInMetadata": "jwt_payloads",
                       "remoteJwks": {
                         "cacheDuration": "300s",

--- a/src/go/options/configgenerator.go
+++ b/src/go/options/configgenerator.go
@@ -172,7 +172,7 @@ func DefaultConfigGeneratorOptions() ConfigGeneratorOptions {
 		JwksFetchNumRetries:                     0,
 		JwksFetchRetryBackOffBaseInterval:       200 * time.Millisecond,
 		JwksFetchRetryBackOffMaxInterval:        32 * time.Second,
-		JwtCacheSize:                            1000,
+		JwtCacheSize:                            100 * 1000,
 		ListenerAddress:                         "0.0.0.0",
 		ListenerPort:                            8080,
 		TokenAgentPort:                          8791,

--- a/src/go/options/configgenerator.go
+++ b/src/go/options/configgenerator.go
@@ -172,7 +172,7 @@ func DefaultConfigGeneratorOptions() ConfigGeneratorOptions {
 		JwksFetchNumRetries:                     0,
 		JwksFetchRetryBackOffBaseInterval:       200 * time.Millisecond,
 		JwksFetchRetryBackOffMaxInterval:        32 * time.Second,
-		JwtCacheSize:                            0,
+		JwtCacheSize:                            1000,
 		ListenerAddress:                         "0.0.0.0",
 		ListenerPort:                            8080,
 		TokenAgentPort:                          8791,

--- a/tests/integration_test/auth_pkey_cache_test/auth_pkey_cache_test.go
+++ b/tests/integration_test/auth_pkey_cache_test/auth_pkey_cache_test.go
@@ -82,7 +82,7 @@ func TestAuthJwksCache(t *testing.T) {
 
 			s := env.NewTestEnv(platform.TestAuthJwksCache, platform.EchoSidecar)
 			args = append(args, "--disable_jwks_async_fetch")
-			// Have to disable jwt cache
+			// Need to disable jwt cache as the test is counting of number of jwks fetching.
 			args = append(args, "--jwt_cache_size=0")
 			if tc.jwksCacheDurationInS != 0 {
 				args = append(args, fmt.Sprintf("--jwks_cache_duration_in_s=%v", tc.jwksCacheDurationInS))

--- a/tests/integration_test/auth_pkey_cache_test/auth_pkey_cache_test.go
+++ b/tests/integration_test/auth_pkey_cache_test/auth_pkey_cache_test.go
@@ -82,6 +82,8 @@ func TestAuthJwksCache(t *testing.T) {
 
 			s := env.NewTestEnv(platform.TestAuthJwksCache, platform.EchoSidecar)
 			args = append(args, "--disable_jwks_async_fetch")
+			// Have to disable jwt cache
+			args = append(args, "--jwt_cache_size=0")
 			if tc.jwksCacheDurationInS != 0 {
 				args = append(args, fmt.Sprintf("--jwks_cache_duration_in_s=%v", tc.jwksCacheDurationInS))
 			}


### PR DESCRIPTION
Benefits JWT cache are
*  Save a lot of CPS consumption as JWT signature verification uses a lot of CPU. 
*  Reduce remote jwks fetch.   jwks cache is 5m,  but jwt lifetime is 1 hour so it can be cached for 1 hour. During this 1 hour, jwks is not needed.  Sometime jwks fetch may fail, it will cause the requests been rejected.

It should be safe to to enable it as I don't see any draw back.

