### PR TITLE
Tracing sample rate

### DIFF
--- a/tests/e2e/scripts/cloud-run/deploy.sh
+++ b/tests/e2e/scripts/cloud-run/deploy.sh
@@ -335,7 +335,7 @@ function setup() {
     -i "${APIPROXY_IMAGE}"
 
   # Redeploy ESPv2 to update the service config. Set flags as follows:
-  proxy_args="^++^--tracing_sample_rate=0.0001"
+  proxy_args="^++^--tracing_sample_rate=0.0005"
 
   if [[ ${PROXY_PLATFORM} == "cloud-run" ]];
   then

--- a/tests/e2e/scripts/cloud-run/deploy.sh
+++ b/tests/e2e/scripts/cloud-run/deploy.sh
@@ -335,8 +335,7 @@ function setup() {
     -i "${APIPROXY_IMAGE}"
 
   # Redeploy ESPv2 to update the service config. Set flags as follows:
-  # - Tracing: Support trace context propagation to the backend and from AppHosting.
-  proxy_args="^++^--tracing_sample_rate=0.05"
+  proxy_args="^++^--tracing_sample_rate=0.0001"
 
   if [[ ${PROXY_PLATFORM} == "cloud-run" ]];
   then

--- a/tests/e2e/scripts/gke/deploy.sh
+++ b/tests/e2e/scripts/gke/deploy.sh
@@ -43,7 +43,7 @@ PROJECT_ID="cloudesf-testing"
 # Parses parameters into config file.
 ARGS="$ARGS \"--service=${APIPROXY_SERVICE}\","
 ARGS="$ARGS \"--rollout_strategy=${ROLLOUT_STRATEGY}\","
-ARGS="$ARGS \"--tracing_sample_rate=0.05\","
+ARGS="$ARGS \"--tracing_sample_rate=0.0001\","
 ARGS="$ARGS \"--admin_port=8001\""
 case "${BACKEND}" in
   'bookstore')

--- a/tests/e2e/scripts/gke/deploy.sh
+++ b/tests/e2e/scripts/gke/deploy.sh
@@ -43,7 +43,7 @@ PROJECT_ID="cloudesf-testing"
 # Parses parameters into config file.
 ARGS="$ARGS \"--service=${APIPROXY_SERVICE}\","
 ARGS="$ARGS \"--rollout_strategy=${ROLLOUT_STRATEGY}\","
-ARGS="$ARGS \"--tracing_sample_rate=0.0001\","
+ARGS="$ARGS \"--tracing_sample_rate=0.0005\","
 ARGS="$ARGS \"--admin_port=8001\""
 case "${BACKEND}" in
   'bookstore')


### PR DESCRIPTION
e2e tests sample too much for ESPv2. Sometimes we hit daily tracing quota in GCP project. Reduce sample rate by 100x. It should still be enough traces if you look at 7 day trace chart.