### PR TITLE
Fix deprecated envoy configs

### DIFF
--- a/examples/testdata/route_match/envoy_config.json
+++ b/examples/testdata/route_match/envoy_config.json
@@ -275,7 +275,6 @@
                                 }
                               ],
                               "safeRegex": {
-                                "googleRe2": {},
                                 "regex": "^/libraries/[^\\/]+/shelves/[^\\/]+\\/?$"
                               }
                             },
@@ -318,7 +317,6 @@
                                 }
                               ],
                               "safeRegex": {
-                                "googleRe2": {},
                                 "regex": "^/libraries/[^\\/]+/shelves/[^\\/]+\\/?$"
                               }
                             },
@@ -361,7 +359,6 @@
                                 }
                               ],
                               "safeRegex": {
-                                "googleRe2": {},
                                 "regex": "^/.*\\/?$"
                               }
                             },
@@ -397,7 +394,6 @@
                                 }
                               ],
                               "safeRegex": {
-                                "googleRe2": {},
                                 "regex": "^/.*\\/?$"
                               }
                             },
@@ -433,7 +429,6 @@
                                 }
                               ],
                               "safeRegex": {
-                                "googleRe2": {},
                                 "regex": "^/.*\\/?$"
                               }
                             },
@@ -469,7 +464,6 @@
                                 }
                               ],
                               "safeRegex": {
-                                "googleRe2": {},
                                 "regex": "^/.*\\/?$"
                               }
                             },
@@ -505,7 +499,6 @@
                                 }
                               ],
                               "safeRegex": {
-                                "googleRe2": {},
                                 "regex": "^/.*\\/?$"
                               }
                             },
@@ -541,7 +534,6 @@
                                 }
                               ],
                               "safeRegex": {
-                                "googleRe2": {},
                                 "regex": "^/.*\\/?$"
                               }
                             },
@@ -575,7 +567,6 @@
                             },
                             "match": {
                               "safeRegex": {
-                                "googleRe2": {},
                                 "regex": "^/libraries/[^\\/]+/shelves/[^\\/]+\\/?$"
                               }
                             }
@@ -592,7 +583,6 @@
                             },
                             "match": {
                               "safeRegex": {
-                                "googleRe2": {},
                                 "regex": "^/.*\\/?$"
                               }
                             }

--- a/src/go/bootstrap/admin.go
+++ b/src/go/bootstrap/admin.go
@@ -29,7 +29,6 @@ func CreateAdmin(opts options.CommonOptions) *bootstrappb.Admin {
 	}
 
 	return &bootstrappb.Admin{
-		AccessLogPath: "/dev/null",
 		Address: &corepb.Address{
 			Address: &corepb.Address_SocketAddress{
 				SocketAddress: &corepb.SocketAddress{

--- a/src/go/bootstrap/admin_test.go
+++ b/src/go/bootstrap/admin_test.go
@@ -39,7 +39,6 @@ func TestCreateAdmin(t *testing.T) {
 			desc:      "Admin interface is enabled, created with default values",
 			adminPort: 8081,
 			want: &bootstrappb.Admin{
-				AccessLogPath: "/dev/null",
 				Address: &corepb.Address{
 					Address: &corepb.Address_SocketAddress{
 						SocketAddress: &corepb.SocketAddress{

--- a/src/go/bootstrap/ads/bootstrap_test.go
+++ b/src/go/bootstrap/ads/bootstrap_test.go
@@ -133,7 +133,6 @@ func TestCreateBootstrapConfig(t *testing.T) {
 			wantConfig: `
 {
    "admin":{
-      "accessLogPath":"/dev/null",
       "address":{
          "socketAddress":{
             "address":"0.0.0.0",

--- a/src/go/configgenerator/route_generator.go
+++ b/src/go/configgenerator/route_generator.go
@@ -189,20 +189,18 @@ func makeRouteCors(serviceInfo *configinfo.ServiceInfo) (*routepb.CorsPolicy, []
 		if err := util.ValidateRegexProgramSize(orgReg, util.GoogleRE2MaxProgramSize); err != nil {
 			return nil, nil, fmt.Errorf("invalid cors origin regex: %v", err)
 		}
-		regexMatcher := &matcher.RegexMatcher{
-			Regex: orgReg,
-		}
-		cors = &routepb.CorsPolicy{
-			AllowOriginStringMatch: []*matcher.StringMatcher{
-				{
-					MatchPattern: &matcher.StringMatcher_SafeRegex{
-						SafeRegex: regexMatcher,
-					},
+		stringMatcher := &matcher.StringMatcher{
+			MatchPattern: &matcher.StringMatcher_SafeRegex{
+				SafeRegex: &matcher.RegexMatcher{
+					Regex: orgReg,
 				},
 			},
 		}
-		originMatcher.HeaderMatchSpecifier = &routepb.HeaderMatcher_SafeRegexMatch{
-			SafeRegexMatch: regexMatcher,
+		cors = &routepb.CorsPolicy{
+			AllowOriginStringMatch: []*matcher.StringMatcher{stringMatcher},
+		}
+		originMatcher.HeaderMatchSpecifier = &routepb.HeaderMatcher_StringMatch{
+			StringMatch: stringMatcher,
 		}
 	case "":
 		glog.Infof("CORS support is disabled")

--- a/src/go/configgenerator/route_generator.go
+++ b/src/go/configgenerator/route_generator.go
@@ -190,9 +190,6 @@ func makeRouteCors(serviceInfo *configinfo.ServiceInfo) (*routepb.CorsPolicy, []
 			return nil, nil, fmt.Errorf("invalid cors origin regex: %v", err)
 		}
 		regexMatcher := &matcher.RegexMatcher{
-			EngineType: &matcher.RegexMatcher_GoogleRe2{
-				GoogleRe2: &matcher.RegexMatcher_GoogleRE2{},
-			},
 			Regex: orgReg,
 		}
 		cors = &routepb.CorsPolicy{
@@ -522,9 +519,6 @@ func makeHttpRouteMatchers(httpRule *httppattern.Pattern, seenUriTemplatesInRout
 			RouteMatch: &routepb.RouteMatch{
 				PathSpecifier: &routepb.RouteMatch_SafeRegex{
 					SafeRegex: &matcher.RegexMatcher{
-						EngineType: &matcher.RegexMatcher_GoogleRe2{
-							GoogleRe2: &matcher.RegexMatcher_GoogleRE2{},
-						},
 						Regex: httpRule.UriTemplate.Regex(disallowColonInWildcardPathSegment),
 					},
 				},

--- a/src/go/configgenerator/route_generator.go
+++ b/src/go/configgenerator/route_generator.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
 	corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	corspb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/cors/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
@@ -66,7 +67,13 @@ func makeRouteConfig(serviceInfo *configinfo.ServiceInfo) (*routepb.RouteConfigu
 	}
 
 	if cors != nil {
-		host.Cors = cors
+		corsAny, err := ptypes.MarshalAny(cors)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling CorsPolicy to Any: %v", err)
+		}
+		host.TypedPerFilterConfig = make(map[string]*anypb.Any)
+		host.TypedPerFilterConfig[util.CORS] = corsAny
+
 		host.Routes = append(host.Routes, corsRoutes...)
 		for i, corsRoute := range corsRoutes {
 			jsonStr, _ := util.ProtoToJson(corsRoute)
@@ -152,8 +159,8 @@ func makeResponseHeadersToAdd(serviceInfo *configinfo.ServiceInfo) ([]*corepb.He
 	return l, nil
 }
 
-func makeRouteCors(serviceInfo *configinfo.ServiceInfo) (*routepb.CorsPolicy, []*routepb.Route, error) {
-	var cors *routepb.CorsPolicy
+func makeRouteCors(serviceInfo *configinfo.ServiceInfo) (*corspb.CorsPolicy, []*routepb.Route, error) {
+	var cors *corspb.CorsPolicy
 	originMatcher := &routepb.HeaderMatcher{
 		Name: "origin",
 	}
@@ -169,7 +176,7 @@ func makeRouteCors(serviceInfo *configinfo.ServiceInfo) (*routepb.CorsPolicy, []
 			},
 		}
 
-		cors = &routepb.CorsPolicy{
+		cors = &corspb.CorsPolicy{
 			AllowOriginStringMatch: []*matcher.StringMatcher{stringMatcher},
 		}
 		if org == "*" {
@@ -196,7 +203,7 @@ func makeRouteCors(serviceInfo *configinfo.ServiceInfo) (*routepb.CorsPolicy, []
 				},
 			},
 		}
-		cors = &routepb.CorsPolicy{
+		cors = &corspb.CorsPolicy{
 			AllowOriginStringMatch: []*matcher.StringMatcher{stringMatcher},
 		}
 		originMatcher.HeaderMatchSpecifier = &routepb.HeaderMatcher_StringMatch{

--- a/src/go/configgenerator/route_generator_test.go
+++ b/src/go/configgenerator/route_generator_test.go
@@ -410,7 +410,6 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "match": {
             "safeRegex": {
-              "googleRe2": {},
               "regex": "^/v1/[^\\/]+/test/.*\\/?$"
             }
           },
@@ -503,7 +502,6 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "match": {
             "safeRegex": {
-              "googleRe2": {},
               "regex": "^/v1/[^\\/:]+/test/[^:]*\\/?$"
             }
           },
@@ -613,7 +611,6 @@ func TestMakeRouteConfig(t *testing.T) {
               }
             ],
             "safeRegex": {
-              "googleRe2": {},
               "regex": "^/v1/shelves/[^\\/]+\\/?$"
             }
           },
@@ -641,7 +638,6 @@ func TestMakeRouteConfig(t *testing.T) {
               }
             ],
             "safeRegex": {
-              "googleRe2": {},
               "regex": "^/v1/shelves/[^\\/]+\\/?$"
             }
           },
@@ -669,7 +665,6 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "match": {
             "safeRegex": {
-              "googleRe2": {},
               "regex": "^/v1/shelves/[^\\/]+\\/?$"
             }
           }
@@ -1116,7 +1111,6 @@ func TestMakeRouteConfig(t *testing.T) {
               }
             ],
             "safeRegex": {
-              "googleRe2": {},
               "regex": "^/foo/[^\\/]+\\/?$"
             }
           },
@@ -1144,7 +1138,6 @@ func TestMakeRouteConfig(t *testing.T) {
               }
             ],
             "safeRegex": {
-              "googleRe2": {},
               "regex": "^/foo/[^\\/]+\\/?$"
             }
           },
@@ -1200,7 +1193,6 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "match": {
             "safeRegex": {
-              "googleRe2": {},
               "regex": "^/foo/[^\\/]+\\/?$"
             }
           }
@@ -1881,7 +1873,6 @@ func TestMakeRouteConfig(t *testing.T) {
               }
             ],
             "safeRegex": {
-              "googleRe2": {},
               "regex": "^/foo/[^\\/]+\\/?$"
             }
           },
@@ -1923,7 +1914,6 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "match": {
             "safeRegex": {
-              "googleRe2": {},
               "regex": "^/foo/[^\\/]+\\/?$"
             }
           }
@@ -2161,7 +2151,6 @@ func TestMakeRouteConfig(t *testing.T) {
               }
             ],
             "safeRegex": {
-              "googleRe2": {},
               "regex": "^/foo/[^\\/]+\\/?$"
             }
           },
@@ -2196,7 +2185,6 @@ func TestMakeRouteConfig(t *testing.T) {
               }
             ],
             "safeRegex": {
-              "googleRe2": {},
               "regex": "^/foo/[^\\/]+/bar\\/?$"
             }
           },
@@ -2231,7 +2219,6 @@ func TestMakeRouteConfig(t *testing.T) {
               }
             ],
             "safeRegex": {
-              "googleRe2": {},
               "regex": "^/foo/.*/bar\\/?$"
             }
           },
@@ -2266,7 +2253,6 @@ func TestMakeRouteConfig(t *testing.T) {
               }
             ],
             "safeRegex": {
-              "googleRe2": {},
               "regex": "^/foo/.*\\/?:verb$"
             }
           },
@@ -2301,7 +2287,6 @@ func TestMakeRouteConfig(t *testing.T) {
               }
             ],
             "safeRegex": {
-              "googleRe2": {},
               "regex": "^/foo/.*\\/?$"
             }
           },
@@ -2364,7 +2349,6 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "match": {
             "safeRegex": {
-              "googleRe2": {},
               "regex": "^/foo/[^\\/]+\\/?$"
             }
           }
@@ -2381,7 +2365,6 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "match": {
             "safeRegex": {
-              "googleRe2": {},
               "regex": "^/foo/[^\\/]+/bar\\/?$"
             }
           }
@@ -2398,7 +2381,6 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "match": {
             "safeRegex": {
-              "googleRe2": {},
               "regex": "^/foo/.*/bar\\/?$"
             }
           }
@@ -2415,7 +2397,6 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "match": {
             "safeRegex": {
-              "googleRe2": {},
               "regex": "^/foo/.*\\/?:verb$"
             }
           }
@@ -2432,7 +2413,6 @@ func TestMakeRouteConfig(t *testing.T) {
           },
           "match": {
             "safeRegex": {
-              "googleRe2": {},
               "regex": "^/foo/.*\\/?$"
             }
           }
@@ -2923,7 +2903,6 @@ func TestMakeFallbackRoute(t *testing.T) {
               }
             ],
             "safeRegex": {
-              "googleRe2": {},
               "regex": "^/echo/[^\\/]+\\/?$"
             }
           },
@@ -2950,7 +2929,6 @@ func TestMakeFallbackRoute(t *testing.T) {
               }
             ],
             "safeRegex": {
-              "googleRe2": {},
               "regex": "^/echo/[^\\/]+\\/?$"
             }
           },
@@ -2977,7 +2955,6 @@ func TestMakeFallbackRoute(t *testing.T) {
           },
           "match": {
             "safeRegex": {
-              "googleRe2": {},
               "regex": "^/echo/[^\\/]+\\/?$"
             }
           }
@@ -3531,7 +3508,6 @@ func TestMakeFallbackRoute(t *testing.T) {
         "allowOriginStringMatch": [
           {
             "safeRegex": {
-              "googleRe2": {},
               "regex": ".*"
             }
           }
@@ -3652,7 +3628,6 @@ func TestMakeFallbackRoute(t *testing.T) {
               {
                 "name": "origin",
                 "safeRegexMatch": {
-                  "googleRe2": {},
                   "regex": ".*"
                 }
               },
@@ -4049,9 +4024,6 @@ func TestMakeRouteConfigForCors(t *testing.T) {
 					{
 						MatchPattern: &matcher.StringMatcher_SafeRegex{
 							SafeRegex: &matcher.RegexMatcher{
-								EngineType: &matcher.RegexMatcher_GoogleRe2{
-									GoogleRe2: &matcher.RegexMatcher_GoogleRE2{},
-								},
 								Regex: `^https?://.+\\.example\\.com\/?$`,
 							},
 						},
@@ -4071,9 +4043,6 @@ func TestMakeRouteConfigForCors(t *testing.T) {
 					{
 						MatchPattern: &matcher.StringMatcher_SafeRegex{
 							SafeRegex: &matcher.RegexMatcher{
-								EngineType: &matcher.RegexMatcher_GoogleRe2{
-									GoogleRe2: &matcher.RegexMatcher_GoogleRE2{},
-								},
 								Regex: `^https?://.+\\.example\\.com\/?$`,
 							},
 						},

--- a/src/go/configgenerator/route_generator_test.go
+++ b/src/go/configgenerator/route_generator_test.go
@@ -25,9 +25,10 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
 
 	corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	corspb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/cors/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 	annotationspb "google.golang.org/genproto/googleapis/api/annotations"
@@ -3018,16 +3019,6 @@ func TestMakeFallbackRoute(t *testing.T) {
   "name": "local_route",
   "virtualHosts": [
     {
-      "cors": {
-        "allowCredentials": false,
-        "allowMethods": "GET,POST,PUT,OPTIONS",
-        "allowOriginStringMatch": [
-          {
-            "exact": "*"
-          }
-        ],
-        "maxAge": "120"
-      },
       "domains": [
         "*"
       ],
@@ -3040,8 +3031,10 @@ func TestMakeFallbackRoute(t *testing.T) {
           "match": {
             "headers": [
               {
-                "stringMatch":{"exact":"GET"},
-                "name": ":method"
+                "name": ":method",
+                "stringMatch": {
+                  "exact": "GET"
+                }
               }
             ],
             "path": "/echo"
@@ -3064,8 +3057,10 @@ func TestMakeFallbackRoute(t *testing.T) {
           "match": {
             "headers": [
               {
-                "stringMatch":{"exact":"GET"},
-                "name": ":method"
+                "name": ":method",
+                "stringMatch": {
+                  "exact": "GET"
+                }
               }
             ],
             "path": "/echo/"
@@ -3088,8 +3083,10 @@ func TestMakeFallbackRoute(t *testing.T) {
           "match": {
             "headers": [
               {
-                "stringMatch":{"exact":"POST"},
-                "name": ":method"
+                "name": ":method",
+                "stringMatch": {
+                  "exact": "POST"
+                }
               }
             ],
             "path": "/echo"
@@ -3112,8 +3109,10 @@ func TestMakeFallbackRoute(t *testing.T) {
           "match": {
             "headers": [
               {
-                "stringMatch":{"exact":"POST"},
-                "name": ":method"
+                "name": ":method",
+                "stringMatch": {
+                  "exact": "POST"
+                }
               }
             ],
             "path": "/echo/"
@@ -3136,8 +3135,10 @@ func TestMakeFallbackRoute(t *testing.T) {
           "match": {
             "headers": [
               {
-                "stringMatch":{"exact":"OPTIONS"},
-                "name": ":method"
+                "name": ":method",
+                "stringMatch": {
+                  "exact": "OPTIONS"
+                }
               },
               {
                 "name": "origin",
@@ -3167,8 +3168,10 @@ func TestMakeFallbackRoute(t *testing.T) {
           "match": {
             "headers": [
               {
-                "stringMatch":{"exact":"OPTIONS"},
-                "name": ":method"
+                "name": ":method",
+                "stringMatch": {
+                  "exact": "OPTIONS"
+                }
               }
             ],
             "prefix": "/"
@@ -3216,7 +3219,20 @@ func TestMakeFallbackRoute(t *testing.T) {
             "prefix": "/"
           }
         }
-      ]
+      ],
+      "typedPerFilterConfig": {
+        "envoy.filters.http.cors": {
+          "@type": "type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy",
+          "allowCredentials": false,
+          "allowMethods": "GET,POST,PUT,OPTIONS",
+          "allowOriginStringMatch": [
+            {
+              "exact": "*"
+            }
+          ],
+          "maxAge": "120"
+        }
+      }
     }
   ]
 }`,
@@ -3260,16 +3276,6 @@ func TestMakeFallbackRoute(t *testing.T) {
   "name": "local_route",
   "virtualHosts": [
     {
-      "cors": {
-        "allowCredentials": false,
-        "allowMethods": "GET,POST,PUT,OPTIONS",
-        "allowOriginStringMatch": [
-          {
-            "exact": "http://example.com"
-          }
-        ],
-        "maxAge": "120"
-      },
       "domains": [
         "*"
       ],
@@ -3282,8 +3288,10 @@ func TestMakeFallbackRoute(t *testing.T) {
           "match": {
             "headers": [
               {
-                "stringMatch":{"exact":"GET"},
-                "name": ":method"
+                "name": ":method",
+                "stringMatch": {
+                  "exact": "GET"
+                }
               }
             ],
             "path": "/echo"
@@ -3306,8 +3314,10 @@ func TestMakeFallbackRoute(t *testing.T) {
           "match": {
             "headers": [
               {
-                "stringMatch":{"exact":"GET"},
-                "name": ":method"
+                "name": ":method",
+                "stringMatch": {
+                  "exact": "GET"
+                }
               }
             ],
             "path": "/echo/"
@@ -3330,8 +3340,10 @@ func TestMakeFallbackRoute(t *testing.T) {
           "match": {
             "headers": [
               {
-                "stringMatch":{"exact":"POST"},
-                "name": ":method"
+                "name": ":method",
+                "stringMatch": {
+                  "exact": "POST"
+                }
               }
             ],
             "path": "/echo"
@@ -3354,8 +3366,10 @@ func TestMakeFallbackRoute(t *testing.T) {
           "match": {
             "headers": [
               {
-                "stringMatch":{"exact":"POST"},
-                "name": ":method"
+                "name": ":method",
+                "stringMatch": {
+                  "exact": "POST"
+                }
               }
             ],
             "path": "/echo/"
@@ -3378,12 +3392,16 @@ func TestMakeFallbackRoute(t *testing.T) {
           "match": {
             "headers": [
               {
-                "stringMatch":{"exact":"OPTIONS"},
-                "name": ":method"
+                "name": ":method",
+                "stringMatch": {
+                  "exact": "OPTIONS"
+                }
               },
               {
                 "name": "origin",
-                "stringMatch":{"exact":"http://example.com"}
+                "stringMatch": {
+                  "exact": "http://example.com"
+                }
               },
               {
                 "name": "access-control-request-method",
@@ -3409,8 +3427,10 @@ func TestMakeFallbackRoute(t *testing.T) {
           "match": {
             "headers": [
               {
-                "stringMatch":{"exact":"OPTIONS"},
-                "name": ":method"
+                "name": ":method",
+                "stringMatch": {
+                  "exact": "OPTIONS"
+                }
               }
             ],
             "prefix": "/"
@@ -3458,7 +3478,20 @@ func TestMakeFallbackRoute(t *testing.T) {
             "prefix": "/"
           }
         }
-      ]
+      ],
+      "typedPerFilterConfig": {
+        "envoy.filters.http.cors": {
+          "@type": "type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy",
+          "allowCredentials": false,
+          "allowMethods": "GET,POST,PUT,OPTIONS",
+          "allowOriginStringMatch": [
+            {
+              "exact": "http://example.com"
+            }
+          ],
+          "maxAge": "120"
+        }
+      }
     }
   ]
 }`,
@@ -3502,18 +3535,6 @@ func TestMakeFallbackRoute(t *testing.T) {
   "name": "local_route",
   "virtualHosts": [
     {
-      "cors": {
-        "allowCredentials": false,
-        "allowMethods": "GET,POST,PUT,OPTIONS",
-        "allowOriginStringMatch": [
-          {
-            "safeRegex": {
-              "regex": ".*"
-            }
-          }
-        ],
-        "maxAge": "120"
-      },
       "domains": [
         "*"
       ],
@@ -3526,8 +3547,10 @@ func TestMakeFallbackRoute(t *testing.T) {
           "match": {
             "headers": [
               {
-                "stringMatch":{"exact":"GET"},
-                "name": ":method"
+                "name": ":method",
+                "stringMatch": {
+                  "exact": "GET"
+                }
               }
             ],
             "path": "/echo"
@@ -3550,8 +3573,10 @@ func TestMakeFallbackRoute(t *testing.T) {
           "match": {
             "headers": [
               {
-                "stringMatch":{"exact":"GET"},
-                "name": ":method"
+                "name": ":method",
+                "stringMatch": {
+                  "exact": "GET"
+                }
               }
             ],
             "path": "/echo/"
@@ -3574,8 +3599,10 @@ func TestMakeFallbackRoute(t *testing.T) {
           "match": {
             "headers": [
               {
-                "stringMatch":{"exact":"POST"},
-                "name": ":method"
+                "name": ":method",
+                "stringMatch": {
+                  "exact": "POST"
+                }
               }
             ],
             "path": "/echo"
@@ -3598,8 +3625,10 @@ func TestMakeFallbackRoute(t *testing.T) {
           "match": {
             "headers": [
               {
-                "stringMatch":{"exact":"POST"},
-                "name": ":method"
+                "name": ":method",
+                "stringMatch": {
+                  "exact": "POST"
+                }
               }
             ],
             "path": "/echo/"
@@ -3622,8 +3651,10 @@ func TestMakeFallbackRoute(t *testing.T) {
           "match": {
             "headers": [
               {
-                "stringMatch":{"exact":"OPTIONS"},
-                "name": ":method"
+                "name": ":method",
+                "stringMatch": {
+                  "exact": "OPTIONS"
+                }
               },
               {
                 "name": "origin",
@@ -3657,8 +3688,10 @@ func TestMakeFallbackRoute(t *testing.T) {
           "match": {
             "headers": [
               {
-                "stringMatch":{"exact":"OPTIONS"},
-                "name": ":method"
+                "name": ":method",
+                "stringMatch": {
+                  "exact": "OPTIONS"
+                }
               }
             ],
             "prefix": "/"
@@ -3706,7 +3739,22 @@ func TestMakeFallbackRoute(t *testing.T) {
             "prefix": "/"
           }
         }
-      ]
+      ],
+      "typedPerFilterConfig": {
+        "envoy.filters.http.cors": {
+          "@type": "type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy",
+          "allowCredentials": false,
+          "allowMethods": "GET,POST,PUT,OPTIONS",
+          "allowOriginStringMatch": [
+            {
+              "safeRegex": {
+                "regex": ".*"
+              }
+            }
+          ],
+          "maxAge": "120"
+        }
+      }
     }
   ]
 }`,
@@ -3976,7 +4024,7 @@ func TestMakeRouteConfigForCors(t *testing.T) {
 		params           []string
 		allowCredentials bool
 		wantedError      string
-		wantCorsPolicy   *routepb.CorsPolicy
+		wantCorsPolicy   *corspb.CorsPolicy
 	}{
 		{
 			desc:           "No Cors",
@@ -4005,7 +4053,7 @@ func TestMakeRouteConfigForCors(t *testing.T) {
 		{
 			desc:   "Correct configured basic Cors, with allow methods",
 			params: []string{"basic", "http://example.com", "", "GET,POST,PUT,OPTIONS", "", "", "2m"},
-			wantCorsPolicy: &routepb.CorsPolicy{
+			wantCorsPolicy: &corspb.CorsPolicy{
 				AllowOriginStringMatch: []*matcher.StringMatcher{
 					{
 						MatchPattern: &matcher.StringMatcher_Exact{
@@ -4021,7 +4069,7 @@ func TestMakeRouteConfigForCors(t *testing.T) {
 		{
 			desc:   "Correct configured regex Cors, with allow headers",
 			params: []string{"cors_with_regex", "", `^https?://.+\\.example\\.com\/?$`, "", "Origin,Content-Type,Accept", "", "2m"},
-			wantCorsPolicy: &routepb.CorsPolicy{
+			wantCorsPolicy: &corspb.CorsPolicy{
 				AllowOriginStringMatch: []*matcher.StringMatcher{
 					{
 						MatchPattern: &matcher.StringMatcher_SafeRegex{
@@ -4040,7 +4088,7 @@ func TestMakeRouteConfigForCors(t *testing.T) {
 			desc:             "Correct configured regex Cors, with expose headers",
 			params:           []string{"cors_with_regex", "", `^https?://.+\\.example\\.com\/?$`, "", "", "Content-Length", "2m"},
 			allowCredentials: true,
-			wantCorsPolicy: &routepb.CorsPolicy{
+			wantCorsPolicy: &corspb.CorsPolicy{
 				AllowOriginStringMatch: []*matcher.StringMatcher{
 					{
 						MatchPattern: &matcher.StringMatcher_SafeRegex{
@@ -4089,9 +4137,22 @@ func TestMakeRouteConfigForCors(t *testing.T) {
 		if len(gotHost) != 1 {
 			t.Errorf("Test (%v): got expected number of virtual host", tc.desc)
 		}
-		gotCors := gotHost[0].GetCors()
-		if !proto.Equal(gotCors, tc.wantCorsPolicy) {
-			t.Errorf("Test (%v): makeRouteConfig failed, got Cors: %v, want: %v", tc.desc, gotCors, tc.wantCorsPolicy)
+
+		corsAny, ok := gotHost[0].TypedPerFilterConfig[util.CORS]
+		if tc.wantCorsPolicy == nil {
+			if ok {
+				t.Errorf("Test (%v): expect not CORS, but found one", tc.desc)
+			}
+		} else {
+			if !ok {
+				t.Errorf("Test (%v): expect CORS, but found none", tc.desc)
+			} else {
+				gotCors := &corspb.CorsPolicy{}
+				ptypes.UnmarshalAny(corsAny, gotCors)
+				if !proto.Equal(gotCors, tc.wantCorsPolicy) {
+					t.Errorf("Test (%v): CorsPolicy diff, got Cors: %v, want: %v", tc.desc, gotCors, tc.wantCorsPolicy)
+				}
+			}
 		}
 	}
 }

--- a/src/go/configgenerator/route_generator_test.go
+++ b/src/go/configgenerator/route_generator_test.go
@@ -3627,8 +3627,10 @@ func TestMakeFallbackRoute(t *testing.T) {
               },
               {
                 "name": "origin",
-                "safeRegexMatch": {
-                  "regex": ".*"
+                "stringMatch": {
+                  "safeRegex": {
+                    "regex": ".*"
+                  }
                 }
               },
               {

--- a/src/go/configmanager/testdata/test_fetch_listeners.go
+++ b/src/go/configmanager/testdata/test_fetch_listeners.go
@@ -874,7 +874,6 @@ var (
                           }
                         ],
                         "safeRegex": {
-                          "googleRe2": {},
                           "regex": "^/v1/shelves/[^\\/]+\\/?$"
                         }
                       },
@@ -991,7 +990,6 @@ var (
                       },
                       "match": {
                         "safeRegex": {
-                          "googleRe2": {},
                           "regex": "^/v1/shelves/[^\\/]+\\/?$"
                         }
                       }
@@ -1355,7 +1353,6 @@ var (
                           }
                         ],
                         "safeRegex": {
-                          "googleRe2": {},
                           "regex": "^/v1/shelves/[^\\/]+/books/[^\\/]+\\/?$"
                         }
                       },
@@ -1382,7 +1379,6 @@ var (
                           }
                         ],
                         "safeRegex": {
-                          "googleRe2": {},
                           "regex": "^/v1/shelves/[^\\/]+/books/[^\\/]+\\/?$"
                         }
                       },
@@ -1471,7 +1467,6 @@ var (
                       },
                       "match": {
                         "safeRegex": {
-                          "googleRe2": {},
                           "regex": "^/v1/shelves/[^\\/]+/books/[^\\/]+\\/?$"
                         }
                       }

--- a/src/go/configmanager/testdata/test_fixed_mode_dynamic_routing.go
+++ b/src/go/configmanager/testdata/test_fixed_mode_dynamic_routing.go
@@ -550,7 +550,6 @@ var (
                           }
                         ],
                         "safeRegex": {
-                          "googleRe2": {},
                           "regex": "^/pet/[^\\/]+\\/?$"
                         }
                       },
@@ -816,7 +815,6 @@ var (
                       },
                       "match": {
                         "safeRegex": {
-                          "googleRe2": {},
                           "regex": "^/pet/[^\\/]+\\/?$"
                         }
                       }


### PR DESCRIPTION
We are still using some deprecated envoy configs.  This pr replaces them with the new config

* Remove `google_re2` field in `RegexMatcher`
* Replace `safe_regex_match` with `string_match`
* Move CorsPolicy in the VirtualHost from `cors` to `typed_per_filter_config`
* Remove `access_log_path` in Admin