### PR TITLE
Add flag --disable_jwt_audience_service_name_check

### DIFF
--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -630,10 +630,13 @@ environment variable or by passing "-k" flag to this script.
         '''
     )
     parser.add_argument(
-        '--disable_jwt_aud_check',
+        '--disable_jwt_audience_service_name_check',
         action='store_true',
         default=False,
-        help='''If true, will not check "aud" feild when verifying the JWT token.'''
+        help='''Normally JWT "aud" field is checked against audiences specified in OpenAPI "x-google-audiences" field.
+        This flag changes the behaviour when the "x-google-audiences" is not specified.
+        When the "x-google-audiences" is not specified, normally the service name is used to check the JWT "aud" field.
+        If this flag is true, the service name is not used, JWT "aud" field will not be checked.'''
     )
     parser.add_argument(
         '--http_request_timeout_s',
@@ -1206,8 +1209,8 @@ def gen_proxy_config(args):
          proxy_conf.extend(["--jwks_fetch_retry_back_off_max_interval_ms", args.jwks_fetch_retry_back_off_max_interval_ms])
     if args.jwt_pad_forward_payload_header:
         proxy_conf.append("--jwt_pad_forward_payload_header")
-    if args.disable_jwt_aud_check:
-        proxy_conf.append("--disable_jwt_aud_check")
+    if args.disable_jwt_audience_service_name_check:
+        proxy_conf.append("--disable_jwt_audience_service_name_check")
 
     if args.management:
         proxy_conf.extend(["--service_management_url", args.management])

--- a/docker/generic/start_proxy.py
+++ b/docker/generic/start_proxy.py
@@ -630,6 +630,12 @@ environment variable or by passing "-k" flag to this script.
         '''
     )
     parser.add_argument(
+        '--disable_jwt_aud_check',
+        action='store_true',
+        default=False,
+        help='''If true, will not check "aud" feild when verifying the JWT token.'''
+    )
+    parser.add_argument(
         '--http_request_timeout_s',
         default=None, type=int,
         help='''
@@ -1200,6 +1206,8 @@ def gen_proxy_config(args):
          proxy_conf.extend(["--jwks_fetch_retry_back_off_max_interval_ms", args.jwks_fetch_retry_back_off_max_interval_ms])
     if args.jwt_pad_forward_payload_header:
         proxy_conf.append("--jwt_pad_forward_payload_header")
+    if args.disable_jwt_aud_check:
+        proxy_conf.append("--disable_jwt_aud_check")
 
     if args.management:
         proxy_conf.extend(["--service_management_url", args.management])

--- a/src/go/configgenerator/filterconfig/filter_gen_jwt_authn.go
+++ b/src/go/configgenerator/filterconfig/filter_gen_jwt_authn.go
@@ -108,16 +108,18 @@ var jaFilterGenFunc = func(serviceInfo *ci.ServiceInfo) (*hcmpb.HttpFilter, []*c
 			PadForwardPayloadHeader: serviceInfo.Options.JwtPadForwardPayloadHeader,
 		}
 
-		if len(provider.GetAudiences()) != 0 {
-			for _, a := range strings.Split(provider.GetAudiences(), ",") {
-				jp.Audiences = append(jp.Audiences, strings.TrimSpace(a))
+		if !serviceInfo.Options.DisableJwtAudCheck {
+			if len(provider.GetAudiences()) != 0 {
+				for _, a := range strings.Split(provider.GetAudiences(), ",") {
+					jp.Audiences = append(jp.Audiences, strings.TrimSpace(a))
+				}
+			} else {
+				// No providers specified by user.
+				// For backwards-compatibility with ESPv1, auto-generate audiences.
+				// See b/147834348 for more information on this default behavior.
+				defaultAudience := fmt.Sprintf("https://%v", serviceInfo.Name)
+				jp.Audiences = append(jp.Audiences, defaultAudience)
 			}
-		} else {
-			// No providers specified by user.
-			// For backwards-compatibility with ESPv1, auto-generate audiences.
-			// See b/147834348 for more information on this default behavior.
-			defaultAudience := fmt.Sprintf("https://%v", serviceInfo.Name)
-			jp.Audiences = append(jp.Audiences, defaultAudience)
 		}
 
 		if serviceInfo.Options.JwtCacheSize > 0 {

--- a/src/go/configgenerator/filterconfig/filter_gen_jwt_authn_test.go
+++ b/src/go/configgenerator/filterconfig/filter_gen_jwt_authn_test.go
@@ -34,10 +34,11 @@ func TestJwtAuthnFilter(t *testing.T) {
 		disableJwksAsyncFetch      bool
 		jwksAsyncFetchFastListener bool
 		jwtCacheSize               uint
+		disableJwtAudCheck         bool
 		wantJwtAuthnFilter         string
 	}{
 		{
-			desc: "Success. Generate jwt authn filter with default jwt locations",
+			desc: "Success. Generate jwt authn filter with default jwt locations with an empty audiences.",
 			fakeServiceConfig: &confpb.Service{
 				Name: testProjectName,
 				Apis: []*apipb.Api{
@@ -82,6 +83,251 @@ func TestJwtAuthnFilter(t *testing.T) {
                 "audiences": [
                     "https://bookstore.endpoints.project123.cloud.goog"
                 ],
+                "forward": true,
+                "forwardPayloadHeader": "X-Endpoint-API-UserInfo",
+                "fromHeaders": [
+                    {
+                        "name": "Authorization",
+                        "valuePrefix": "Bearer "
+                    },
+                    {
+                        "name": "X-Goog-Iap-Jwt-Assertion"
+                    }
+                ],
+                "fromParams": [
+                    "access_token"
+                ],
+                "issuer": "issuer-0",
+                "payloadInMetadata": "jwt_payloads",
+                "remoteJwks": {
+                    "cacheDuration": "300s",
+                    "httpUri": {
+                        "cluster": "jwt-provider-cluster-fake-jwks.com:443",
+                        "timeout": "30s",
+                        "uri": "https://fake-jwks.com?key=value"
+                    },
+                    "asyncFetch": {}
+                }
+            }
+        },
+        "requirementMap": {
+            "testapi.foo": {
+                "providerName": "auth_provider"
+            }
+        }
+    }
+}
+`,
+		},
+		{
+			desc: "Success. Generate jwt authn filter with default jwt locations with non empty audiences.",
+			fakeServiceConfig: &confpb.Service{
+				Name: testProjectName,
+				Apis: []*apipb.Api{
+					{
+						Name: "testapi",
+						Methods: []*apipb.Method{
+							{
+								Name: "foo",
+							},
+						},
+					},
+				},
+				SourceInfo: &confpb.SourceInfo{
+					SourceFiles: []*anypb.Any{content},
+				},
+				Authentication: &confpb.Authentication{
+					Providers: []*confpb.AuthProvider{
+						{
+							Id:        "auth_provider",
+							Issuer:    "issuer-0",
+							JwksUri:   "https://fake-jwks.com?key=value",
+							Audiences: "audience1,audience2",
+						},
+					},
+					Rules: []*confpb.AuthenticationRule{
+						{
+							Selector: "testapi.foo",
+							Requirements: []*confpb.AuthRequirement{
+								{
+									ProviderId: "auth_provider",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantJwtAuthnFilter: `{
+    "name": "envoy.filters.http.jwt_authn",
+    "typedConfig": {
+        "@type": "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication",
+        "providers": {
+            "auth_provider": {
+                "audiences": [
+                    "audience1",
+                    "audience2"
+                ],
+                "forward": true,
+                "forwardPayloadHeader": "X-Endpoint-API-UserInfo",
+                "fromHeaders": [
+                    {
+                        "name": "Authorization",
+                        "valuePrefix": "Bearer "
+                    },
+                    {
+                        "name": "X-Goog-Iap-Jwt-Assertion"
+                    }
+                ],
+                "fromParams": [
+                    "access_token"
+                ],
+                "issuer": "issuer-0",
+                "payloadInMetadata": "jwt_payloads",
+                "remoteJwks": {
+                    "cacheDuration": "300s",
+                    "httpUri": {
+                        "cluster": "jwt-provider-cluster-fake-jwks.com:443",
+                        "timeout": "30s",
+                        "uri": "https://fake-jwks.com?key=value"
+                    },
+                    "asyncFetch": {}
+                }
+            }
+        },
+        "requirementMap": {
+            "testapi.foo": {
+                "providerName": "auth_provider"
+            }
+        }
+    }
+}
+`,
+		},
+		{
+			desc: "Success. Generate jwt authn filter with disabled aud check and an empty audiences.",
+			fakeServiceConfig: &confpb.Service{
+				Name: testProjectName,
+				Apis: []*apipb.Api{
+					{
+						Name: "testapi",
+						Methods: []*apipb.Method{
+							{
+								Name: "foo",
+							},
+						},
+					},
+				},
+				SourceInfo: &confpb.SourceInfo{
+					SourceFiles: []*anypb.Any{content},
+				},
+				Authentication: &confpb.Authentication{
+					Providers: []*confpb.AuthProvider{
+						{
+							Id:      "auth_provider",
+							Issuer:  "issuer-0",
+							JwksUri: "https://fake-jwks.com?key=value",
+						},
+					},
+					Rules: []*confpb.AuthenticationRule{
+						{
+							Selector: "testapi.foo",
+							Requirements: []*confpb.AuthRequirement{
+								{
+									ProviderId: "auth_provider",
+								},
+							},
+						},
+					},
+				},
+			},
+			disableJwtAudCheck: true,
+			wantJwtAuthnFilter: `{
+    "name": "envoy.filters.http.jwt_authn",
+    "typedConfig": {
+        "@type": "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication",
+        "providers": {
+            "auth_provider": {
+                "forward": true,
+                "forwardPayloadHeader": "X-Endpoint-API-UserInfo",
+                "fromHeaders": [
+                    {
+                        "name": "Authorization",
+                        "valuePrefix": "Bearer "
+                    },
+                    {
+                        "name": "X-Goog-Iap-Jwt-Assertion"
+                    }
+                ],
+                "fromParams": [
+                    "access_token"
+                ],
+                "issuer": "issuer-0",
+                "payloadInMetadata": "jwt_payloads",
+                "remoteJwks": {
+                    "cacheDuration": "300s",
+                    "httpUri": {
+                        "cluster": "jwt-provider-cluster-fake-jwks.com:443",
+                        "timeout": "30s",
+                        "uri": "https://fake-jwks.com?key=value"
+                    },
+                    "asyncFetch": {}
+                }
+            }
+        },
+        "requirementMap": {
+            "testapi.foo": {
+                "providerName": "auth_provider"
+            }
+        }
+    }
+}
+`,
+		},
+		{
+			desc: "Success. Generate jwt authn filter with disabled aud check and non empty audiences.",
+			fakeServiceConfig: &confpb.Service{
+				Name: testProjectName,
+				Apis: []*apipb.Api{
+					{
+						Name: "testapi",
+						Methods: []*apipb.Method{
+							{
+								Name: "foo",
+							},
+						},
+					},
+				},
+				SourceInfo: &confpb.SourceInfo{
+					SourceFiles: []*anypb.Any{content},
+				},
+				Authentication: &confpb.Authentication{
+					Providers: []*confpb.AuthProvider{
+						{
+							Id:        "auth_provider",
+							Issuer:    "issuer-0",
+							JwksUri:   "https://fake-jwks.com?key=value",
+							Audiences: "audience1,audience2",
+						},
+					},
+					Rules: []*confpb.AuthenticationRule{
+						{
+							Selector: "testapi.foo",
+							Requirements: []*confpb.AuthRequirement{
+								{
+									ProviderId: "auth_provider",
+								},
+							},
+						},
+					},
+				},
+			},
+			disableJwtAudCheck: true,
+			wantJwtAuthnFilter: `{
+    "name": "envoy.filters.http.jwt_authn",
+    "typedConfig": {
+        "@type": "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication",
+        "providers": {
+            "auth_provider": {
                 "forward": true,
                 "forwardPayloadHeader": "X-Endpoint-API-UserInfo",
                 "fromHeaders": [
@@ -397,6 +643,7 @@ func TestJwtAuthnFilter(t *testing.T) {
 		opts.BackendAddress = "grpc://127.0.0.0:80"
 		opts.DisableJwksAsyncFetch = tc.disableJwksAsyncFetch
 		opts.JwksAsyncFetchFastListener = tc.jwksAsyncFetchFastListener
+		opts.DisableJwtAudCheck = tc.disableJwtAudCheck
 		opts.JwtCacheSize = tc.jwtCacheSize
 		fakeServiceInfo, err := configinfo.NewServiceInfoFromServiceConfig(tc.fakeServiceConfig, testConfigID, opts)
 		if err != nil {

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -144,8 +144,9 @@ var (
 	JwksFetchRetryBackOffMaxIntervalMs  = flag.Int("jwks_fetch_retry_back_off_max_interval_ms", int(defaults.JwksFetchRetryBackOffMaxInterval.Milliseconds()), `Specify JWKS fetch retry exponential back off maximum interval in milliseconds. The default is 32 seconds.`)
 	JwtPatForwardPayloadHeader          = flag.Bool("jwt_pad_forward_payload_header", defaults.JwtPadForwardPayloadHeader, `For the JWT in request, the JWT payload is forwarded to backend in the "X-Endpoint-API-UserInfo"" header by default. 
 Normally JWT based64 encode doesn’t add padding. If this flag is true, the header will be padded.`)
-	JwtCacheSize       = flag.Uint("jwt_cache_size", defaults.JwtCacheSize, `Specify JWT cache size, the number of unique JWT tokens in the cache. The cache only stores verified good tokens. If 0, JWT cache is disabled. It limits the memory usage. The cache used memory is roughly (token size + 64 bytes) per token. If not specified, the default is 100000.`)
-	DisableJwtAudCheck = flag.Bool("disable_jwt_aud_check", defaults.DisableJwtAudCheck, `If true, not to check "aud" field in the JWT token.`)
+	JwtCacheSize = flag.Uint("jwt_cache_size", defaults.JwtCacheSize, `Specify JWT cache size, the number of unique JWT tokens in the cache. The cache only stores verified good tokens. If 0, JWT cache is disabled. It limits the memory usage. The cache used memory is roughly (token size + 64 bytes) per token. If not specified, the default is 100000.`)
+
+	DisableJwtAudienceServiceNameCheck = flag.Bool("disable_jwt_audience_service_name_check", defaults.DisableJwtAudienceServiceNameCheck, `Normally JWT "aud" field is checked against audiences specified in OpenAPI "x-google-audiences" field. This flag changes the behaviour when the "x-google-audiences" is not specified. When the "x-google-audiences" is not specified, normally the service name is used to check the JWT "aud" field.  If this flag is true, the service name is not used, JWT "aud" field will not be checked.`)
 
 	ScCheckTimeoutMs  = flag.Int("service_control_check_timeout_ms", defaults.ScCheckTimeoutMs, `Set the timeout in millisecond for service control Check request. Must be > 0 and the default is 1000 if not set.`)
 	ScQuotaTimeoutMs  = flag.Int("service_control_quota_timeout_ms", defaults.ScQuotaTimeoutMs, `Set the timeout in millisecond for service control Quota request. Must be > 0 and the default is 1000 if not set.`)
@@ -288,7 +289,7 @@ func EnvoyConfigOptionsFromFlags() options.ConfigGeneratorOptions {
 		JwksFetchRetryBackOffMaxInterval:              time.Duration(*JwksFetchRetryBackOffMaxIntervalMs) * time.Millisecond,
 		JwtPadForwardPayloadHeader:                    *JwtPatForwardPayloadHeader,
 		JwtCacheSize:                                  *JwtCacheSize,
-		DisableJwtAudCheck:                            *DisableJwtAudCheck,
+		DisableJwtAudienceServiceNameCheck:            *DisableJwtAudienceServiceNameCheck,
 		BackendRetryOns:                               *BackendRetryOns,
 		BackendRetryNum:                               *BackendRetryNum,
 		BackendPerTryTimeout:                          *BackendPerTryTimeout,

--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -144,7 +144,8 @@ var (
 	JwksFetchRetryBackOffMaxIntervalMs  = flag.Int("jwks_fetch_retry_back_off_max_interval_ms", int(defaults.JwksFetchRetryBackOffMaxInterval.Milliseconds()), `Specify JWKS fetch retry exponential back off maximum interval in milliseconds. The default is 32 seconds.`)
 	JwtPatForwardPayloadHeader          = flag.Bool("jwt_pad_forward_payload_header", defaults.JwtPadForwardPayloadHeader, `For the JWT in request, the JWT payload is forwarded to backend in the "X-Endpoint-API-UserInfo"" header by default. 
 Normally JWT based64 encode doesn’t add padding. If this flag is true, the header will be padded.`)
-	JwtCacheSize = flag.Uint("jwt_cache_size", defaults.JwtCacheSize, `Specify JWT cache size, the number of unique JWT tokens in the cache. The cache only stores verified good tokens. If 0, JWT cache is disabled. It limits the memory usage. The cache used memory is roughly (token size + 64 bytes) per token. If not specified, the default is 100000.`)
+	JwtCacheSize       = flag.Uint("jwt_cache_size", defaults.JwtCacheSize, `Specify JWT cache size, the number of unique JWT tokens in the cache. The cache only stores verified good tokens. If 0, JWT cache is disabled. It limits the memory usage. The cache used memory is roughly (token size + 64 bytes) per token. If not specified, the default is 100000.`)
+	DisableJwtAudCheck = flag.Bool("disable_jwt_aud_check", defaults.DisableJwtAudCheck, `If true, not to check "aud" field in the JWT token.`)
 
 	ScCheckTimeoutMs  = flag.Int("service_control_check_timeout_ms", defaults.ScCheckTimeoutMs, `Set the timeout in millisecond for service control Check request. Must be > 0 and the default is 1000 if not set.`)
 	ScQuotaTimeoutMs  = flag.Int("service_control_quota_timeout_ms", defaults.ScQuotaTimeoutMs, `Set the timeout in millisecond for service control Quota request. Must be > 0 and the default is 1000 if not set.`)
@@ -287,6 +288,7 @@ func EnvoyConfigOptionsFromFlags() options.ConfigGeneratorOptions {
 		JwksFetchRetryBackOffMaxInterval:              time.Duration(*JwksFetchRetryBackOffMaxIntervalMs) * time.Millisecond,
 		JwtPadForwardPayloadHeader:                    *JwtPatForwardPayloadHeader,
 		JwtCacheSize:                                  *JwtCacheSize,
+		DisableJwtAudCheck:                            *DisableJwtAudCheck,
 		BackendRetryOns:                               *BackendRetryOns,
 		BackendRetryNum:                               *BackendRetryNum,
 		BackendPerTryTimeout:                          *BackendPerTryTimeout,

--- a/src/go/options/configgenerator.go
+++ b/src/go/options/configgenerator.go
@@ -123,6 +123,7 @@ type ConfigGeneratorOptions struct {
 	JwksFetchRetryBackOffMaxInterval  time.Duration
 	JwtPadForwardPayloadHeader        bool
 	JwtCacheSize                      uint
+	DisableJwtAudCheck                bool
 
 	ScCheckTimeoutMs  int
 	ScQuotaTimeoutMs  int

--- a/src/go/options/configgenerator.go
+++ b/src/go/options/configgenerator.go
@@ -115,15 +115,15 @@ type ConfigGeneratorOptions struct {
 	ConnectionBufferLimitBytes    int
 
 	// JwtAuthn related flags
-	DisableJwksAsyncFetch             bool
-	JwksAsyncFetchFastListener        bool
-	JwksCacheDurationInS              int
-	JwksFetchNumRetries               int
-	JwksFetchRetryBackOffBaseInterval time.Duration
-	JwksFetchRetryBackOffMaxInterval  time.Duration
-	JwtPadForwardPayloadHeader        bool
-	JwtCacheSize                      uint
-	DisableJwtAudCheck                bool
+	DisableJwksAsyncFetch              bool
+	JwksAsyncFetchFastListener         bool
+	JwksCacheDurationInS               int
+	JwksFetchNumRetries                int
+	JwksFetchRetryBackOffBaseInterval  time.Duration
+	JwksFetchRetryBackOffMaxInterval   time.Duration
+	JwtPadForwardPayloadHeader         bool
+	JwtCacheSize                       uint
+	DisableJwtAudienceServiceNameCheck bool
 
 	ScCheckTimeoutMs  int
 	ScQuotaTimeoutMs  int

--- a/tests/env/platform/ports.go
+++ b/tests/env/platform/ports.go
@@ -90,6 +90,7 @@ const (
 	TestIdleTimeoutsForGrpcStreaming
 	TestIdleTimeoutsForUnaryRPCs
 	TestInvalidOpenIDConnectDiscovery
+	TestJWTDisabledAudCheck
 	TestJwtLocations
 	TestManagedServiceConfig
 	TestMetadataRequestsPerPlatform

--- a/tests/start_proxy/start_proxy_test.py
+++ b/tests/start_proxy/start_proxy_test.py
@@ -153,6 +153,21 @@ class TestStartProxy(unittest.TestCase):
               '--check_metadata', '--underscores_in_headers',
               '--disable_tracing'
               ]),
+            # disable_jwt_aud_check
+            (['-R=managed','--disable_jwt_aud_check',
+              '--http_port=8079', '--service_control_quota_retries=3',
+              '--service_control_report_timeout_ms=300',
+              '--check_metadata',
+              '--disable_tracing', '--underscores_in_headers'],
+             ['bin/configmanager', '--logtostderr', '--rollout_strategy', 'managed',
+              '--backend_address', 'http://127.0.0.1:8082', '--v', '0',
+              '--disable_jwt_aud_check',
+              '--listener_port', '8079',
+              '--service_control_quota_retries', '3',
+              '--service_control_report_timeout_ms', '300',
+              '--check_metadata', '--underscores_in_headers',
+              '--disable_tracing'
+              ]),
             # jwks_fetch retry backoff
             (['-R=managed','--disable_jwks_async_fetch',
               '--jwks_fetch_num_retries=10',

--- a/tests/start_proxy/start_proxy_test.py
+++ b/tests/start_proxy/start_proxy_test.py
@@ -153,15 +153,15 @@ class TestStartProxy(unittest.TestCase):
               '--check_metadata', '--underscores_in_headers',
               '--disable_tracing'
               ]),
-            # disable_jwt_aud_check
-            (['-R=managed','--disable_jwt_aud_check',
+            # --disable_jwt_audience_service_name_check
+            (['-R=managed','--disable_jwt_audience_service_name_check',
               '--http_port=8079', '--service_control_quota_retries=3',
               '--service_control_report_timeout_ms=300',
               '--check_metadata',
               '--disable_tracing', '--underscores_in_headers'],
              ['bin/configmanager', '--logtostderr', '--rollout_strategy', 'managed',
               '--backend_address', 'http://127.0.0.1:8082', '--v', '0',
-              '--disable_jwt_aud_check',
+              '--disable_jwt_audience_service_name_check',
               '--listener_port', '8079',
               '--service_control_quota_retries', '3',
               '--service_control_report_timeout_ms', '300',


### PR DESCRIPTION
To fix: https://github.com/GoogleCloudPlatform/esp-v2/issues/706

Normally JWT "aud" field is checked against audiences specified in OpenAPI `x-google-audiences` field.
This flag changes the behavior when the `x-google-audiences` is not specified.
 When the `x-google-audiences` is not specified, normally the service name is used to check the JWT `aud` field.
 If this flag is true, the service name is not used, JWT `aud` field will not be checked.

