### PR TITLE
Change `GenFilterConfig()` to return `proto.Message` instead of `Any`

### DIFF
--- a/src/go/configgenerator/filter_generator.go
+++ b/src/go/configgenerator/filter_generator.go
@@ -18,7 +18,7 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/configgenerator/filtergen"
 	ci "github.com/GoogleCloudPlatform/esp-v2/src/go/configinfo"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
-	"google.golang.org/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 )
 
 // FilterGenerator is an interface for objects that generate Envoy filters.

--- a/src/go/configgenerator/filter_generator.go
+++ b/src/go/configgenerator/filter_generator.go
@@ -18,8 +18,7 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/configgenerator/filtergen"
 	ci "github.com/GoogleCloudPlatform/esp-v2/src/go/configinfo"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
-	hcmpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
-	anypb "github.com/golang/protobuf/ptypes/any"
+	"google.golang.org/protobuf/proto"
 )
 
 // FilterGenerator is an interface for objects that generate Envoy filters.
@@ -34,16 +33,20 @@ type FilterGenerator interface {
 
 	// GenFilterConfig generates the filter config.
 	//
+	// Return type is the filter's config proto.
+	//
 	// Return (nil, nil) if the filter has no listener-level config, but may
 	// have per-route configurations.
-	GenFilterConfig(*ci.ServiceInfo) (*hcmpb.HttpFilter, error)
+	GenFilterConfig(*ci.ServiceInfo) (proto.Message, error)
 
 	// GenPerRouteConfig generates the per-route config for the given HTTP route (HTTP pattern).
 	// The MethodInfo that contains the route is also provided.
 	//
+	// Return type is the filter's per-route config proto.
+	//
 	// This method is called on all routes. Return (nil, nil) to indicate the
 	// filter does NOT require a per-route config for the given route.
-	GenPerRouteConfig(*ci.MethodInfo, *httppattern.Pattern) (*anypb.Any, error)
+	GenPerRouteConfig(*ci.MethodInfo, *httppattern.Pattern) (proto.Message, error)
 }
 
 // MakeFilterGenerators provide of a slice of FilterGenerator in sequence.

--- a/src/go/configgenerator/filtergen/backend_auth.go
+++ b/src/go/configgenerator/filtergen/backend_auth.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
-	"google.golang.org/protobuf/proto"
 
 	ci "github.com/GoogleCloudPlatform/esp-v2/src/go/configinfo"
 	bapb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/v11/http/backend_auth"

--- a/src/go/configgenerator/filtergen/backend_auth_test.go
+++ b/src/go/configgenerator/filtergen/backend_auth_test.go
@@ -289,8 +289,13 @@ func TestBackendAuthFilter(t *testing.T) {
 				return
 			}
 
+			httpFilter, err := FilterConfigToHTTPFilter(filterConfig, gen.FilterName())
+			if err != nil {
+				t.Fatalf("Fail to convert filter config to HTTP filter: %v", err)
+			}
+
 			marshaler := &jsonpb.Marshaler{}
-			gotFilter, err := marshaler.MarshalToString(filterConfig)
+			gotFilter, err := marshaler.MarshalToString(httpFilter)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/src/go/configgenerator/filtergen/compressor.go
+++ b/src/go/configgenerator/filtergen/compressor.go
@@ -18,16 +18,13 @@ import (
 	"fmt"
 
 	ci "github.com/GoogleCloudPlatform/esp-v2/src/go/configinfo"
-	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
 	corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	brpb "github.com/envoyproxy/go-control-plane/envoy/extensions/compression/brotli/compressor/v3"
 	gzippb "github.com/envoyproxy/go-control-plane/envoy/extensions/compression/gzip/compressor/v3"
 	comppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/compressor/v3"
-	hcmpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
-	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
-	anypb "github.com/golang/protobuf/ptypes/any"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 type CompressorType int
@@ -35,6 +32,17 @@ type CompressorType int
 const (
 	GzipCompressor CompressorType = iota
 	BrotliCompressor
+)
+
+const (
+	// EnvoyCompressorFilterName is the Envoy filter name for debug logging.
+	EnvoyCompressorFilterName = "envoy.filters.http.compressor"
+
+	// EnvoyBrotliCompressorName is a compressor extension name.
+	EnvoyBrotliCompressorName = "envoy.compression.brotli.compressor"
+
+	// EnvoyGzipCompressorName is a compressor extension name.
+	EnvoyGzipCompressorName = "envoy.compression.gzip.compressor"
 )
 
 type CompressorGenerator struct {
@@ -53,56 +61,40 @@ func NewCompressorGenerator(serviceInfo *ci.ServiceInfo, compressorType Compress
 }
 
 func (g *CompressorGenerator) FilterName() string {
-	switch g.compressorType {
-	case GzipCompressor:
-		return util.EnvoyGzipCompressor
-	case BrotliCompressor:
-		return util.EnvoyBrotliCompressor
-	}
-	return ""
+	return EnvoyCompressorFilterName
 }
 
 func (g *CompressorGenerator) IsEnabled() bool {
 	return !g.skipFilter
 }
 
-func (g *CompressorGenerator) GenFilterConfig(serviceInfo *ci.ServiceInfo) (*hcmpb.HttpFilter, error) {
+func (g *CompressorGenerator) GenFilterConfig(serviceInfo *ci.ServiceInfo) (proto.Message, error) {
 	cfg, name, err := g.getCompressorConfig()
 	if err != nil {
 		return nil, err
 	}
-	ca, err := ptypes.MarshalAny(cfg)
+	ca, err := anypb.New(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling %s Compressor config to Any: %v", name, err)
 	}
-	cmp := &comppb.Compressor{
+	return &comppb.Compressor{
 		CompressorLibrary: &corepb.TypedExtensionConfig{
 			Name:        name,
 			TypedConfig: ca,
 		},
-	}
-	a, err := ptypes.MarshalAny(cmp)
-	if err != nil {
-		return nil, fmt.Errorf("error marshaling Compressor filter config to Any: %v", err)
-	}
-	return &hcmpb.HttpFilter{
-		Name: util.EnvoyCompressorFilter,
-		ConfigType: &hcmpb.HttpFilter_TypedConfig{
-			TypedConfig: a,
-		},
 	}, nil
 }
 
-func (g *CompressorGenerator) GenPerRouteConfig(method *ci.MethodInfo, httpRule *httppattern.Pattern) (*anypb.Any, error) {
+func (g *CompressorGenerator) GenPerRouteConfig(method *ci.MethodInfo, httpRule *httppattern.Pattern) (proto.Message, error) {
 	return nil, nil
 }
 
 func (g *CompressorGenerator) getCompressorConfig() (proto.Message, string, error) {
 	switch g.compressorType {
 	case GzipCompressor:
-		return &gzippb.Gzip{}, util.EnvoyGzipCompressor, nil
+		return &gzippb.Gzip{}, EnvoyBrotliCompressorName, nil
 	case BrotliCompressor:
-		return &brpb.Brotli{}, util.EnvoyBrotliCompressor, nil
+		return &brpb.Brotli{}, EnvoyGzipCompressorName, nil
 	}
 	return nil, "", fmt.Errorf("unknown compressor type: %v", g.compressorType)
 }

--- a/src/go/configgenerator/filtergen/compressor.go
+++ b/src/go/configgenerator/filtergen/compressor.go
@@ -23,8 +23,8 @@ import (
 	brpb "github.com/envoyproxy/go-control-plane/envoy/extensions/compression/brotli/compressor/v3"
 	gzippb "github.com/envoyproxy/go-control-plane/envoy/extensions/compression/gzip/compressor/v3"
 	comppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/compressor/v3"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/anypb"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
 )
 
 type CompressorType int
@@ -73,7 +73,7 @@ func (g *CompressorGenerator) GenFilterConfig(serviceInfo *ci.ServiceInfo) (prot
 	if err != nil {
 		return nil, err
 	}
-	ca, err := anypb.New(cfg)
+	ca, err := ptypes.MarshalAny(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling %s Compressor config to Any: %v", name, err)
 	}
@@ -92,9 +92,9 @@ func (g *CompressorGenerator) GenPerRouteConfig(method *ci.MethodInfo, httpRule 
 func (g *CompressorGenerator) getCompressorConfig() (proto.Message, string, error) {
 	switch g.compressorType {
 	case GzipCompressor:
-		return &gzippb.Gzip{}, EnvoyBrotliCompressorName, nil
+		return &gzippb.Gzip{}, EnvoyGzipCompressorName, nil
 	case BrotliCompressor:
-		return &brpb.Brotli{}, EnvoyGzipCompressorName, nil
+		return &brpb.Brotli{}, EnvoyBrotliCompressorName, nil
 	}
 	return nil, "", fmt.Errorf("unknown compressor type: %v", g.compressorType)
 }

--- a/src/go/configgenerator/filtergen/cors.go
+++ b/src/go/configgenerator/filtergen/cors.go
@@ -16,12 +16,14 @@ package filtergen
 
 import (
 	ci "github.com/GoogleCloudPlatform/esp-v2/src/go/configinfo"
-	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
 	corspb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/cors/v3"
-	hcmpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
-	"github.com/golang/protobuf/ptypes"
-	anypb "github.com/golang/protobuf/ptypes/any"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	// CORSFilterName is the Envoy filter name for debug logging.
+	CORSFilterName = "envoy.filters.http.cors"
 )
 
 type CORSGenerator struct {
@@ -37,25 +39,17 @@ func NewCORSGenerator(serviceInfo *ci.ServiceInfo) *CORSGenerator {
 }
 
 func (g *CORSGenerator) FilterName() string {
-	return util.CORS
+	return CORSFilterName
 }
 
 func (g *CORSGenerator) IsEnabled() bool {
 	return !g.skipFilter
 }
 
-func (g *CORSGenerator) GenFilterConfig(serviceInfo *ci.ServiceInfo) (*hcmpb.HttpFilter, error) {
-	a, err := ptypes.MarshalAny(&corspb.Cors{})
-	if err != nil {
-		return nil, err
-	}
-	corsFilter := &hcmpb.HttpFilter{
-		Name:       util.CORS,
-		ConfigType: &hcmpb.HttpFilter_TypedConfig{TypedConfig: a},
-	}
-	return corsFilter, nil
+func (g *CORSGenerator) GenFilterConfig(serviceInfo *ci.ServiceInfo) (proto.Message, error) {
+	return &corspb.Cors{}, nil
 }
 
-func (g *CORSGenerator) GenPerRouteConfig(method *ci.MethodInfo, httpRule *httppattern.Pattern) (*anypb.Any, error) {
+func (g *CORSGenerator) GenPerRouteConfig(method *ci.MethodInfo, httpRule *httppattern.Pattern) (proto.Message, error) {
 	return nil, nil
 }

--- a/src/go/configgenerator/filtergen/cors.go
+++ b/src/go/configgenerator/filtergen/cors.go
@@ -18,7 +18,7 @@ import (
 	ci "github.com/GoogleCloudPlatform/esp-v2/src/go/configinfo"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
 	corspb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/cors/v3"
-	"google.golang.org/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 )
 
 const (

--- a/src/go/configgenerator/filtergen/grpc_metadata_scrubber.go
+++ b/src/go/configgenerator/filtergen/grpc_metadata_scrubber.go
@@ -18,7 +18,7 @@ import (
 	ci "github.com/GoogleCloudPlatform/esp-v2/src/go/configinfo"
 	gmspb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/v11/http/grpc_metadata_scrubber"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
-	"google.golang.org/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 )
 
 const (

--- a/src/go/configgenerator/filtergen/grpc_metadata_scrubber.go
+++ b/src/go/configgenerator/filtergen/grpc_metadata_scrubber.go
@@ -17,11 +17,13 @@ package filtergen
 import (
 	ci "github.com/GoogleCloudPlatform/esp-v2/src/go/configinfo"
 	gmspb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/v11/http/grpc_metadata_scrubber"
-	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
-	hcmpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
-	"github.com/golang/protobuf/ptypes"
-	anypb "github.com/golang/protobuf/ptypes/any"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	// GrpcMetadataScrubberFilterName is the Envoy filter name for debug logging.
+	GrpcMetadataScrubberFilterName = "com.google.espv2.filters.http.grpc_metadata_scrubber"
 )
 
 type GRPCMetadataScrubberGenerator struct {
@@ -37,24 +39,17 @@ func NewGRPCMetadataScrubberGenerator(serviceInfo *ci.ServiceInfo) *GRPCMetadata
 }
 
 func (g *GRPCMetadataScrubberGenerator) FilterName() string {
-	return util.GrpcMetadataScrubber
+	return GrpcMetadataScrubberFilterName
 }
 
 func (g *GRPCMetadataScrubberGenerator) IsEnabled() bool {
 	return !g.skipFilter
 }
 
-func (g *GRPCMetadataScrubberGenerator) GenFilterConfig(serviceInfo *ci.ServiceInfo) (*hcmpb.HttpFilter, error) {
-	a, err := ptypes.MarshalAny(&gmspb.FilterConfig{})
-	if err != nil {
-		return nil, err
-	}
-	return &hcmpb.HttpFilter{
-		Name:       util.GrpcMetadataScrubber,
-		ConfigType: &hcmpb.HttpFilter_TypedConfig{TypedConfig: a},
-	}, nil
+func (g *GRPCMetadataScrubberGenerator) GenFilterConfig(serviceInfo *ci.ServiceInfo) (proto.Message, error) {
+	return &gmspb.FilterConfig{}, nil
 }
 
-func (g *GRPCMetadataScrubberGenerator) GenPerRouteConfig(method *ci.MethodInfo, httpRule *httppattern.Pattern) (*anypb.Any, error) {
+func (g *GRPCMetadataScrubberGenerator) GenPerRouteConfig(method *ci.MethodInfo, httpRule *httppattern.Pattern) (proto.Message, error) {
 	return nil, nil
 }

--- a/src/go/configgenerator/filtergen/grpc_transcoder_test.go
+++ b/src/go/configgenerator/filtergen/grpc_transcoder_test.go
@@ -25,12 +25,13 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	"github.com/GoogleCloudPlatform/esp-v2/tests/utils"
 	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
 	ahpb "google.golang.org/genproto/googleapis/api/annotations"
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
 	smpb "google.golang.org/genproto/googleapis/api/servicemanagement/v1"
 	apipb "google.golang.org/genproto/protobuf/api"
 	"google.golang.org/protobuf/encoding/prototext"
-	"google.golang.org/protobuf/proto"
 	descpb "google.golang.org/protobuf/types/descriptorpb"
 	"google.golang.org/protobuf/types/known/anypb"
 )
@@ -47,7 +48,7 @@ func TestTranscoderFilter(t *testing.T) {
 		FileContents: rawDescriptor,
 		FileType:     smpb.ConfigFile_FILE_DESCRIPTOR_SET_PROTO,
 	}
-	content, err := anypb.New(sourceFile)
+	content, err := ptypes.MarshalAny(sourceFile)
 	if err != nil {
 		t.Fatalf("Failed to marshal source file into any: %v", err)
 	}
@@ -335,8 +336,13 @@ func TestTranscoderFilter(t *testing.T) {
 				t.Fatal("Got empty filter config.")
 			}
 
+			httpFilter, err := FilterConfigToHTTPFilter(filterConfig, gen.FilterName())
+			if err != nil {
+				t.Fatalf("Fail to convert filter config to HTTP filter: %v", err)
+			}
+
 			marshaler := &jsonpb.Marshaler{}
-			gotFilter, err := marshaler.MarshalToString(filterConfig)
+			gotFilter, err := marshaler.MarshalToString(httpFilter)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -359,7 +365,7 @@ func TestTranscoderFilter_Disabled(t *testing.T) {
 		FileContents: rawDescriptor,
 		FileType:     smpb.ConfigFile_FILE_DESCRIPTOR_SET_PROTO,
 	}
-	content, err := anypb.New(sourceFile)
+	content, err := ptypes.MarshalAny(sourceFile)
 	if err != nil {
 		t.Fatalf("Failed to marshal source file into any: %v", err)
 	}

--- a/src/go/configgenerator/filtergen/grpc_web.go
+++ b/src/go/configgenerator/filtergen/grpc_web.go
@@ -18,7 +18,7 @@ import (
 	ci "github.com/GoogleCloudPlatform/esp-v2/src/go/configinfo"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
 	grpcwebpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/grpc_web/v3"
-	"google.golang.org/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 )
 
 const (

--- a/src/go/configgenerator/filtergen/grpc_web.go
+++ b/src/go/configgenerator/filtergen/grpc_web.go
@@ -16,12 +16,14 @@ package filtergen
 
 import (
 	ci "github.com/GoogleCloudPlatform/esp-v2/src/go/configinfo"
-	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
 	grpcwebpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/grpc_web/v3"
-	hcmpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
-	"github.com/golang/protobuf/ptypes"
-	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	// GRPCWebFilterName is the Envoy filter name for debug logging.
+	GRPCWebFilterName = "envoy.filters.http.grpc_web"
 )
 
 type GRPCWebGenerator struct {
@@ -37,24 +39,17 @@ func NewGRPCWebGenerator(serviceInfo *ci.ServiceInfo) *GRPCWebGenerator {
 }
 
 func (g *GRPCWebGenerator) FilterName() string {
-	return util.GRPCWeb
+	return GRPCWebFilterName
 }
 
 func (g *GRPCWebGenerator) IsEnabled() bool {
 	return !g.skipFilter
 }
 
-func (g *GRPCWebGenerator) GenFilterConfig(serviceInfo *ci.ServiceInfo) (*hcmpb.HttpFilter, error) {
-	a, err := ptypes.MarshalAny(&grpcwebpb.GrpcWeb{})
-	if err != nil {
-		return nil, err
-	}
-	return &hcmpb.HttpFilter{
-		Name:       util.GRPCWeb,
-		ConfigType: &hcmpb.HttpFilter_TypedConfig{TypedConfig: a},
-	}, nil
+func (g *GRPCWebGenerator) GenFilterConfig(serviceInfo *ci.ServiceInfo) (proto.Message, error) {
+	return &grpcwebpb.GrpcWeb{}, nil
 }
 
-func (g *GRPCWebGenerator) GenPerRouteConfig(method *ci.MethodInfo, httpRule *httppattern.Pattern) (*anypb.Any, error) {
+func (g *GRPCWebGenerator) GenPerRouteConfig(method *ci.MethodInfo, httpRule *httppattern.Pattern) (proto.Message, error) {
 	return nil, nil
 }

--- a/src/go/configgenerator/filtergen/header_sanitizer.go
+++ b/src/go/configgenerator/filtergen/header_sanitizer.go
@@ -17,34 +17,29 @@ package filtergen
 import (
 	ci "github.com/GoogleCloudPlatform/esp-v2/src/go/configinfo"
 	hspb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/v11/http/header_sanitizer"
-	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
-	hcmpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
-	"github.com/golang/protobuf/ptypes"
-	anypb "github.com/golang/protobuf/ptypes/any"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	// HeaderSanitizerFilterName is the Envoy filter name for debug logging.
+	HeaderSanitizerFilterName = "com.google.espv2.filters.http.header_sanitizer"
 )
 
 type HeaderSanitizerGenerator struct{}
 
 func (g *HeaderSanitizerGenerator) FilterName() string {
-	return util.HeaderSanitizerScrubber
+	return HeaderSanitizerFilterName
 }
 
 func (g *HeaderSanitizerGenerator) IsEnabled() bool {
 	return true
 }
 
-func (g *HeaderSanitizerGenerator) GenFilterConfig(serviceInfo *ci.ServiceInfo) (*hcmpb.HttpFilter, error) {
-	a, err := ptypes.MarshalAny(&hspb.FilterConfig{})
-	if err != nil {
-		return nil, err
-	}
-	return &hcmpb.HttpFilter{
-		Name:       g.FilterName(),
-		ConfigType: &hcmpb.HttpFilter_TypedConfig{TypedConfig: a},
-	}, nil
+func (g *HeaderSanitizerGenerator) GenFilterConfig(serviceInfo *ci.ServiceInfo) (proto.Message, error) {
+	return &hspb.FilterConfig{}, nil
 }
 
-func (g *HeaderSanitizerGenerator) GenPerRouteConfig(method *ci.MethodInfo, httpRule *httppattern.Pattern) (*anypb.Any, error) {
+func (g *HeaderSanitizerGenerator) GenPerRouteConfig(method *ci.MethodInfo, httpRule *httppattern.Pattern) (proto.Message, error) {
 	return nil, nil
 }

--- a/src/go/configgenerator/filtergen/header_sanitizer.go
+++ b/src/go/configgenerator/filtergen/header_sanitizer.go
@@ -18,7 +18,7 @@ import (
 	ci "github.com/GoogleCloudPlatform/esp-v2/src/go/configinfo"
 	hspb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/v11/http/header_sanitizer"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
-	"google.golang.org/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 )
 
 const (

--- a/src/go/configgenerator/filtergen/health_check.go
+++ b/src/go/configgenerator/filtergen/health_check.go
@@ -21,8 +21,8 @@ import (
 	hcpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/health_check/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	envoytypepb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"github.com/golang/protobuf/proto"
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
-	"google.golang.org/protobuf/proto"
 )
 
 const (

--- a/src/go/configgenerator/filtergen/health_check_test.go
+++ b/src/go/configgenerator/filtergen/health_check_test.go
@@ -123,13 +123,18 @@ func TestHealthCheckFilter(t *testing.T) {
 				t.Fatal("HealthCheckGenerator is not enabled, want it to be enabled")
 			}
 
-			filter, err := gen.GenFilterConfig(fakeServiceInfo)
+			filterConfig, err := gen.GenFilterConfig(fakeServiceInfo)
 			if err != nil {
 				t.Fatal(err)
 			}
 
+			httpFilter, err := FilterConfigToHTTPFilter(filterConfig, gen.FilterName())
+			if err != nil {
+				t.Fatalf("Fail to convert filter config to HTTP filter: %v", err)
+			}
+
 			marshaler := &jsonpb.Marshaler{}
-			gotFilter, err := marshaler.MarshalToString(filter)
+			gotFilter, err := marshaler.MarshalToString(httpFilter)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/src/go/configgenerator/filtergen/jwt_authn.go
+++ b/src/go/configgenerator/filtergen/jwt_authn.go
@@ -21,9 +21,9 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
 	"github.com/golang/glog"
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
-	"google.golang.org/protobuf/proto"
 
 	ci "github.com/GoogleCloudPlatform/esp-v2/src/go/configinfo"
 

--- a/src/go/configgenerator/filtergen/jwt_authn_test.go
+++ b/src/go/configgenerator/filtergen/jwt_authn_test.go
@@ -657,13 +657,18 @@ func TestJwtAuthnFilter(t *testing.T) {
 				t.Fatal("JwtAuthnGenerator is not enabled, want it to be enabled")
 			}
 
-			gotProto, err := gen.GenFilterConfig(fakeServiceInfo)
+			filterConfig, err := gen.GenFilterConfig(fakeServiceInfo)
 			if err != nil {
 				t.Fatalf("GenFilterConfig got err %v, want no err", err)
 			}
 
+			httpFilter, err := FilterConfigToHTTPFilter(filterConfig, gen.FilterName())
+			if err != nil {
+				t.Fatalf("Fail to convert filter config to HTTP filter: %v", err)
+			}
+
 			marshaler := &jsonpb.Marshaler{}
-			gotFilter, err := marshaler.MarshalToString(gotProto)
+			gotFilter, err := marshaler.MarshalToString(httpFilter)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/src/go/configgenerator/filtergen/path_rewrite.go
+++ b/src/go/configgenerator/filtergen/path_rewrite.go
@@ -18,8 +18,8 @@ import (
 	ci "github.com/GoogleCloudPlatform/esp-v2/src/go/configinfo"
 	prpb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/v11/http/path_rewrite"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
+	"github.com/golang/protobuf/proto"
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
-	"google.golang.org/protobuf/proto"
 )
 
 const (

--- a/src/go/configgenerator/filtergen/router.go
+++ b/src/go/configgenerator/filtergen/router.go
@@ -18,7 +18,7 @@ import (
 	ci "github.com/GoogleCloudPlatform/esp-v2/src/go/configinfo"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
 	routerpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
-	"google.golang.org/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 )
 
 const (

--- a/src/go/configgenerator/filtergen/router.go
+++ b/src/go/configgenerator/filtergen/router.go
@@ -16,37 +16,33 @@ package filtergen
 
 import (
 	ci "github.com/GoogleCloudPlatform/esp-v2/src/go/configinfo"
-	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
 	routerpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
-	hcmpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
-	"github.com/golang/protobuf/ptypes"
-	anypb "github.com/golang/protobuf/ptypes/any"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	// RouterFilterName is the Envoy filter name for debug logging.
+	RouterFilterName = "envoy.filters.http.router"
 )
 
 type RouterGenerator struct{}
 
 func (g *RouterGenerator) FilterName() string {
-	return util.Router
+	return RouterFilterName
 }
 
 func (g *RouterGenerator) IsEnabled() bool {
 	return true
 }
 
-func (g *RouterGenerator) GenFilterConfig(serviceInfo *ci.ServiceInfo) (*hcmpb.HttpFilter, error) {
-	router, _ := ptypes.MarshalAny(&routerpb.Router{
+func (g *RouterGenerator) GenFilterConfig(serviceInfo *ci.ServiceInfo) (proto.Message, error) {
+	return &routerpb.Router{
 		SuppressEnvoyHeaders: serviceInfo.Options.SuppressEnvoyHeaders,
 		StartChildSpan:       !serviceInfo.Options.DisableTracing,
-	})
-
-	routerFilter := &hcmpb.HttpFilter{
-		Name:       util.Router,
-		ConfigType: &hcmpb.HttpFilter_TypedConfig{TypedConfig: router},
-	}
-	return routerFilter, nil
+	}, nil
 }
 
-func (g *RouterGenerator) GenPerRouteConfig(method *ci.MethodInfo, httpRule *httppattern.Pattern) (*anypb.Any, error) {
+func (g *RouterGenerator) GenPerRouteConfig(method *ci.MethodInfo, httpRule *httppattern.Pattern) (proto.Message, error) {
 	return nil, nil
 }

--- a/src/go/configgenerator/filtergen/service_control.go
+++ b/src/go/configgenerator/filtergen/service_control.go
@@ -24,10 +24,10 @@ import (
 	scpb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/v11/http/service_control"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
 	confpb "google.golang.org/genproto/googleapis/api/serviceconfig"
-	"google.golang.org/protobuf/proto"
 )
 
 const (

--- a/src/go/configgenerator/filtergen/util.go
+++ b/src/go/configgenerator/filtergen/util.go
@@ -19,6 +19,9 @@ import (
 	"sort"
 
 	commonpb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/v11/http/common"
+	hcmpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
 )
 
 func parseDepErrorBehavior(stringVal string) (commonpb.DependencyErrorBehavior, error) {
@@ -32,4 +35,17 @@ func parseDepErrorBehavior(stringVal string) (commonpb.DependencyErrorBehavior, 
 		return commonpb.DependencyErrorBehavior_UNSPECIFIED, fmt.Errorf("unknown value for DependencyErrorBehavior (%v), accepted values are: %+q", stringVal, keys)
 	}
 	return commonpb.DependencyErrorBehavior(depErrorBehaviorInt), nil
+}
+
+func FilterConfigToHTTPFilter(filter proto.Message, name string) (*hcmpb.HttpFilter, error) {
+	a, err := ptypes.MarshalAny(filter)
+	if err != nil {
+		return nil, fmt.Errorf("fail to marshal filter config to Any for filter %q: %v", name, err)
+	}
+	return &hcmpb.HttpFilter{
+		Name: name,
+		ConfigType: &hcmpb.HttpFilter_TypedConfig{
+			TypedConfig: a,
+		},
+	}, nil
 }

--- a/src/go/configgenerator/listener_generator_test.go
+++ b/src/go/configgenerator/listener_generator_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/options"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/ptypes"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -35,7 +36,7 @@ func TestMakeListeners(t *testing.T) {
 	configFile := &smpb.ConfigFile{
 		FileType: smpb.ConfigFile_FILE_DESCRIPTOR_SET_PROTO,
 	}
-	data, err := anypb.New(configFile)
+	data, err := ptypes.MarshalAny(configFile)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/go/configgenerator/route_generator.go
+++ b/src/go/configgenerator/route_generator.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/esp-v2/src/go/configgenerator/filtergen"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/configinfo"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
@@ -72,7 +73,7 @@ func makeRouteConfig(serviceInfo *configinfo.ServiceInfo, filterGenerators []Fil
 			return nil, fmt.Errorf("error marshaling CorsPolicy to Any: %v", err)
 		}
 		host.TypedPerFilterConfig = make(map[string]*anypb.Any)
-		host.TypedPerFilterConfig[util.CORS] = corsAny
+		host.TypedPerFilterConfig[filtergen.CORSFilterName] = corsAny
 
 		host.Routes = append(host.Routes, corsRoutes...)
 		for i, corsRoute := range corsRoutes {
@@ -325,7 +326,7 @@ func makePerRouteFilterConfig(method *configinfo.MethodInfo, httpRule *httppatte
 			continue
 		}
 
-		perRouteFilterConfig, err := anypb.New(config)
+		perRouteFilterConfig, err := ptypes.MarshalAny(config)
 		if err != nil {
 			return nil, fmt.Errorf("fail to marshal per-route config to Any for filter %q: %v", filterGen.FilterName(), err)
 		}

--- a/src/go/configgenerator/route_generator.go
+++ b/src/go/configgenerator/route_generator.go
@@ -30,8 +30,8 @@ import (
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
-	anypb "github.com/golang/protobuf/ptypes/any"
 	wrapperspb "github.com/golang/protobuf/ptypes/wrappers"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 const (
@@ -317,15 +317,18 @@ func makePerRouteFilterConfig(method *configinfo.MethodInfo, httpRule *httppatte
 			continue
 		}
 
-		perRouteFilterConfig, err := filterGen.GenPerRouteConfig(method, httpRule)
+		config, err := filterGen.GenPerRouteConfig(method, httpRule)
 		if err != nil {
 			return perFilterConfig, fmt.Errorf("failed to generate per-route config for filter %q: %v", filterGen.FilterName(), err)
 		}
-
-		if perRouteFilterConfig == nil {
+		if config == nil {
 			continue
 		}
 
+		perRouteFilterConfig, err := anypb.New(config)
+		if err != nil {
+			return nil, fmt.Errorf("fail to marshal per-route config to Any for filter %q: %v", filterGen.FilterName(), err)
+		}
 		perFilterConfig[filterGen.FilterName()] = perRouteFilterConfig
 	}
 

--- a/src/go/configgenerator/route_generator_test.go
+++ b/src/go/configgenerator/route_generator_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GoogleCloudPlatform/esp-v2/src/go/configgenerator/filtergen"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/configinfo"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/options"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
@@ -4598,7 +4599,7 @@ func TestMakeRouteConfigForCors(t *testing.T) {
 			t.Errorf("Test (%v): got expected number of virtual host", tc.desc)
 		}
 
-		corsAny, ok := gotHost[0].TypedPerFilterConfig[util.CORS]
+		corsAny, ok := gotHost[0].TypedPerFilterConfig[filtergen.CORSFilterName]
 		if tc.wantCorsPolicy == nil {
 			if ok {
 				t.Errorf("Test (%v): expect not CORS, but found one", tc.desc)

--- a/src/go/util/xds_name.go
+++ b/src/go/util/xds_name.go
@@ -17,49 +17,16 @@ package util
 import "fmt"
 
 const (
-	// Upstream envoy http filter names.
-
-	// Buffer HTTP filter
-	Buffer = "envoy.filters.http.buffer"
-	// CORS HTTP filter
-	CORS = "envoy.filters.http.cors"
-	// GRPCJSONTranscoder HTTP filter
-	GRPCJSONTranscoder = "envoy.filters.http.grpc_json_transcoder"
-	// GRPCWeb HTTP filter
-	GRPCWeb = "envoy.filters.http.grpc_web"
-	// Router HTTP filter
-	Router = "envoy.filters.http.router"
-	// Health checking HTTP filter
-	HealthCheck = "envoy.filters.http.health_check"
 	// Echo network filter
 	Echo = "envoy.filters.network.echo"
 	// HTTPConnectionManager network filter
 	HTTPConnectionManager = "envoy.filters.network.http_connection_manager"
-	// JwtAuthn filter.
-	JwtAuthn = "envoy.filters.http.jwt_authn"
 	// TLSTransportSocket is Envoy TLS Transport Socket name.
 	TLSTransportSocket = "envoy.transport_sockets.tls"
 	// AccessFileLogger filter name
 	AccessFileLogger = "envoy.access_loggers.file"
 	// Upstream protocol options
 	UpstreamProtocolOptions = "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
-	// Envoy compressor filter name
-	EnvoyCompressorFilter = "envoy.filters.http.compressor"
-	EnvoyBrotliCompressor = "envoy.compression.brotli.compressor"
-	EnvoyGzipCompressor   = "envoy.compression.gzip.compressor"
-
-	// ESPv2 custom http filters.
-
-	// ServiceControl filter.
-	ServiceControl = "com.google.espv2.filters.http.service_control"
-	// PathRewrite filter.
-	PathRewrite = "com.google.espv2.filters.http.path_rewrite"
-	// BackendAuth filter.
-	BackendAuth = "com.google.espv2.filters.http.backend_auth"
-	// gRPC Metadata Scrubber filter.
-	GrpcMetadataScrubber = "com.google.espv2.filters.http.grpc_metadata_scrubber"
-	// HeaderSanitizerScrubber is the filter name (matches c++ factory).
-	HeaderSanitizerScrubber = "com.google.espv2.filters.http.header_sanitizer"
 
 	// The metadata server cluster name.
 	MetadataServerClusterName = "metadata-cluster"


### PR DESCRIPTION
Benefits:

1) Reduces code duplication, as only the caller needs to worry about marshall into `Any`. Note the net diff of this PR is negative 👍 
2) Useful for internal consumption, as sometimes we don't need the `Any`.
3) Removes dependencies in the filter generators.

Other diffs:
- Same change for `GenPerRouteConfig()`.
- Move filter names into same files.