### PR TITLE
improve parsing and handling of ServiceControlUrl

### DIFF
--- a/examples/grpc_dynamic_routing/envoy_config.json
+++ b/examples/grpc_dynamic_routing/envoy_config.json
@@ -347,7 +347,7 @@
                         "serviceControlUri": {
                           "cluster": "service-control-cluster",
                           "timeout": "30s",
-                          "uri": "https://servicecontrol.googleapis.com/v1/services"
+                          "uri": "https://servicecontrol.googleapis.com:443/v1/services"
                         },
                         "services": [
                           {

--- a/examples/service_control/envoy_config.json
+++ b/examples/service_control/envoy_config.json
@@ -164,7 +164,7 @@
                         "serviceControlUri": {
                           "cluster": "service-control-cluster",
                           "timeout": "30s",
-                          "uri": "https://servicecontrol.googleapis.com/v1/services"
+                          "uri": "https://servicecontrol.googleapis.com:443/v1/services"
                         },
                         "services": [
                           {

--- a/src/go/configgenerator/filtergen/service_control.go
+++ b/src/go/configgenerator/filtergen/service_control.go
@@ -121,7 +121,7 @@ func (g *ServiceControlGenerator) GenFilterConfig(serviceInfo *ci.ServiceInfo) (
 		Services:        []*scpb.Service{service},
 		ScCallingConfig: makeServiceControlCallingConfig(serviceInfo.Options),
 		ServiceControlUri: &commonpb.HttpUri{
-			Uri:     serviceInfo.ServiceControlURI,
+			Uri:     serviceInfo.ServiceControlURI.String() + "/v1/services",
 			Cluster: util.ServiceControlClusterName,
 			Timeout: ptypes.DurationProto(serviceInfo.Options.HttpRequestTimeout),
 		},

--- a/src/go/configmanager/testdata/test_fetch_listeners.go
+++ b/src/go/configmanager/testdata/test_fetch_listeners.go
@@ -1621,7 +1621,7 @@ var (
                   "serviceControlUri": {
                     "cluster": "service-control-cluster",
                     "timeout": "30s",
-                    "uri": "https://servicecontrol.googleapis.com/v1/services"
+                    "uri": "https://servicecontrol.googleapis.com:443/v1/services"
                   },
                   "services": [
                     {
@@ -2489,7 +2489,7 @@ var (
                   "serviceControlUri": {
                     "cluster": "service-control-cluster",
                     "timeout": "30s",
-                    "uri": "https://servicecontrol.googleapis.com/v1/services"
+                    "uri": "https://servicecontrol.googleapis.com:443/v1/services"
                   },
                   "services": [
                     {

--- a/src/go/util/url_util.go
+++ b/src/go/util/url_util.go
@@ -75,6 +75,31 @@ func ParseURI(uri string) (string, string, uint32, string, error) {
 	return u.Scheme, u.Hostname(), uint32(portVal), pathNoTrailingSlash, nil
 }
 
+// ParseURIIntoURL is the same as ParseURI, but it returns the URL in a
+// standard struct.
+func ParseURIIntoURL(uri string) (url.URL, error) {
+	scheme, hostname, port, path, err := ParseURI(uri)
+	if err != nil {
+		return url.URL{}, err
+	}
+
+	host := fmt.Sprintf("%v:%v", hostname, port)
+	if isIpv6Hostname(hostname) {
+		// IPv6 hostname should be embraced by brackets
+		host = fmt.Sprintf("[%v]:%d", hostname, port)
+	}
+
+	return url.URL{
+		Scheme: scheme,
+		Host:   host,
+		Path:   path,
+	}, nil
+}
+
+func isIpv6Hostname(hostname string) bool {
+	return strings.Contains(hostname, ":")
+}
+
 // ParseBackendProtocol parses a scheme string and http protocol string into BackendProtocol and UseTLS bool.
 func ParseBackendProtocol(scheme string, httpProtocol string) (BackendProtocol, bool, error) {
 	scheme = strings.ToLower(scheme)


### PR DESCRIPTION
Changes from google3 cl/518452758:

- Support parsing IPv6 addresses.
- Remove use of global variable: ServiceControlUrl should be parsed in `ServiceInfo`, not `cluster_generator`.