### PR TITLE
Revert: Add back in HTTP method override in service control filter (#802)

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -8,15 +8,37 @@ The folder names under `api/` contain version, e.g. `api/envoy/v11/http/backend_
 The proto package names contain version too, e.g. `espv2.api.envoy.v11.http.common.Pattern`.
 
 ## Versioning Rules:
+
+Cloud API Gateway may run:
+
+* An older Envoy binary with a newer Config Generator
+* A newer Envoy binary with an older Config Generator
+
 When making changes to the config proto files, make sure:
+
 * No breaking changes, the changes should be backward compatible,
 * If a breaking change is required, increase config version.
 
-When making changes to Config Manager, make sure the new config is compatible
-with older Envoy binaries under the current API version. If it's incompatible,
-increase the config version.
+Examples of breaking changes:
+
+* Adding a new filter config to Config Generator: Old Envoys with new config
+  will fail to parse the filter config proto type URL.
+
+Examples of potential breaking changes:
+
+* Removing a field: Older configs may last for years in CAG, leading to
+  functionality breaking when new Envoys rollout, as they ignore the old field.
+* Adding a new CLI flag to GCSRunner: This is baked into the data plane and may
+  change functionality when older configs are used.
+
+Examples of non-breaking changes:
+
+* Adding a new field to pre-existing filter: Old Envoys with new config will
+  ignore the new field, and the new feature won't be enabled. New Envoys with
+  old config will also have the feature disabled.
 
 ## Steps to increase config version
+
 If a breaking change is required, use following steps to increase config version.
 * Increase `api/VERSION` to a newer version, e.g. from `v6` to `v7`.
 * Rename folder name from `api/envoy/v6/http` to `api/envoy/v11/http`.

--- a/api/README.md
+++ b/api/README.md
@@ -12,8 +12,8 @@ When making changes to the config proto files, make sure:
 * No breaking changes, the changes should be backward compatible,
 * If a breaking change is required, increase config version.
 
-When making changes to Config Manager, make sure that **older** config generator binaries are compatible
-with **newer** Envoy binaries under the current API version. If it's incompatible,
+When making changes to Config Manager, make sure the new config is compatible
+with older Envoy binaries under the current API version. If it's incompatible,
 increase the config version.
 
 ## Steps to increase config version

--- a/src/envoy/http/service_control/filter.cc
+++ b/src/envoy/http/service_control/filter.cc
@@ -53,14 +53,6 @@ Envoy::Http::FilterHeadersStatus ServiceControlFilter::decodeHeaders(
     return Envoy::Http::FilterHeadersStatus::StopIteration;
   }
 
-  // TODO(b/273531500): Temporary until CAG rollout is complete.
-  if (utils::handleHttpMethodOverride(headers)) {
-    // Update later filters that the HTTP method has changed by clearing the
-    // route cache.
-    ENVOY_LOG(debug, "HTTP method override occurred, recalculating route");
-    decoder_callbacks_->downstreamCallbacks()->clearRouteCache();
-  }
-
   // Make sure route is calculated
   auto route = decoder_callbacks_->route();
 


### PR DESCRIPTION
Reverts #802. No need since we will build new API version `v12`.

Also document examples of breaking changes.