### PR TITLE
b/261147007: Add keep alive for upstream http2 connection

### DIFF
--- a/examples/dynamic_routing/envoy_config.json
+++ b/examples/dynamic_routing/envoy_config.json
@@ -149,7 +149,12 @@
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
             "explicitHttpConfig": {
-              "http2ProtocolOptions": {}
+              "http2ProtocolOptions": {
+                "connectionKeepalive": {
+                  "interval": "30s",
+                  "timeout": "10s"
+                }
+              }
             }
           }
         }

--- a/examples/grpc_dynamic_routing/envoy_config.json
+++ b/examples/grpc_dynamic_routing/envoy_config.json
@@ -44,7 +44,12 @@
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
             "explicitHttpConfig": {
-              "http2ProtocolOptions": {}
+              "http2ProtocolOptions": {
+                "connectionKeepalive": {
+                  "interval": "30s",
+                  "timeout": "10s"
+                }
+              }
             }
           }
         }
@@ -157,7 +162,12 @@
           "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
             "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
             "explicitHttpConfig": {
-              "http2ProtocolOptions": {}
+              "http2ProtocolOptions": {
+                "connectionKeepalive": {
+                  "interval": "30s",
+                  "timeout": "10s"
+                }
+              }
             }
           }
         }

--- a/src/go/bootstrap/ads/bootstrap_test.go
+++ b/src/go/bootstrap/ads/bootstrap_test.go
@@ -86,7 +86,14 @@ func TestCreateBootstrapConfig(t *testing.T) {
             "typedExtensionProtocolOptions":{
                "envoy.extensions.upstreams.http.v3.HttpProtocolOptions":{
                   "@type":"type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-                  "explicitHttpConfig":{"http2ProtocolOptions":{}}
+                  "explicitHttpConfig":{
+                     "http2ProtocolOptions":{
+                       "connectionKeepalive":{
+                         "interval":"30s",
+                         "timeout":"10s"
+                       }
+                     }
+                  }
                }
             },
             "loadAssignment":{
@@ -180,7 +187,14 @@ func TestCreateBootstrapConfig(t *testing.T) {
             "typedExtensionProtocolOptions":{
                "envoy.extensions.upstreams.http.v3.HttpProtocolOptions":{
                   "@type":"type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
-                  "explicitHttpConfig":{"http2ProtocolOptions":{}}
+                  "explicitHttpConfig":{
+                     "http2ProtocolOptions":{
+                       "connectionKeepalive":{
+                         "interval":"30s",
+                         "timeout":"10s"
+                       }
+                     }
+                  }
                }
             },
             "loadAssignment":{

--- a/src/go/util/load_assignment.go
+++ b/src/go/util/load_assignment.go
@@ -15,6 +15,8 @@
 package util
 
 import (
+	"time"
+
 	corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	endpointpb "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
@@ -22,12 +24,24 @@ import (
 	anypb "github.com/golang/protobuf/ptypes/any"
 )
 
+const (
+	Http2KeepaliveInterval = 30 * time.Second
+	Http2KeepaliveTimeout  = 10 * time.Second
+)
+
 // CreateUpstreamProtocolOptions creates a http2 protocol option as a typed upstream extension.
 func CreateUpstreamProtocolOptions() map[string]*anypb.Any {
 	o := &httppb.HttpProtocolOptions{
 		UpstreamProtocolOptions: &httppb.HttpProtocolOptions_ExplicitHttpConfig_{
 			ExplicitHttpConfig: &httppb.HttpProtocolOptions_ExplicitHttpConfig{
-				ProtocolConfig: &httppb.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{},
+				ProtocolConfig: &httppb.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{
+					Http2ProtocolOptions: &corepb.Http2ProtocolOptions{
+						ConnectionKeepalive: &corepb.KeepaliveSettings{
+							Interval: ptypes.DurationProto(Http2KeepaliveInterval),
+							Timeout:  ptypes.DurationProto(Http2KeepaliveTimeout),
+						},
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

Enable Keep-alive for HTTP2 connection to upstream.

* Just enable it for now,  I don't think it will break anything.
* Hardcode the numbers  30s for interval,  10s for timeout.

