### PR TITLE
fix interface for listener creation

### DIFF
--- a/src/go/configgenerator/filtergen/http_connection_manager.go
+++ b/src/go/configgenerator/filtergen/http_connection_manager.go
@@ -198,11 +198,6 @@ func (g *HTTPConnectionManagerGenerator) GenFilterConfig() (proto.Message, error
 	jsonStr, _ := util.ProtoToJson(httpConMgr)
 	glog.Infof("HTTP Connection Manager config before adding routes or HTTP filters: %v", jsonStr)
 
-	httpConMgr.HttpFilters = g.HTTPFilterConfigs
-	httpConMgr.RouteSpecifier = &hcmpb.HttpConnectionManager_RouteConfig{
-		RouteConfig: g.RouteConfig,
-	}
-
 	return httpConMgr, nil
 }
 

--- a/src/go/configgenerator/filtergen/http_connection_manager_test.go
+++ b/src/go/configgenerator/filtergen/http_connection_manager_test.go
@@ -54,7 +54,6 @@ func TestNewHTTPConnectionManagerGenFromOPConfig_GenConfig(t *testing.T) {
 	},
 	"normalizePath": false,
 	"pathWithEscapedSlashesAction": "KEEP_UNCHANGED",
-	"routeConfig": {},
 	"statPrefix": "ingress_http",
 	"upgradeConfigs": [
 		{
@@ -105,7 +104,6 @@ func TestNewHTTPConnectionManagerGenFromOPConfig_GenConfig(t *testing.T) {
 	},
 	"normalizePath": false,
 	"pathWithEscapedSlashesAction": "KEEP_UNCHANGED",
-	"routeConfig": {},
 	"statPrefix": "ingress_http",
 	"upgradeConfigs": [
 		{
@@ -146,7 +144,6 @@ func TestNewHTTPConnectionManagerGenFromOPConfig_GenConfig(t *testing.T) {
 	},
 	"normalizePath": false,
 	"pathWithEscapedSlashesAction": "KEEP_UNCHANGED",
-	"routeConfig": {},
 	"statPrefix": "ingress_http",
 	"tracing":{
 		"clientSampling":{},
@@ -202,7 +199,6 @@ func TestNewHTTPConnectionManagerGenFromOPConfig_GenConfig(t *testing.T) {
 	},
 	"normalizePath": false,
 	"pathWithEscapedSlashesAction": "KEEP_UNCHANGED",
-	"routeConfig": {},
 	"statPrefix": "ingress_http",
 	"upgradeConfigs": [
 		{
@@ -242,7 +238,6 @@ func TestNewHTTPConnectionManagerGenFromOPConfig_GenConfig(t *testing.T) {
 	},
 	"normalizePath": false,
 	"pathWithEscapedSlashesAction": "KEEP_UNCHANGED",
-	"routeConfig": {},
 	"statPrefix": "ingress_http",
 	"upgradeConfigs": [
 		{


### PR DESCRIPTION
`MakeListener` needs to take in `filtergen.FilterGenerator` instead of direct `*filtergen.HTTPConnectionManagerGenerator`. Otherwise we cannot dependency inject an override in g3.

Fix this by moving route and filter config out of the struct and placing it in the output config directly.