### PR TITLE
 b/262774083: Fix trace id in the endpoint log

### DIFF
--- a/api/envoy/v11/http/service_control/config.proto
+++ b/api/envoy/v11/http/service_control/config.proto
@@ -89,6 +89,12 @@ message Service {
 
   // If true, extract client ip from "forwarded" header.
   bool client_ip_from_forwarded_header = 11;
+
+  // The tracing project id specified from the flag --tracing_project_id
+  string tracing_project_id = 12;
+
+  // The tracing is disabled.
+  bool tracing_disabled = 13;
 }
 
 message GcpAttributes {

--- a/examples/grpc_dynamic_routing/envoy_config.json
+++ b/examples/grpc_dynamic_routing/envoy_config.json
@@ -874,7 +874,8 @@
                               }
                             },
                             "serviceConfigId": "2019-12-16r0",
-                            "serviceName": "examples-grpc-dynamic-routing-wd6ufmzfya-uc.a.run.app"
+                            "serviceName": "examples-grpc-dynamic-routing-wd6ufmzfya-uc.a.run.app",
+                            "tracingDisabled": true
                           }
                         ]
                       }

--- a/examples/service_control/envoy_config.json
+++ b/examples/service_control/envoy_config.json
@@ -699,7 +699,8 @@
                               }
                             },
                             "serviceConfigId": "2019-12-16r0",
-                            "serviceName": "examples-service-control.endpoints.cloudesf-testing.cloud.goog"
+                            "serviceName": "examples-service-control.endpoints.cloudesf-testing.cloud.goog",
+                            "tracingDisabled": true
                           }
                         ]
                       }

--- a/src/api_proxy/service_control/request_builder.cc
+++ b/src/api_proxy/service_control/request_builder.cc
@@ -830,8 +830,14 @@ void FillLogEntry(const ReportRequestInfo& info, const std::string& name,
   log_entry->set_severity(severity);
 
   // Add trace if available.
-  if (!info.trace_id.empty() && !info.project_id.empty()) {
-    log_entry->set_trace(TraceResourceName(info.trace_id, info.project_id));
+  if (!info.trace_id.empty()) {
+    if (!info.tracing_project_id.empty()) {
+      log_entry->set_trace(
+          TraceResourceName(info.trace_id, info.tracing_project_id));
+    } else if (!info.gcp_project_id.empty()) {
+      log_entry->set_trace(
+          TraceResourceName(info.trace_id, info.gcp_project_id));
+    }
   }
 
   // Fill in http request.

--- a/src/api_proxy/service_control/request_builder_test.cc
+++ b/src/api_proxy/service_control/request_builder_test.cc
@@ -261,7 +261,24 @@ TEST_F(RequestBuilderTest, FillGoodReportRequestTest) {
   FillOperationInfo(&info);
   FillReportRequestInfo(&info);
   info.backend_protocol = protocol::GRPC;
-  info.project_id = "test_project_id";
+  info.gcp_project_id = "test_project_id";
+  info.trace_id = "test_trace_id";
+
+  gasv1::ReportRequest request;
+  ASSERT_TRUE(scp_.FillReportRequest(info, &request).ok());
+
+  std::string text = ReportRequestToString(&request);
+  std::string expected_text = ReadTestBaseline("report_request.golden");
+  ASSERT_EQ(expected_text, text);
+}
+
+TEST_F(RequestBuilderTest, FillGoodReportRequestWithTracingProjectId) {
+  ReportRequestInfo info;
+  FillOperationInfo(&info);
+  FillReportRequestInfo(&info);
+  info.backend_protocol = protocol::GRPC;
+  info.tracing_project_id = "test_project_id";
+  info.gcp_project_id = "gcp_project_id";
   info.trace_id = "test_trace_id";
 
   gasv1::ReportRequest request;

--- a/src/api_proxy/service_control/request_info.h
+++ b/src/api_proxy/service_control/request_info.h
@@ -262,7 +262,10 @@ struct ReportRequestInfo : public OperationInfo {
   std::string response_code_detail;
 
   // The GCP project ID the proxy is deployed on.
-  std::string project_id;
+  std::string gcp_project_id;
+
+  // The project ID from the flag --tracing_project_id
+  std::string tracing_project_id;
 
   // Trace id (in hex) the request is tied to.
   std::string trace_id;

--- a/src/envoy/http/service_control/handler_impl.cc
+++ b/src/envoy/http/service_control/handler_impl.cc
@@ -185,6 +185,9 @@ void ServiceControlHandlerImpl::prepareReportRequest(
   info.status = check_status_;
 
   fillGCPInfo(cfg_parser_.config(), info);
+
+  info.tracing_project_id =
+      require_ctx_->service_ctx().config().tracing_project_id();
 }
 
 void ServiceControlHandlerImpl::callCheck(
@@ -369,7 +372,9 @@ void ServiceControlHandlerImpl::callReport(
 
   info.response_code_detail = stream_info_.responseCodeDetails().value_or("");
 
-  info.trace_id = parent_span.getTraceIdAsHex();
+  if (!require_ctx_->service_ctx().config().tracing_disabled()) {
+    info.trace_id = parent_span.getTraceIdAsHex();
+  }
 
   require_ctx_->service_ctx().call().callReport(info);
 }

--- a/src/envoy/http/service_control/handler_utils.cc
+++ b/src/envoy/http/service_control/handler_utils.cc
@@ -158,7 +158,7 @@ void fillGCPInfo(
   }
 
   if (!gcp_attributes.project_id().empty()) {
-    info.project_id = gcp_attributes.project_id();
+    info.gcp_project_id = gcp_attributes.project_id();
   }
 }
 

--- a/src/go/configgenerator/filterconfig/filter_gen_service_control.go
+++ b/src/go/configgenerator/filterconfig/filter_gen_service_control.go
@@ -65,6 +65,8 @@ var scFilterGenFunc = func(serviceInfo *ci.ServiceInfo) (*hcmpb.HttpFilter, []*c
 		ServiceConfig:               copyServiceConfigForReportMetrics(serviceInfo.ServiceConfig()),
 		BackendProtocol:             protocol,
 		ClientIpFromForwardedHeader: serviceInfo.Options.ClientIPFromForwardedHeader,
+		TracingProjectId:            serviceInfo.Options.TracingProjectId,
+		TracingDisabled:             serviceInfo.Options.DisableTracing,
 	}
 
 	if serviceInfo.Options.LogRequestHeaders != "" {

--- a/src/go/configmanager/testdata/test_fetch_listeners.go
+++ b/src/go/configmanager/testdata/test_fetch_listeners.go
@@ -1646,7 +1646,9 @@ var (
                         ]
                       },
                       "serviceConfigId": "%v",
-                      "serviceName": "%v"
+                      "serviceName": "%v",
+                      "tracingDisabled": true,
+                      "tracingProjectId": "fake-project-id"
                     }
                   ]
                 }
@@ -2496,7 +2498,8 @@ var (
                       "producerProjectId": "project123",
                       "serviceConfig": {},
                       "serviceConfigId": "2017-05-01r0",
-                      "serviceName": "bookstore.endpoints.project123.cloud.goog"
+                      "serviceName": "bookstore.endpoints.project123.cloud.goog",
+                      "tracingProjectId": "fake-project-id"
                     }
                   ]
                 }


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

If the flag `--tracing_project_id` is used,  `trace_id` in the endpoint log is wrong.  It always uses the GCP deploy project. 

If trace is disabled,  we also write trace_id in the log,   We should not write it. 