### PR TITLE
refactor: move business logic to filter generators

### DIFF
--- a/src/go/configgenerator/filter_generator.go
+++ b/src/go/configgenerator/filter_generator.go
@@ -38,7 +38,8 @@ type FilterGenerator interface {
 	// have per-route configurations.
 	GenFilterConfig(*ci.ServiceInfo) (*hcmpb.HttpFilter, error)
 
-	// GenPerRouteConfig generates the per-route config for the given HTTP route.
+	// GenPerRouteConfig generates the per-route config for the given HTTP route (HTTP pattern).
+	// The MethodInfo that contains the route is also provided.
 	//
 	// This method is called on all routes. Return (nil, nil) to indicate the
 	// filter does NOT require a per-route config for the given route.

--- a/src/go/configgenerator/filter_generator.go
+++ b/src/go/configgenerator/filter_generator.go
@@ -28,68 +28,50 @@ type FilterGenerator interface {
 	// FilterName returns the name of the filter.
 	FilterName() string
 
-	// GenFilterConfig generates the filter config and a list of methods that need per-route configs.
-	GenFilterConfig(*ci.ServiceInfo) (*hcmpb.HttpFilter, []*ci.MethodInfo, error)
+	// IsEnabled returns true if the filter config should be generated.
+	// If false, none of the generation methods will be called.
+	IsEnabled() bool
+
+	// GenFilterConfig generates the filter config.
+	//
+	// Return (nil, nil) if the filter has no listener-level config, but may
+	// have per-route configurations.
+	GenFilterConfig(*ci.ServiceInfo) (*hcmpb.HttpFilter, error)
 
 	// GenPerRouteConfig generates the per-route config for the given HTTP route.
-	// This method is only called on the routes that `GenFilterConfig` returns.
+	//
+	// This method is called on all routes. Return (nil, nil) to indicate the
+	// filter does NOT require a per-route config for the given route.
 	GenPerRouteConfig(*ci.MethodInfo, *httppattern.Pattern) (*anypb.Any, error)
 }
 
 // MakeFilterGenerators provide of a slice of FilterGenerator in sequence.
 func MakeFilterGenerators(serviceInfo *ci.ServiceInfo) ([]FilterGenerator, error) {
-	var filterGenerators []FilterGenerator
+	return []FilterGenerator{
+		filtergen.NewCORSGenerator(serviceInfo),
 
-	if serviceInfo.Options.CorsPreset == "basic" || serviceInfo.Options.CorsPreset == "cors_with_regex" {
-		filterGenerators = append(filterGenerators, &filtergen.CORSGenerator{})
-	}
+		// Health check filter is behind Path Matcher filter, since Service Control
+		// filter needs to get the corresponding rule for health check in order to skip Report
+		filtergen.NewHealthCheckGenerator(serviceInfo),
+		filtergen.NewCompressorGenerator(serviceInfo, filtergen.GzipCompressor),
+		filtergen.NewCompressorGenerator(serviceInfo, filtergen.BrotliCompressor),
+		filtergen.NewJwtAuthnGenerator(serviceInfo),
+		filtergen.NewServiceControlGenerator(serviceInfo),
 
-	// Add Health Check filter if needed. It must behind Path Matcher filter, since Service Control
-	// filter needs to get the corresponding rule for health check cmake depend.insalls, in order to skip Report
-	if serviceInfo.Options.Healthz != "" {
-		filterGenerators = append(filterGenerators, &filtergen.HealthCheckGenerator{})
-	}
-
-	if serviceInfo.Options.EnableResponseCompression {
-		filterGenerators = append(filterGenerators, &filtergen.CompressorGenerator{
-			CompressorType: filtergen.GzipCompressor,
-		})
-		filterGenerators = append(filterGenerators, &filtergen.CompressorGenerator{
-			CompressorType: filtergen.BrotliCompressor,
-		})
-	}
-
-	// Add JWT Authn filter if needed.
-	if !serviceInfo.Options.SkipJwtAuthnFilter {
-		filterGenerators = append(filterGenerators, &filtergen.JwtAuthnGenerator{})
-	}
-
-	// Add Service Control filter if needed.
-	if !serviceInfo.Options.SkipServiceControlFilter {
-		filterGenerators = append(filterGenerators, &filtergen.ServiceControlGenerator{})
-	}
-
-	// Add gRPC Transcoder filter and gRPCWeb filter configs for gRPC backend.
-	if serviceInfo.GrpcSupportRequired {
 		// grpc-web filter should be before grpc transcoder filter.
 		// It converts content-type application/grpc-web to application/grpc and
 		// grpc transcoder will bypass requests with application/grpc content type.
 		// Otherwise grpc transcoder will try to transcode a grpc-web request which
 		// will fail.
-		filterGenerators = append(filterGenerators, &filtergen.GRPCWebGenerator{})
-		filterGenerators = append(filterGenerators, &filtergen.GRPCTranscoderGenerator{})
-	}
+		filtergen.NewGRPCWebGenerator(serviceInfo),
+		filtergen.NewGRPCTranscoderGenerator(serviceInfo),
 
-	filterGenerators = append(filterGenerators, &filtergen.BackendAuthGenerator{})
-	filterGenerators = append(filterGenerators, &filtergen.PathRewriteGenerator{})
+		filtergen.NewBackendAuthGenerator(serviceInfo),
+		filtergen.NewPathRewriteGenerator(serviceInfo),
+		filtergen.NewGRPCMetadataScrubberGenerator(serviceInfo),
 
-	if serviceInfo.Options.EnableGrpcForHttp1 {
-		// Add GrpcMetadataScrubber filter to retain gRPC trailers
-		filterGenerators = append(filterGenerators, &filtergen.GRPCMetadataScrubberGenerator{})
-	}
-
-	// Add Envoy Router filter so requests are routed upstream.
-	// Router filter should be the last.
-	filterGenerators = append(filterGenerators, &filtergen.RouterGenerator{})
-	return filterGenerators, nil
+		// Add Envoy Router filter so requests are routed upstream.
+		// Router filter should be the last.
+		&filtergen.RouterGenerator{},
+	}, nil
 }

--- a/src/go/configgenerator/filtergen/backend_auth_test.go
+++ b/src/go/configgenerator/filtergen/backend_auth_test.go
@@ -276,8 +276,12 @@ func TestBackendAuthFilter(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			gen := BackendAuthGenerator{}
-			filterConfig, _, err := gen.GenFilterConfig(fakeServiceInfo)
+			gen := NewBackendAuthGenerator(fakeServiceInfo)
+			if !gen.IsEnabled() {
+				t.Fatal("BackendAuthGenerator is not enabled, want it to be enabled")
+			}
+
+			filterConfig, err := gen.GenFilterConfig(fakeServiceInfo)
 			if err != nil {
 				if tc.wantError == "" || !strings.Contains(err.Error(), tc.wantError) {
 					t.Fatalf("exepected err (%v), got err (%v)", tc.wantError, err)

--- a/src/go/configgenerator/filtergen/grpc_web.go
+++ b/src/go/configgenerator/filtergen/grpc_web.go
@@ -15,8 +15,6 @@
 package filtergen
 
 import (
-	"fmt"
-
 	ci "github.com/GoogleCloudPlatform/esp-v2/src/go/configinfo"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
@@ -26,23 +24,37 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
-type GRPCWebGenerator struct{}
+type GRPCWebGenerator struct {
+	// skipFilter indicates if this filter is disabled based on options and config.
+	skipFilter bool
+}
+
+// NewGRPCWebGenerator creates the GRPCWebGenerator with cached config.
+func NewGRPCWebGenerator(serviceInfo *ci.ServiceInfo) *GRPCWebGenerator {
+	return &GRPCWebGenerator{
+		skipFilter: !serviceInfo.GrpcSupportRequired,
+	}
+}
 
 func (g *GRPCWebGenerator) FilterName() string {
 	return util.GRPCWeb
 }
 
-func (g *GRPCWebGenerator) GenFilterConfig(serviceInfo *ci.ServiceInfo) (*hcmpb.HttpFilter, []*ci.MethodInfo, error) {
+func (g *GRPCWebGenerator) IsEnabled() bool {
+	return !g.skipFilter
+}
+
+func (g *GRPCWebGenerator) GenFilterConfig(serviceInfo *ci.ServiceInfo) (*hcmpb.HttpFilter, error) {
 	a, err := ptypes.MarshalAny(&grpcwebpb.GrpcWeb{})
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	return &hcmpb.HttpFilter{
 		Name:       util.GRPCWeb,
 		ConfigType: &hcmpb.HttpFilter_TypedConfig{TypedConfig: a},
-	}, nil, nil
+	}, nil
 }
 
 func (g *GRPCWebGenerator) GenPerRouteConfig(method *ci.MethodInfo, httpRule *httppattern.Pattern) (*anypb.Any, error) {
-	return nil, fmt.Errorf("UNIMPLEMENTED")
+	return nil, nil
 }

--- a/src/go/configgenerator/filtergen/health_check_test.go
+++ b/src/go/configgenerator/filtergen/health_check_test.go
@@ -118,8 +118,12 @@ func TestHealthCheckFilter(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			gen := &HealthCheckGenerator{}
-			filter, _, err := gen.GenFilterConfig(fakeServiceInfo)
+			gen := NewHealthCheckGenerator(fakeServiceInfo)
+			if !gen.IsEnabled() {
+				t.Fatal("HealthCheckGenerator is not enabled, want it to be enabled")
+			}
+
+			filter, err := gen.GenFilterConfig(fakeServiceInfo)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/src/go/configgenerator/filtergen/jwt_authn_test.go
+++ b/src/go/configgenerator/filtergen/jwt_authn_test.go
@@ -652,8 +652,12 @@ func TestJwtAuthnFilter(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			gen := &JwtAuthnGenerator{}
-			gotProto, _, err := gen.GenFilterConfig(fakeServiceInfo)
+			gen := NewJwtAuthnGenerator(fakeServiceInfo)
+			if !gen.IsEnabled() {
+				t.Fatal("JwtAuthnGenerator is not enabled, want it to be enabled")
+			}
+
+			gotProto, err := gen.GenFilterConfig(fakeServiceInfo)
 			if err != nil {
 				t.Fatalf("GenFilterConfig got err %v, want no err", err)
 			}

--- a/src/go/configgenerator/filtergen/router.go
+++ b/src/go/configgenerator/filtergen/router.go
@@ -15,8 +15,6 @@
 package filtergen
 
 import (
-	"fmt"
-
 	ci "github.com/GoogleCloudPlatform/esp-v2/src/go/configinfo"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
@@ -32,7 +30,11 @@ func (g *RouterGenerator) FilterName() string {
 	return util.Router
 }
 
-func (g *RouterGenerator) GenFilterConfig(serviceInfo *ci.ServiceInfo) (*hcmpb.HttpFilter, []*ci.MethodInfo, error) {
+func (g *RouterGenerator) IsEnabled() bool {
+	return true
+}
+
+func (g *RouterGenerator) GenFilterConfig(serviceInfo *ci.ServiceInfo) (*hcmpb.HttpFilter, error) {
 	router, _ := ptypes.MarshalAny(&routerpb.Router{
 		SuppressEnvoyHeaders: serviceInfo.Options.SuppressEnvoyHeaders,
 		StartChildSpan:       !serviceInfo.Options.DisableTracing,
@@ -42,9 +44,9 @@ func (g *RouterGenerator) GenFilterConfig(serviceInfo *ci.ServiceInfo) (*hcmpb.H
 		Name:       util.Router,
 		ConfigType: &hcmpb.HttpFilter_TypedConfig{TypedConfig: router},
 	}
-	return routerFilter, nil, nil
+	return routerFilter, nil
 }
 
 func (g *RouterGenerator) GenPerRouteConfig(method *ci.MethodInfo, httpRule *httppattern.Pattern) (*anypb.Any, error) {
-	return nil, fmt.Errorf("UNIMPLEMENTED")
+	return nil, nil
 }

--- a/src/go/configgenerator/filtergen/service_control_test.go
+++ b/src/go/configgenerator/filtergen/service_control_test.go
@@ -108,13 +108,17 @@ func TestServiceControl(t *testing.T) {
 				t.Error(err)
 			}
 
-			marshaler := &jsonpb.Marshaler{}
-			gen := &ServiceControlGenerator{}
-			filter, _, err := gen.GenFilterConfig(fakeServiceInfo)
+			gen := NewServiceControlGenerator(fakeServiceInfo)
+			if !gen.IsEnabled() {
+				t.Fatal("ServiceControlGenerator is not enabled, want it to be enabled")
+			}
+
+			filter, err := gen.GenFilterConfig(fakeServiceInfo)
 			if err != nil {
 				t.Fatal(err)
 			}
 
+			marshaler := &jsonpb.Marshaler{}
 			gotFilter, err := marshaler.MarshalToString(filter)
 			if err != nil {
 				t.Fatal(err)

--- a/src/go/configgenerator/listener_generator.go
+++ b/src/go/configgenerator/listener_generator.go
@@ -49,18 +49,6 @@ func MakeListeners(serviceInfo *sc.ServiceInfo) ([]*listenerpb.Listener, error) 
 	return []*listenerpb.Listener{listener}, nil
 }
 
-// AddPerRouteConfigGenToMethods adds the filterGenerator functions to all the methods in place.
-func AddPerRouteConfigGenToMethods(methods []*sc.MethodInfo, filterGen FilterGenerator) error {
-	for _, method := range methods {
-		method.PerRouteConfigGens = append(method.PerRouteConfigGens, &sc.PerRouteConfigGenerator{
-			FilterName:            filterGen.FilterName(),
-			PerRouteConfigGenFunc: filterGen.GenPerRouteConfig,
-		})
-	}
-	return nil
-
-}
-
 // GetFilterConfigAndAddPerRouteConfigGen does two things
 //   - Return all http filter configs in a list
 //   - In place add the perRouteConfigGen function to all methods defined in serviceInfo
@@ -68,21 +56,26 @@ func GetFilterConfigAndAddPerRouteConfigGen(serviceInfo *sc.ServiceInfo, filterG
 	var httpFilters []*hcmpb.HttpFilter
 
 	for _, filterGenerator := range filterGenerators {
-		filter, perRouteConfigRequiredMethods, err := filterGenerator.GenFilterConfig(serviceInfo)
+		if !filterGenerator.IsEnabled() {
+			continue
+		}
+
+		filter, err := filterGenerator.GenFilterConfig(serviceInfo)
 		if err != nil {
 			return nil, fmt.Errorf("fail to create config for the filter %q: %v", filterGenerator.FilterName(), err)
 		}
-		if filter != nil {
-			jsonStr, _ := util.ProtoToJson(filter)
-			glog.Infof("adding filter config of %q : %v", filterGenerator.FilterName(), jsonStr)
-			httpFilters = append(httpFilters, filter)
-
-			if len(perRouteConfigRequiredMethods) > 0 {
-				if err := AddPerRouteConfigGenToMethods(perRouteConfigRequiredMethods, filterGenerator); err != nil {
-					return nil, err
-				}
-			}
+		if filter == nil {
+			glog.Infof("No filter config generated for %q, potentially because it only has per-route configs.", filterGenerator.FilterName())
+			continue
 		}
+
+		jsonStr, err := util.ProtoToJson(filter)
+		if err != nil {
+			return nil, fmt.Errorf("fail to convert proto to JSON for filter %q: %v", filterGenerator.FilterName(), err)
+		}
+
+		glog.Infof("adding filter config of %q : %v", filterGenerator.FilterName(), jsonStr)
+		httpFilters = append(httpFilters, filter)
 	}
 	return httpFilters, nil
 }
@@ -94,7 +87,7 @@ func MakeListener(serviceInfo *sc.ServiceInfo, filterGenerators []FilterGenerato
 		return nil, err
 	}
 
-	route, err := makeRouteConfig(serviceInfo)
+	route, err := makeRouteConfig(serviceInfo, filterGenerators)
 	if err != nil {
 		return nil, fmt.Errorf("makeHttpConnectionManagerRouteConfig got err: %s", err)
 	}

--- a/src/go/configgenerator/listener_generator.go
+++ b/src/go/configgenerator/listener_generator.go
@@ -49,10 +49,8 @@ func MakeListeners(serviceInfo *sc.ServiceInfo) ([]*listenerpb.Listener, error) 
 	return []*listenerpb.Listener{listener}, nil
 }
 
-// GetFilterConfigAndAddPerRouteConfigGen does two things
-//   - Return all http filter configs in a list
-//   - In place add the perRouteConfigGen function to all methods defined in serviceInfo
-func GetFilterConfigAndAddPerRouteConfigGen(serviceInfo *sc.ServiceInfo, filterGenerators []FilterGenerator) ([]*hcmpb.HttpFilter, error) {
+// MakeHttpFilterConfigs generates all enabled HTTP filter configs and returns them (ordered list).
+func MakeHttpFilterConfigs(serviceInfo *sc.ServiceInfo, filterGenerators []FilterGenerator) ([]*hcmpb.HttpFilter, error) {
 	var httpFilters []*hcmpb.HttpFilter
 
 	for _, filterGenerator := range filterGenerators {
@@ -82,7 +80,7 @@ func GetFilterConfigAndAddPerRouteConfigGen(serviceInfo *sc.ServiceInfo, filterG
 
 // MakeListener provides a dynamic listener for Envoy
 func MakeListener(serviceInfo *sc.ServiceInfo, filterGenerators []FilterGenerator, localReplyConfig *hcmpb.LocalReplyConfig) (*listenerpb.Listener, error) {
-	httpFilters, err := GetFilterConfigAndAddPerRouteConfigGen(serviceInfo, filterGenerators)
+	httpFilters, err := MakeHttpFilterConfigs(serviceInfo, filterGenerators)
 	if err != nil {
 		return nil, err
 	}

--- a/src/go/configgenerator/route_generator_test.go
+++ b/src/go/configgenerator/route_generator_test.go
@@ -2633,7 +2633,7 @@ func TestMakeRouteConfig(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			gotRoute, err := makeRouteConfig(fakeServiceInfo)
+			gotRoute, err := makeRouteConfig(fakeServiceInfo, nil)
 			if tc.wantedError != "" {
 				if err == nil || !strings.Contains(err.Error(), tc.wantedError) {
 					t.Fatalf("expected err: %v, got: %v", tc.wantedError, err)
@@ -3083,7 +3083,7 @@ func TestMakeRouteForBothGrpcAndHttpRoute_WithHttpBackend(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			gotRoute, err := makeRouteConfig(fakeServiceInfo)
+			gotRoute, err := makeRouteConfig(fakeServiceInfo, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -4442,7 +4442,7 @@ func TestMakeFallbackRoute(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			gotRoute, err := makeRouteConfig(fakeServiceInfo)
+			gotRoute, err := makeRouteConfig(fakeServiceInfo, nil)
 			if err != nil {
 				t.Fatalf("got error: %v", err)
 			}
@@ -4570,7 +4570,7 @@ func TestMakeRouteConfigForCors(t *testing.T) {
 		gotRoute, err := makeRouteConfig(&configinfo.ServiceInfo{
 			Name:    "test-api",
 			Options: opts,
-		})
+		}, nil)
 		if tc.wantedError != "" {
 			if err == nil || !strings.Contains(err.Error(), tc.wantedError) {
 				t.Errorf("Test (%s): expected err: %v, got: %v", tc.desc, tc.wantedError, err)
@@ -4714,7 +4714,7 @@ func TestHeadersToAdd(t *testing.T) {
 		gotRoute, err := makeRouteConfig(&configinfo.ServiceInfo{
 			Name:    "test-api",
 			Options: opts,
-		})
+		}, nil)
 		if tc.wantedError != "" {
 			if err == nil || !strings.Contains(err.Error(), tc.wantedError) {
 				t.Errorf("Test (%s): expected err: %v, got: %v", tc.desc, tc.wantedError, err)

--- a/src/go/configinfo/method_info.go
+++ b/src/go/configinfo/method_info.go
@@ -21,7 +21,6 @@ import (
 
 	scpb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/v11/http/service_control"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
-	anypb "github.com/golang/protobuf/ptypes/any"
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
 )
 
@@ -53,11 +52,6 @@ type MethodInfo struct {
 	// The auto-generated cors methods, used to replace snakeName with jsonName in their
 	// url templates in config time.
 	GeneratedCorsMethod *MethodInfo
-
-	// The PerRouteConfig generator.
-	// It should be added during making filters if the filter has the PerRouteConfig
-	// for the methods.
-	PerRouteConfigGens []*PerRouteConfigGenerator
 }
 
 // backendInfo stores information from Backend rule for backend rerouting.
@@ -100,10 +94,3 @@ func (m *MethodInfo) IsGRPCPath(path string) bool {
 func IsDiscoveryAPI(operationName string) bool {
 	return strings.HasPrefix(operationName, discoveryAPIPrefix)
 }
-
-type PerRouteConfigGenerator struct {
-	FilterName string
-	PerRouteConfigGenFunc
-}
-
-type PerRouteConfigGenFunc func(method *MethodInfo, httpRule *httppattern.Pattern) (*anypb.Any, error)

--- a/src/go/configinfo/service_info.go
+++ b/src/go/configinfo/service_info.go
@@ -57,23 +57,28 @@ type ServiceInfo struct {
 	// Stores all the query parameters to be ignored for json-grpc transcoder.
 	AllTranscodingIgnoredQueryParams map[string]bool
 
-	AllowCors         bool
+	AllowCors bool
+	// TODO(nareddyt): Fix immutability, this var is updated by consumers
 	ServiceControlURI string
-	GcpAttributes     *scpb.GcpAttributes
+	// TODO(nareddyt): Fix immutability, this var is updated by consumers
+	GcpAttributes *scpb.GcpAttributes
 	// Keep a pointer to original service config. Should always process rules
 	// inside ServiceInfo.
 	serviceConfig *confpb.Service
 	AccessToken   *commonpb.AccessToken
-	Options       options.ConfigGeneratorOptions
+	// TODO(nareddyt): Fix immutability, this var is updated by consumers
+	Options options.ConfigGeneratorOptions
 
 	// Stores information about all backend clusters.
-	GrpcSupportRequired     bool
-	LocalBackendCluster     *BackendRoutingCluster
+	GrpcSupportRequired bool
+	LocalBackendCluster *BackendRoutingCluster
+	// TODO(nareddyt): Fix immutability, this var is updated by consumers
 	LocalHTTPBackendCluster *BackendRoutingCluster
 	RemoteBackendClusters   []*BackendRoutingCluster
 }
 
 type BackendRoutingCluster struct {
+	// TODO(nareddyt): Fix immutability, this var is updated by consumers
 	ClusterName string
 	Hostname    string
 	Port        uint32


### PR DESCRIPTION
- Remove `PerRouteConfigGenerator` from `MethodInfo`. We should not be mutating the configinfo inputs during filter generation. Instead, each filter generator's `GenPerRouteConfig()` is called on all routes, and the filter decides if the route needs a config generated for it.
- Move the enablement of filters to each filter generator and remove all business logic from `MakeFilterGenerators()`. This allows us to re-use the filter generators internally, or add new filter generators in the future.

Testing done: All unit tests pass with no change to configs.