### PR TITLE
b/262717830: Increase check cache duration

### DIFF
--- a/src/envoy/http/service_control/client_cache.cc
+++ b/src/envoy/http/service_control/client_cache.cc
@@ -56,7 +56,7 @@ constexpr uint32_t kCheckAggregationEntries = 10000;
 //
 // * flush_interval (10m): The first request hits the cache item needs
 // to make a check call. But the other requests after it can continue
-// to use old cached results until the check call is respond.
+// to use old cached results until the check call is responded.
 //
 // * Expiration (1h): the cache item is purged after this.
 constexpr uint32_t kCheckAggregationFlushIntervalMs = (10 * 60 * 1000);

--- a/src/envoy/http/service_control/client_cache.cc
+++ b/src/envoy/http/service_control/client_cache.cc
@@ -54,7 +54,7 @@ constexpr uint32_t kCheckAggregationEntries = 10000;
 // api-key. It is safe to increase the check cache "flush_interval" and
 // "expiration".
 //
-// * flush_interval (5m): The first request hits the cache item needs
+// * FlushInterval (5m): the first request hits the cache item needs
 // to make a check call. But the other requests after it can continue
 // to use old cached results until the check call is responded.
 //

--- a/src/envoy/http/service_control/client_cache.cc
+++ b/src/envoy/http/service_control/client_cache.cc
@@ -50,11 +50,17 @@ namespace {
 
 // Default config for check aggregator
 constexpr uint32_t kCheckAggregationEntries = 10000;
-// Check doesn't support quota yet. It is safe to increase
-// the cache life of check results.
-// Cache life is 5 minutes. It will be refreshed every minute.
-constexpr uint32_t kCheckAggregationFlushIntervalMs = 60000;
-constexpr uint32_t kCheckAggregationExpirationMs = 300000;
+// We don't support quota in the check call. A check call only checks its
+// api-key. It is safe to increase the check cache "flush_interval" and
+// "expiration".
+//
+// * flush_interval (10m): The first request hits the cache item needs
+// to make a check call. But the other requests after it can continue
+// to use old cached results until the check call is respond.
+//
+// * Expiration (1h): the cache item is purged after this.
+constexpr uint32_t kCheckAggregationFlushIntervalMs = (10 * 60 * 1000);
+constexpr uint32_t kCheckAggregationExpirationMs = (60 * 60 * 1000);
 
 // Default config for quota aggregator
 constexpr uint32_t kQuotaAggregationEntries = 10000;

--- a/src/envoy/http/service_control/client_cache.cc
+++ b/src/envoy/http/service_control/client_cache.cc
@@ -54,12 +54,12 @@ constexpr uint32_t kCheckAggregationEntries = 10000;
 // api-key. It is safe to increase the check cache "flush_interval" and
 // "expiration".
 //
-// * flush_interval (10m): The first request hits the cache item needs
+// * flush_interval (5m): The first request hits the cache item needs
 // to make a check call. But the other requests after it can continue
 // to use old cached results until the check call is responded.
 //
 // * Expiration (1h): the cache item is purged after this.
-constexpr uint32_t kCheckAggregationFlushIntervalMs = (10 * 60 * 1000);
+constexpr uint32_t kCheckAggregationFlushIntervalMs = (5 * 60 * 1000);
 constexpr uint32_t kCheckAggregationExpirationMs = (60 * 60 * 1000);
 
 // Default config for quota aggregator


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

Making check calls greatly increase ESPv2 latency.  Currently check calls only check api-key, not quota info.  So it is safe to increase check `flush interval` and `expiration`.

Changes:  
* increase `flush_interval` from 1m to 10m.   
* increase `expiration` from 5m to 1h.
