### PR TITLE
Fix gcpproxy-prow  by adding llvm package for scudo allocator

### DIFF
--- a/docker/Dockerfile-prow-env
+++ b/docker/Dockerfile-prow-env
@@ -36,11 +36,12 @@ RUN wget -O /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/relea
     chmod +x /usr/local/bin/bazelisk
 
 # install clang-14 and associated tools (new envoy)
+# see https://apt.llvm.org/ for exhaustive list of all llvm related packages
 RUN wget -O- https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add - && \
     echo "deb https://apt.llvm.org/buster/ llvm-toolchain-buster-14 main" >> /etc/apt/sources.list && \
     apt-get update && \
     apt-get install -y llvm-14 llvm-14-dev libclang-14-dev clang-14 \
-        lld-14 clang-tools-14 clang-format-14 libc++-dev xz-utils
+        lld-14 clang-tools-14 clang-format-14 libc++-dev xz-utils libclang-rt-14-dev
 
 ENV CC clang-14
 ENV CXX clang++-14


### PR DESCRIPTION
Latest gcpproxy-prow image sumitted in https://github.com/GoogleCloudPlatform/oss-test-infra/pull/1984 is causing ESPv2 presubmit tests to fail. Example: [ESPv2-build log](https://oss.gprow.dev/view/gs/oss-prow/pr-logs/pull/GoogleCloudPlatform_esp-v2/831/ESPv2-build/1676592089766301696). Relevant error:
```
    /usr/bin/ld: cannot find /usr/lib/llvm-14/lib/clang/14.0.6/lib/linux/libclang_rt.scudo-x86_64.a: No such file or directory
    clang: error: linker command failed with exit code 1 (use -v to see invocation)
    ninja: build stopped: subcommand failed.
```
Fix: Installing compiler-rt package.

Test:
```sh
# Failure
git checkout master
make docker.build-prow
docker run -it --entrypoint /bin/bash <prow-tag>
apt install -y vim && git clone https://github.com/GoogleCloudPlatform/esp-v2.git && cd esp-v2 && mkdir bin
make build-envoy # This should FAIL

# Success
git checkout fix-clang-dep
make docker.build-prow
docker run -it --entrypoint /bin/bash <prow-tag>
apt install -y vim && git clone https://github.com/GoogleCloudPlatform/esp-v2.git && cd esp-v2 && mkdir bin
make build-envoy # This should PASS
```