### PR TITLE
b/262776950: Set environment variable GOOGLE_APPLICATION_CREDENTIALS

### DIFF
--- a/tests/start_proxy/start_proxy_test.py
+++ b/tests/start_proxy/start_proxy_test.py
@@ -910,7 +910,7 @@ class TestStartProxy(unittest.TestCase):
         i = 0
         for flags, wantedArgs in testcases:
             print("==== checking flags [{}]".format(', '.join(flags)))
-            # Reset environment varaible as start_proxy.py may set it.
+            # Reset the environment variable as start_proxy.py may set it.
             os.environ.pop(GOOGLE_CREDS_KEY, None)
             gotArgs = gen_proxy_config(self.parser.parse_args(flags))
             self.assertEqual(gotArgs, wantedArgs,


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

When the flag `--service_account_key` is used.  Stackdriver will this GOOGLE_APPLICATION_CREDENTIALS.