### PR TITLE
Add back in HTTP method override in service control filter

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -12,8 +12,8 @@ When making changes to the config proto files, make sure:
 * No breaking changes, the changes should be backward compatible,
 * If a breaking change is required, increase config version.
 
-When making changes to Config Manager, make sure the new config is compatible
-with older Envoy binaries under the current API version. If it's incompatible,
+When making changes to Config Manager, make sure that **older** config generator binaries are compatible
+with **newer** Envoy binaries under the current API version. If it's incompatible,
 increase the config version.
 
 ## Steps to increase config version

--- a/src/envoy/http/service_control/filter.cc
+++ b/src/envoy/http/service_control/filter.cc
@@ -53,6 +53,14 @@ Envoy::Http::FilterHeadersStatus ServiceControlFilter::decodeHeaders(
     return Envoy::Http::FilterHeadersStatus::StopIteration;
   }
 
+  // TODO(b/273531500): Temporary until CAG rollout is complete.
+  if (utils::handleHttpMethodOverride(headers)) {
+    // Update later filters that the HTTP method has changed by clearing the
+    // route cache.
+    ENVOY_LOG(debug, "HTTP method override occurred, recalculating route");
+    decoder_callbacks_->downstreamCallbacks()->clearRouteCache();
+  }
+
   // Make sure route is calculated
   auto route = decoder_callbacks_->route();
 


### PR DESCRIPTION
Removed by https://github.com/GoogleCloudPlatform/esp-v2/pull/801, adding back in the change to service control filter.

This is NOT used by ESPv2, but it is needed for CAG temporarily. We can remove once their rollout is complete.