### PR TITLE
Disable tracing in e2e tests

### DIFF
--- a/tests/e2e/scripts/cloud-run/deploy.sh
+++ b/tests/e2e/scripts/cloud-run/deploy.sh
@@ -335,8 +335,8 @@ function setup() {
     -i "${APIPROXY_IMAGE}"
 
   # Redeploy ESPv2 to update the service config. Set flags as follows:
-  # - Tracing: Support trace context propagation to the backend and from AppHosting.
-  proxy_args="^++^--tracing_sample_rate=0.05"
+  # - Tracing: Disable tracing to free up resources in test project.
+  proxy_args="^++^--disable_tracing"
 
   if [[ ${PROXY_PLATFORM} == "cloud-run" ]];
   then

--- a/tests/e2e/scripts/gke/deploy.sh
+++ b/tests/e2e/scripts/gke/deploy.sh
@@ -43,7 +43,7 @@ PROJECT_ID="cloudesf-testing"
 # Parses parameters into config file.
 ARGS="$ARGS \"--service=${APIPROXY_SERVICE}\","
 ARGS="$ARGS \"--rollout_strategy=${ROLLOUT_STRATEGY}\","
-ARGS="$ARGS \"--tracing_sample_rate=0.05\","
+ARGS="$ARGS \"--disable_tracing\","
 ARGS="$ARGS \"--admin_port=8001\""
 case "${BACKEND}" in
   'bookstore')


### PR DESCRIPTION
ESPv2 is stable and we don't verify traces published via e2e. Disable it to allow better visualization of Cloud ESF traces. Integration tests in ESPv2 still verify tracing behavior.