### PR TITLE
Add two grpc transcoding flags

### DIFF
--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -862,6 +862,16 @@ environment variable or by passing "-k" flag to this script.
         By default they are rendered as strings. Defaults to false.''')
 
     parser.add_argument(
+        '--transcoding_stream_newline_delimited', action='store_true',
+        help='''If true, use new line delimiter to separate response streaming messages.
+        If false, all response streaming messages will be transcoded into a JSON array.''')
+
+    parser.add_argument(
+        '--transcoding_case_insensitive_enum_parsing', action='store_true',
+        help='''Proto enum values are supposed to be in upper cases when used in JSON.
+        Set this flag to true if your JSON request uses non uppercase enum values.''')
+
+    parser.add_argument(
         '--transcoding_preserve_proto_field_names', action='store_true',
         help='''Whether to preserve proto field names for grpc-json transcoding.
         By default protobuf will generate JSON field names using the json_name
@@ -1374,6 +1384,12 @@ def gen_proxy_config(args):
 
     if args.transcoding_always_print_enums_as_ints:
         proxy_conf.append("--transcoding_always_print_enums_as_ints")
+
+    if args.transcoding_stream_newline_delimited:
+        proxy_conf.append("--transcoding_stream_newline_delimited")
+
+    if args.transcoding_case_insensitive_enum_parsing:
+        proxy_conf.append("--transcoding_case_insensitive_enum_parsing")
 
     if args.transcoding_preserve_proto_field_names:
         proxy_conf.append("--transcoding_preserve_proto_field_names")

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/census-instrumentation/opencensus-proto v0.3.0
 	github.com/cncf/xds/go v0.0.0-20220314180256-7f1daf1720fc // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/envoyproxy/go-control-plane v0.10.3-0.20220719090109-b024c36d9935
+	github.com/envoyproxy/go-control-plane v0.10.3-0.20221202001402-e85facd0160f
 	github.com/envoyproxy/protoc-gen-validate v0.6.7
 	github.com/golang/glog v1.0.0
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
@@ -19,7 +19,6 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2
 	github.com/miekg/dns v1.1.45
-	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/spf13/afero v1.8.0 // indirect
 	github.com/stretchr/testify v1.7.1 // indirect
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,8 @@ github.com/envoyproxy/go-control-plane v0.10.2-0.20220112105034-1553555e45ad h1:
 github.com/envoyproxy/go-control-plane v0.10.2-0.20220112105034-1553555e45ad/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
 github.com/envoyproxy/go-control-plane v0.10.3-0.20220719090109-b024c36d9935 h1:1P6HktLf+VNpEwASft2E0KU7ddeuu73UMnFpawKuD58=
 github.com/envoyproxy/go-control-plane v0.10.3-0.20220719090109-b024c36d9935/go.mod h1:fJJn/j26vwOu972OllsvAgJJM//w9BV6Fxbg2LuVd34=
+github.com/envoyproxy/go-control-plane v0.10.3-0.20221202001402-e85facd0160f h1:7LHcyL2EVCERNQ4geqiDSUAoKmJHaKZ+W2GOiMhfTj8=
+github.com/envoyproxy/go-control-plane v0.10.3-0.20221202001402-e85facd0160f/go.mod h1:ufpOdMVWU+v42FYQiIBUhSWglFcK3S1Ml8bbzLwkdcE=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.6.3 h1:HkntewfZJ9RofA/FX38zBCeIAqlLDFLbAI6eTpZqFJw=
 github.com/envoyproxy/protoc-gen-validate v0.6.3/go.mod h1:dyJXwwfPK2VSqiB9Klm1J6romD608Ba7Hij42vrOBCo=
@@ -225,6 +227,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.2.0 h1:uq5h0d+GuxiXLJLNABMgp2qUWDPiLvgCzz2dUR+/W/M=
 github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/prometheus/client_model v0.3.0 h1:UBgGFHqYdG/TPFD1B1ogZywDqEkwp3fBMvqdiQ7Xew4=
+github.com/prometheus/client_model v0.3.0/go.mod h1:LDGWKZIo7rky3hgvBe+caln+Dr3dPggB5dvjtD7w9+w=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/src/go/configgenerator/filterconfig/filter_generator.go
+++ b/src/go/configgenerator/filterconfig/filter_generator.go
@@ -329,8 +329,10 @@ func makeTranscoderFilter(serviceInfo *ci.ServiceInfo) (*hcmpb.HttpFilter, error
 					AlwaysPrintPrimitiveFields: serviceInfo.Options.TranscodingAlwaysPrintPrimitiveFields,
 					AlwaysPrintEnumsAsInts:     serviceInfo.Options.TranscodingAlwaysPrintEnumsAsInts,
 					PreserveProtoFieldNames:    serviceInfo.Options.TranscodingPreserveProtoFieldNames,
+					StreamNewlineDelimited:     serviceInfo.Options.TranscodingStreamNewLineDelimited,
 				},
 				MatchUnregisteredCustomVerb: serviceInfo.Options.TranscodingMatchUnregisteredCustomVerb,
+				CaseInsensitiveEnumParsing:  serviceInfo.Options.TranscodingCaseInsensitiveEnumParsing,
 			}
 			if serviceInfo.Options.TranscodingStrictRequestValidation {
 				transcodeConfig.RequestValidationOptions = &transcoderpb.GrpcJsonTranscoder_RequestValidationOptions{

--- a/src/go/configgenerator/filterconfig/filter_generator_test.go
+++ b/src/go/configgenerator/filterconfig/filter_generator_test.go
@@ -56,11 +56,13 @@ func TestTranscoderFilter(t *testing.T) {
 		fakeServiceConfig                             *confpb.Service
 		transcodingAlwaysPrintPrimitiveFields         bool
 		transcodingAlwaysPrintEnumsAsInts             bool
+		transcodingStreamNewLineDelimited             bool
 		transcodingPreserveProtoFieldNames            bool
 		transcodingIgnoreQueryParameters              string
 		transcodingIgnoreUnknownQueryParameters       bool
 		transcodingQueryParametersDisableUnescapePlus bool
 		transcodingStrictRequestValidation            bool
+		transcodingCaseInsensitiveEnumParsing         bool
 		wantTranscoderFilter                          string
 	}{
 		{
@@ -213,16 +215,19 @@ func TestTranscoderFilter(t *testing.T) {
 			},
 			transcodingAlwaysPrintPrimitiveFields:         true,
 			transcodingAlwaysPrintEnumsAsInts:             true,
+			transcodingStreamNewLineDelimited:             true,
 			transcodingPreserveProtoFieldNames:            true,
 			transcodingIgnoreQueryParameters:              "parameter_foo,parameter_bar",
 			transcodingIgnoreUnknownQueryParameters:       true,
 			transcodingQueryParametersDisableUnescapePlus: true,
+			transcodingCaseInsensitiveEnumParsing:         true,
 			wantTranscoderFilter: fmt.Sprintf(`
 {
    "name":"envoy.filters.http.grpc_json_transcoder",
    "typedConfig":{
       "@type":"type.googleapis.com/envoy.extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder",
       "autoMapping":true,
+      "caseInsensitiveEnumParsing":true,
       "convertGrpcStatus":true,
       "ignoreUnknownQueryParameters":true,
       "ignoredQueryParameters":[
@@ -234,7 +239,8 @@ func TestTranscoderFilter(t *testing.T) {
       "printOptions":{
          "alwaysPrintEnumsAsInts":true,
          "alwaysPrintPrimitiveFields":true,
-         "preserveProtoFieldNames":true
+         "preserveProtoFieldNames":true,
+         "streamNewLineDelimited":true
       },
       "protoDescriptorBin":"%s",
       "services":[
@@ -313,11 +319,13 @@ func TestTranscoderFilter(t *testing.T) {
 			opts.BackendAddress = "grpc://127.0.0.0:80"
 			opts.TranscodingAlwaysPrintPrimitiveFields = tc.transcodingAlwaysPrintPrimitiveFields
 			opts.TranscodingPreserveProtoFieldNames = tc.transcodingPreserveProtoFieldNames
+			opts.TranscodingStreamNewLineDelimited = tc.transcodingStreamNewLineDelimited
 			opts.TranscodingAlwaysPrintEnumsAsInts = tc.transcodingAlwaysPrintEnumsAsInts
 			opts.TranscodingIgnoreQueryParameters = tc.transcodingIgnoreQueryParameters
 			opts.TranscodingIgnoreUnknownQueryParameters = tc.transcodingIgnoreUnknownQueryParameters
 			opts.TranscodingQueryParametersDisableUnescapePlus = tc.transcodingQueryParametersDisableUnescapePlus
 			opts.TranscodingStrictRequestValidation = tc.transcodingStrictRequestValidation
+			opts.TranscodingCaseInsensitiveEnumParsing = tc.transcodingCaseInsensitiveEnumParsing
 			fakeServiceInfo, err := configinfo.NewServiceInfoFromServiceConfig(tc.fakeServiceConfig, testConfigID, opts)
 			if err != nil {
 				t.Fatal(err)

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -164,9 +164,11 @@ Normally JWT based64 encode doesn’t add padding. If this flag is true, the hea
 
 	TranscodingAlwaysPrintPrimitiveFields         = flag.Bool("transcoding_always_print_primitive_fields", defaults.TranscodingAlwaysPrintPrimitiveFields, "Whether to always print primitive fields for grpc-json transcoding")
 	TranscodingAlwaysPrintEnumsAsInts             = flag.Bool("transcoding_always_print_enums_as_ints", defaults.TranscodingAlwaysPrintPrimitiveFields, "Whether to always print enums as ints for grpc-json transcoding")
+	TranscodingStreamNewLineDelimited             = flag.Bool("transcoding_stream_newline_delimited", defaults.TranscodingStreamNewLineDelimited, "If true, use new line delimiter to separate response streaming messages. If false, all response streaming messages will be transcoded into a JSON array.")
 	TranscodingPreserveProtoFieldNames            = flag.Bool("transcoding_preserve_proto_field_names", defaults.TranscodingPreserveProtoFieldNames, "Whether to preserve proto field names for grpc-json transcoding")
 	TranscodingIgnoreQueryParameters              = flag.String("transcoding_ignore_query_parameters", defaults.TranscodingIgnoreQueryParameters, "A list of query parameters(separated by comma) to be ignored for transcoding method mapping in grpc-json transcoding.")
 	TranscodingIgnoreUnknownQueryParameters       = flag.Bool("transcoding_ignore_unknown_query_parameters", defaults.TranscodingIgnoreUnknownQueryParameters, "Whether to ignore query parameters that cannot be mapped to a corresponding protobuf field in grpc-json transcoding.")
+	TranscodingCaseInsensitiveEnumParsing         = flag.Bool("transcoding_case_insensitive_enum_parsing", defaults.TranscodingCaseInsensitiveEnumParsing, "Proto enum values are supposed to be in upper cases when used in JSON. Set this flag to true if your JSON request uses non uppercase enum values.")
 	TranscodingQueryParametersDisableUnescapePlus = flag.Bool("transcoding_query_parameters_disable_unescape_plus", defaults.TranscodingIgnoreUnknownQueryParameters, `By default, unescape "+" to space when extracting variables in
            the query parameters in grpc-json transcoding. This is to support HTML 2.0<https://tools.ietf.org/html/rfc1866#section-8.2.1>. Set this flag to true to disable this feature.`)
 	TranscodingMatchUnregisteredCustomVerb = flag.Bool("transcoding_match_unregistered_custom_verb", defaults.TranscodingMatchUnregisteredCustomVerb, `If true, try to match the custom verb even if it is unregistered. By default, only match when it is registered.
@@ -296,11 +298,13 @@ func EnvoyConfigOptionsFromFlags() options.ConfigGeneratorOptions {
 		BackendClusterMaxRequests:                     *BackendClusterMaxRequests,
 		TranscodingAlwaysPrintPrimitiveFields:         *TranscodingAlwaysPrintPrimitiveFields,
 		TranscodingAlwaysPrintEnumsAsInts:             *TranscodingAlwaysPrintEnumsAsInts,
+		TranscodingStreamNewLineDelimited:             *TranscodingStreamNewLineDelimited,
 		TranscodingPreserveProtoFieldNames:            *TranscodingPreserveProtoFieldNames,
 		TranscodingIgnoreQueryParameters:              *TranscodingIgnoreQueryParameters,
 		TranscodingIgnoreUnknownQueryParameters:       *TranscodingIgnoreUnknownQueryParameters,
 		TranscodingQueryParametersDisableUnescapePlus: *TranscodingQueryParametersDisableUnescapePlus,
 		TranscodingMatchUnregisteredCustomVerb:        *TranscodingMatchUnregisteredCustomVerb,
+		TranscodingCaseInsensitiveEnumParsing:         *TranscodingCaseInsensitiveEnumParsing,
 		EnableResponseCompression:                     *EnableResponseCompression,
 
 		// These options are not for ESPv2 users. They are overridden internally.

--- a/src/go/options/configgenerator.go
+++ b/src/go/options/configgenerator.go
@@ -142,6 +142,7 @@ type ConfigGeneratorOptions struct {
 
 	TranscodingAlwaysPrintPrimitiveFields         bool
 	TranscodingAlwaysPrintEnumsAsInts             bool
+	TranscodingStreamNewLineDelimited             bool
 	TranscodingPreserveProtoFieldNames            bool
 	TranscodingIgnoreQueryParameters              string
 	TranscodingIgnoreUnknownQueryParameters       bool
@@ -149,6 +150,7 @@ type ConfigGeneratorOptions struct {
 	TranscodingMatchUnregisteredCustomVerb        bool
 	TranscodingStrictRequestValidation            bool
 	TranscodingRejectCollision                    bool
+	TranscodingCaseInsensitiveEnumParsing         bool
 	APIAllowList                                  []string
 	AllowDiscoveryAPIs                            bool
 }

--- a/tests/start_proxy/start_proxy_test.py
+++ b/tests/start_proxy/start_proxy_test.py
@@ -471,6 +471,34 @@ class TestStartProxy(unittest.TestCase):
               '--disable_tracing',
               '--transcoding_query_parameters_disable_unescape_plus'
               ]),
+            # json-grpc transcoding_stream_newline_delimited
+            (['--service=test_bookstore.gloud.run',
+              '--backend=grpc://127.0.0.1:8000',
+              '--transcoding_stream_newline_delimited',
+              '--disable_tracing',
+              '--version=2019-11-09r0',
+              ],
+             ['bin/configmanager', '--logtostderr', '--rollout_strategy', 'fixed',
+              '--backend_address', 'grpc://127.0.0.1:8000', '--v', '0',
+              '--service', 'test_bookstore.gloud.run',
+              '--service_config_id', '2019-11-09r0',
+              '--disable_tracing',
+              '--transcoding_stream_newline_delimited'
+              ]),
+            # json-grpc transcoding_case_insensitive_enum_parsing
+            (['--service=test_bookstore.gloud.run',
+              '--backend=grpc://127.0.0.1:8000',
+              '--transcoding_case_insensitive_enum_parsing',
+              '--disable_tracing',
+              '--version=2019-11-09r0',
+              ],
+             ['bin/configmanager', '--logtostderr', '--rollout_strategy', 'fixed',
+              '--backend_address', 'grpc://127.0.0.1:8000', '--v', '0',
+              '--service', 'test_bookstore.gloud.run',
+              '--service_config_id', '2019-11-09r0',
+              '--disable_tracing',
+              '--transcoding_case_insensitive_enum_parsing'
+              ]),
             # route_match disallow_colon_in_wildcard_path_segment
             (['--service=test_bookstore.gloud.run',
               '--backend=grpc://127.0.0.1:8000',


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

*  `--transcoding_stream_newline_delimited`  to use new line as delimiter for streaming response messages
*  `--transcoding_case_insensitive_enum_parsing` to support lower case enum values.