### PR TITLE
refactor: generate CORS per-vHost config in CORS filter

### DIFF
--- a/src/go/configgenerator/filtergen/backend_auth.go
+++ b/src/go/configgenerator/filtergen/backend_auth.go
@@ -52,6 +52,8 @@ type BackendAuthGenerator struct {
 	BackendAuthCredentials  *options.IAMCredentialsOptions
 
 	AccessToken *helpers.FilterAccessTokenConfiger
+
+	NoopFilterGenerator
 }
 
 // NewBackendAuthFilterGensFromOPConfig creates a BackendAuthGenerator from

--- a/src/go/configgenerator/filtergen/compressor.go
+++ b/src/go/configgenerator/filtergen/compressor.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/options"
-	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
 	corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	brpb "github.com/envoyproxy/go-control-plane/envoy/extensions/compression/brotli/compressor/v3"
 	gzippb "github.com/envoyproxy/go-control-plane/envoy/extensions/compression/gzip/compressor/v3"
@@ -49,6 +48,8 @@ const (
 
 type CompressorGenerator struct {
 	compressorType CompressorType
+
+	NoopFilterGenerator
 }
 
 // NewCompressorFilterGensFromOPConfig creates a CompressorGenerator from
@@ -88,10 +89,6 @@ func (g *CompressorGenerator) GenFilterConfig() (proto.Message, error) {
 			TypedConfig: ca,
 		},
 	}, nil
-}
-
-func (g *CompressorGenerator) GenPerRouteConfig(selector string, httpRule *httppattern.Pattern) (proto.Message, error) {
-	return nil, nil
 }
 
 func (g *CompressorGenerator) getCompressorConfig() (proto.Message, string, error) {

--- a/src/go/configgenerator/filtergen/cors.go
+++ b/src/go/configgenerator/filtergen/cors.go
@@ -15,12 +15,17 @@
 package filtergen
 
 import (
+	"fmt"
+	"strconv"
+	"time"
+
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/options"
-	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
 	corspb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/cors/v3"
+	matcherpb "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"github.com/golang/glog"
 	servicepb "google.golang.org/genproto/googleapis/api/serviceconfig"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 const (
@@ -28,29 +33,117 @@ const (
 	CORSFilterName = "envoy.filters.http.cors"
 )
 
-type CORSGenerator struct{}
+type CORSBasicGenerator struct {
+	// AllowOrigin is the name of the origin to allow through.
+	AllowOrigin string
+	Options     *CorsOptions
+
+	NoopFilterGenerator
+}
+
+type CORSRegexGenerator struct {
+	// AllowOriginRegex is the regex of the origins to allow through.
+	AllowOriginRegex string
+	Options          *CorsOptions
+
+	NoopFilterGenerator
+}
+
+type CorsOptions struct {
+	MaxAge           time.Duration
+	AllowMethods     string
+	AllowHeaders     string
+	ExposeHeaders    string
+	AllowCredentials bool
+}
 
 // NewCORSFilterGensFromOPConfig creates a CORSGenerator from
 // OP service config + descriptor + ESPv2 options. It is a FilterGeneratorOPFactory.
 func NewCORSFilterGensFromOPConfig(serviceConfig *servicepb.Service, opts options.ConfigGeneratorOptions) ([]FilterGenerator, error) {
-	if opts.CorsPreset != "basic" && opts.CorsPreset != "cors_with_regex" {
-		glog.Infof("Not adding CORS filter gen because the feature is disabled by option, option is currently %q", opts.CorsPreset)
-		return nil, nil
+	corsOptions := &CorsOptions{
+		MaxAge:           opts.CorsMaxAge,
+		AllowMethods:     opts.CorsAllowMethods,
+		AllowHeaders:     opts.CorsAllowHeaders,
+		ExposeHeaders:    opts.CorsExposeHeaders,
+		AllowCredentials: opts.CorsAllowCredentials,
 	}
 
-	return []FilterGenerator{
-		&CORSGenerator{},
-	}, nil
+	switch opts.CorsPreset {
+	case "":
+		glog.Infof("Not adding CORS filter gen because the feature is disabled by option, option is currently %q", opts.CorsPreset)
+		return nil, nil
+
+	case "basic":
+		return []FilterGenerator{
+			&CORSBasicGenerator{
+				AllowOrigin: opts.CorsAllowOrigin,
+				Options:     corsOptions,
+			},
+		}, nil
+
+	case "cors_with_regex":
+		return []FilterGenerator{
+			&CORSRegexGenerator{
+				AllowOriginRegex: opts.CorsAllowOriginRegex,
+				Options:          corsOptions,
+			},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf(`cors_preset must be either "basic" or "cors_with_regex"`)
+	}
 }
 
-func (g *CORSGenerator) FilterName() string {
+func (g *CORSBasicGenerator) FilterName() string {
 	return CORSFilterName
 }
 
-func (g *CORSGenerator) GenFilterConfig() (proto.Message, error) {
+func (g *CORSBasicGenerator) GenFilterConfig() (proto.Message, error) {
 	return &corspb.Cors{}, nil
 }
 
-func (g *CORSGenerator) GenPerRouteConfig(selector string, httpRule *httppattern.Pattern) (proto.Message, error) {
-	return nil, nil
+func (g *CORSBasicGenerator) GenPerHostConfig(vHostName string) (proto.Message, error) {
+	policy := genCorsPolicyFromOptions(g.Options)
+	policy.AllowOriginStringMatch = []*matcherpb.StringMatcher{
+		{
+			MatchPattern: &matcherpb.StringMatcher_Exact{
+				Exact: g.AllowOrigin,
+			},
+		},
+	}
+	return policy, nil
+}
+
+func (g *CORSRegexGenerator) FilterName() string {
+	return CORSFilterName
+}
+
+func (g *CORSRegexGenerator) GenFilterConfig() (proto.Message, error) {
+	return &corspb.Cors{}, nil
+}
+
+func (g *CORSRegexGenerator) GenPerHostConfig(vHostName string) (proto.Message, error) {
+	policy := genCorsPolicyFromOptions(g.Options)
+	policy.AllowOriginStringMatch = []*matcherpb.StringMatcher{
+		{
+			MatchPattern: &matcherpb.StringMatcher_SafeRegex{
+				SafeRegex: &matcherpb.RegexMatcher{
+					Regex: g.AllowOriginRegex,
+				},
+			},
+		},
+	}
+	return policy, nil
+}
+
+func genCorsPolicyFromOptions(options *CorsOptions) *corspb.CorsPolicy {
+	return &corspb.CorsPolicy{
+		MaxAge:        strconv.Itoa(int(options.MaxAge.Seconds())),
+		AllowMethods:  options.AllowMethods,
+		AllowHeaders:  options.AllowHeaders,
+		ExposeHeaders: options.ExposeHeaders,
+		AllowCredentials: &wrapperspb.BoolValue{
+			Value: options.AllowCredentials,
+		},
+	}
 }

--- a/src/go/configgenerator/filtergen/cors.go
+++ b/src/go/configgenerator/filtergen/cors.go
@@ -33,117 +33,87 @@ const (
 	CORSFilterName = "envoy.filters.http.cors"
 )
 
-type CORSBasicGenerator struct {
-	// AllowOrigin is the name of the origin to allow through.
+// CORSGenerator is a FilterGenerator to configure CORS config.
+type CORSGenerator struct {
+	Preset string
+	// AllowOrigin should only be set if preset=basic
 	AllowOrigin string
-	Options     *CorsOptions
-
-	NoopFilterGenerator
-}
-
-type CORSRegexGenerator struct {
-	// AllowOriginRegex is the regex of the origins to allow through.
+	// AllowOriginRegex should only be set if preset=cors_with_regex
 	AllowOriginRegex string
-	Options          *CorsOptions
-
-	NoopFilterGenerator
-}
-
-type CorsOptions struct {
 	MaxAge           time.Duration
 	AllowMethods     string
 	AllowHeaders     string
 	ExposeHeaders    string
 	AllowCredentials bool
+
+	NoopFilterGenerator
 }
 
 // NewCORSFilterGensFromOPConfig creates a CORSGenerator from
 // OP service config + descriptor + ESPv2 options. It is a FilterGeneratorOPFactory.
 func NewCORSFilterGensFromOPConfig(serviceConfig *servicepb.Service, opts options.ConfigGeneratorOptions) ([]FilterGenerator, error) {
-	corsOptions := &CorsOptions{
-		MaxAge:           opts.CorsMaxAge,
-		AllowMethods:     opts.CorsAllowMethods,
-		AllowHeaders:     opts.CorsAllowHeaders,
-		ExposeHeaders:    opts.CorsExposeHeaders,
-		AllowCredentials: opts.CorsAllowCredentials,
-	}
-
-	switch opts.CorsPreset {
-	case "":
+	if opts.CorsPreset == "" {
 		glog.Infof("Not adding CORS filter gen because the feature is disabled by option, option is currently %q", opts.CorsPreset)
 		return nil, nil
+	}
 
+	return []FilterGenerator{
+		&CORSGenerator{
+			Preset:           opts.CorsPreset,
+			AllowOrigin:      opts.CorsAllowOrigin,
+			AllowOriginRegex: opts.CorsAllowOriginRegex,
+			MaxAge:           opts.CorsMaxAge,
+			AllowMethods:     opts.CorsAllowMethods,
+			AllowHeaders:     opts.CorsAllowHeaders,
+			ExposeHeaders:    opts.CorsExposeHeaders,
+			AllowCredentials: opts.CorsAllowCredentials,
+		},
+	}, nil
+}
+
+func (g *CORSGenerator) FilterName() string {
+	return CORSFilterName
+}
+
+func (g *CORSGenerator) GenFilterConfig() (proto.Message, error) {
+	return &corspb.Cors{}, nil
+}
+
+func (g *CORSGenerator) GenPerHostConfig(vHostName string) (proto.Message, error) {
+	policy := &corspb.CorsPolicy{
+		MaxAge:        strconv.Itoa(int(g.MaxAge.Seconds())),
+		AllowMethods:  g.AllowMethods,
+		AllowHeaders:  g.AllowHeaders,
+		ExposeHeaders: g.ExposeHeaders,
+		AllowCredentials: &wrapperspb.BoolValue{
+			Value: g.AllowCredentials,
+		},
+	}
+
+	switch g.Preset {
 	case "basic":
-		return []FilterGenerator{
-			&CORSBasicGenerator{
-				AllowOrigin: opts.CorsAllowOrigin,
-				Options:     corsOptions,
+		policy.AllowOriginStringMatch = []*matcherpb.StringMatcher{
+			{
+				MatchPattern: &matcherpb.StringMatcher_Exact{
+					Exact: g.AllowOrigin,
+				},
 			},
-		}, nil
+		}
 
 	case "cors_with_regex":
-		return []FilterGenerator{
-			&CORSRegexGenerator{
-				AllowOriginRegex: opts.CorsAllowOriginRegex,
-				Options:          corsOptions,
+		policy.AllowOriginStringMatch = []*matcherpb.StringMatcher{
+			{
+				MatchPattern: &matcherpb.StringMatcher_SafeRegex{
+					SafeRegex: &matcherpb.RegexMatcher{
+						Regex: g.AllowOriginRegex,
+					},
+				},
 			},
-		}, nil
+		}
 
 	default:
 		return nil, fmt.Errorf(`cors_preset must be either "basic" or "cors_with_regex"`)
 	}
-}
 
-func (g *CORSBasicGenerator) FilterName() string {
-	return CORSFilterName
-}
-
-func (g *CORSBasicGenerator) GenFilterConfig() (proto.Message, error) {
-	return &corspb.Cors{}, nil
-}
-
-func (g *CORSBasicGenerator) GenPerHostConfig(vHostName string) (proto.Message, error) {
-	policy := genCorsPolicyFromOptions(g.Options)
-	policy.AllowOriginStringMatch = []*matcherpb.StringMatcher{
-		{
-			MatchPattern: &matcherpb.StringMatcher_Exact{
-				Exact: g.AllowOrigin,
-			},
-		},
-	}
 	return policy, nil
-}
-
-func (g *CORSRegexGenerator) FilterName() string {
-	return CORSFilterName
-}
-
-func (g *CORSRegexGenerator) GenFilterConfig() (proto.Message, error) {
-	return &corspb.Cors{}, nil
-}
-
-func (g *CORSRegexGenerator) GenPerHostConfig(vHostName string) (proto.Message, error) {
-	policy := genCorsPolicyFromOptions(g.Options)
-	policy.AllowOriginStringMatch = []*matcherpb.StringMatcher{
-		{
-			MatchPattern: &matcherpb.StringMatcher_SafeRegex{
-				SafeRegex: &matcherpb.RegexMatcher{
-					Regex: g.AllowOriginRegex,
-				},
-			},
-		},
-	}
-	return policy, nil
-}
-
-func genCorsPolicyFromOptions(options *CorsOptions) *corspb.CorsPolicy {
-	return &corspb.CorsPolicy{
-		MaxAge:        strconv.Itoa(int(options.MaxAge.Seconds())),
-		AllowMethods:  options.AllowMethods,
-		AllowHeaders:  options.AllowHeaders,
-		ExposeHeaders: options.ExposeHeaders,
-		AllowCredentials: &wrapperspb.BoolValue{
-			Value: options.AllowCredentials,
-		},
-	}
 }

--- a/src/go/configgenerator/filtergen/filtergen.go
+++ b/src/go/configgenerator/filtergen/filtergen.go
@@ -44,6 +44,16 @@ type FilterGenerator interface {
 	// This method is called on all routes. Return (nil, nil) to indicate the
 	// filter does NOT require a per-route config for the given route.
 	GenPerRouteConfig(string, *httppattern.Pattern) (proto.Message, error)
+
+	// GenPerHostConfig generates the per-host config in RDS for the given virtual
+	// host name. Useful in case a filter needs to apply config for the entire
+	// virtual host.
+	//
+	// Return type is the filter's per-host config proto.
+	//
+	// This method is called on all virtual hosts. Return (nil, nil) to indicate the
+	// filter does NOT require a per-host config for the given virtual host.
+	GenPerHostConfig(string) (proto.Message, error)
 }
 
 // FilterGeneratorOPFactory is the factory function to create an ordered slice
@@ -52,3 +62,15 @@ type FilterGenerator interface {
 // The majority of factories will only return 1 FilterGenerator, but they should
 // be encapsulated by a slice for generalization.
 type FilterGeneratorOPFactory func(serviceConfig *servicepb.Service, opts options.ConfigGeneratorOptions) ([]FilterGenerator, error)
+
+// NoopFilterGenerator is a FilterGenerator that provides empty implementation
+// for all optional methods.
+type NoopFilterGenerator struct{}
+
+func (g *NoopFilterGenerator) GenPerRouteConfig(string, *httppattern.Pattern) (proto.Message, error) {
+	return nil, nil
+}
+
+func (g *NoopFilterGenerator) GenPerHostConfig(string) (proto.Message, error) {
+	return nil, nil
+}

--- a/src/go/configgenerator/filtergen/grpc_metadata_scrubber.go
+++ b/src/go/configgenerator/filtergen/grpc_metadata_scrubber.go
@@ -17,7 +17,6 @@ package filtergen
 import (
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/options"
 	gmspb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/v12/http/grpc_metadata_scrubber"
-	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
 	"github.com/golang/glog"
 	servicepb "google.golang.org/genproto/googleapis/api/serviceconfig"
 	"google.golang.org/protobuf/proto"
@@ -28,7 +27,9 @@ const (
 	GrpcMetadataScrubberFilterName = "com.google.espv2.filters.http.grpc_metadata_scrubber"
 )
 
-type GRPCMetadataScrubberGenerator struct{}
+type GRPCMetadataScrubberGenerator struct {
+	NoopFilterGenerator
+}
 
 // NewGRPCMetadataScrubberFilterGensFromOPConfig creates a GRPCMetadataScrubberGenerator from
 // OP service config + descriptor + ESPv2 options. It is a FilterGeneratorOPFactory.
@@ -49,8 +50,4 @@ func (g *GRPCMetadataScrubberGenerator) FilterName() string {
 
 func (g *GRPCMetadataScrubberGenerator) GenFilterConfig() (proto.Message, error) {
 	return &gmspb.FilterConfig{}, nil
-}
-
-func (g *GRPCMetadataScrubberGenerator) GenPerRouteConfig(selector string, httpRule *httppattern.Pattern) (proto.Message, error) {
-	return nil, nil
 }

--- a/src/go/configgenerator/filtergen/grpc_transcoder.go
+++ b/src/go/configgenerator/filtergen/grpc_transcoder.go
@@ -58,6 +58,8 @@ type GRPCTranscoderGenerator struct {
 	StrictRequestValidation            bool
 	RejectCollision                    bool
 	PrintOptions                       *transcoderpb.GrpcJsonTranscoder_PrintOptions
+
+	NoopFilterGenerator
 }
 
 // NewGRPCTranscoderFilterGensFromOPConfig creates a GRPCTranscoderGenerator from

--- a/src/go/configgenerator/filtergen/grpc_web.go
+++ b/src/go/configgenerator/filtergen/grpc_web.go
@@ -16,7 +16,6 @@ package filtergen
 
 import (
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/options"
-	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
 	grpcwebpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/grpc_web/v3"
 	"github.com/golang/glog"
 	servicepb "google.golang.org/genproto/googleapis/api/serviceconfig"
@@ -28,7 +27,9 @@ const (
 	GRPCWebFilterName = "envoy.filters.http.grpc_web"
 )
 
-type GRPCWebGenerator struct{}
+type GRPCWebGenerator struct {
+	NoopFilterGenerator
+}
 
 // NewGRPCWebFilterGensFromOPConfig creates a GRPCWebGenerator from
 // OP service config + descriptor + ESPv2 options. It is a FilterGeneratorOPFactory.
@@ -53,8 +54,4 @@ func (g *GRPCWebGenerator) FilterName() string {
 
 func (g *GRPCWebGenerator) GenFilterConfig() (proto.Message, error) {
 	return &grpcwebpb.GrpcWeb{}, nil
-}
-
-func (g *GRPCWebGenerator) GenPerRouteConfig(selector string, httpRule *httppattern.Pattern) (proto.Message, error) {
-	return nil, nil
 }

--- a/src/go/configgenerator/filtergen/header_sanitizer.go
+++ b/src/go/configgenerator/filtergen/header_sanitizer.go
@@ -17,7 +17,6 @@ package filtergen
 import (
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/options"
 	hspb "github.com/GoogleCloudPlatform/esp-v2/src/go/proto/api/envoy/v12/http/header_sanitizer"
-	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
 	servicepb "google.golang.org/genproto/googleapis/api/serviceconfig"
 	"google.golang.org/protobuf/proto"
 )
@@ -27,7 +26,9 @@ const (
 	HeaderSanitizerFilterName = "com.google.espv2.filters.http.header_sanitizer"
 )
 
-type HeaderSanitizerGenerator struct{}
+type HeaderSanitizerGenerator struct {
+	NoopFilterGenerator
+}
 
 // NewHeaderSanitizerFilterGensFromOPConfig creates a HeaderSanitizerGenerator from
 // OP service config + descriptor + ESPv2 options. It is a FilterGeneratorOPFactory.
@@ -43,8 +44,4 @@ func (g *HeaderSanitizerGenerator) FilterName() string {
 
 func (g *HeaderSanitizerGenerator) GenFilterConfig() (proto.Message, error) {
 	return &hspb.FilterConfig{}, nil
-}
-
-func (g *HeaderSanitizerGenerator) GenPerRouteConfig(selector string, httpRule *httppattern.Pattern) (proto.Message, error) {
-	return nil, nil
 }

--- a/src/go/configgenerator/filtergen/health_check.go
+++ b/src/go/configgenerator/filtergen/health_check.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/configgenerator/clustergen"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/options"
-	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
 	routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	hcpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/health_check/v3"
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
@@ -40,6 +39,8 @@ type HealthCheckGenerator struct {
 	HealthzPath                  string
 	ShouldHealthCheckGrpcBackend bool
 	LocalBackendClusterName      string
+
+	NoopFilterGenerator
 }
 
 // NewHealthCheckFilterGensFromOPConfig creates a HealthCheckGenerator from
@@ -93,8 +94,4 @@ func (g *HealthCheckGenerator) GenFilterConfig() (proto.Message, error) {
 	}
 
 	return hcFilterConfig, nil
-}
-
-func (g *HealthCheckGenerator) GenPerRouteConfig(selector string, httpRule *httppattern.Pattern) (proto.Message, error) {
-	return nil, nil
 }

--- a/src/go/configgenerator/filtergen/http_connection_manager.go
+++ b/src/go/configgenerator/filtergen/http_connection_manager.go
@@ -20,7 +20,6 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/options"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/tracing"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
-	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
 	acpb "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
 	corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	facpb "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/file/v3"
@@ -52,6 +51,8 @@ type HTTPConnectionManagerGenerator struct {
 	UnderscoresInHeaders         bool
 	EnableGrpcForHttp1           bool
 	TracingOptions               *options.TracingOptions
+
+	NoopFilterGenerator
 }
 
 // NewHTTPConnectionManagerGenFromOPConfig creates a HTTPConnectionManagerGenerator from
@@ -196,10 +197,6 @@ func (g *HTTPConnectionManagerGenerator) GenFilterConfig() (proto.Message, error
 	glog.Infof("HTTP Connection Manager config before adding routes or HTTP filters: %v", jsonStr)
 
 	return httpConMgr, nil
-}
-
-func (g *HTTPConnectionManagerGenerator) GenPerRouteConfig(selector string, httpRule *httppattern.Pattern) (proto.Message, error) {
-	return nil, nil
 }
 
 // IsSchemeHeaderOverrideRequiredForOPConfig fixes b/221072669:

--- a/src/go/configgenerator/filtergen/jwt_authn.go
+++ b/src/go/configgenerator/filtergen/jwt_authn.go
@@ -67,6 +67,8 @@ type JwtAuthnGenerator struct {
 	JwtPadForwardPayloadHeader         bool
 	DisableJwtAudienceServiceNameCheck bool
 	JwtCacheSize                       uint
+
+	NoopFilterGenerator
 }
 
 // NewJwtAuthnFilterGensFromOPConfig creates a JwtAuthnGenerator from

--- a/src/go/configgenerator/filtergen/path_rewrite.go
+++ b/src/go/configgenerator/filtergen/path_rewrite.go
@@ -33,6 +33,8 @@ const (
 
 type PathRewriteGenerator struct {
 	TranslationInfoBySelector map[string]TranslationInfo
+
+	NoopFilterGenerator
 }
 
 // TranslationInfo captures https://cloud.google.com/endpoints/docs/openapi/openapi-extensions#understanding_path_translation.

--- a/src/go/configgenerator/filtergen/router.go
+++ b/src/go/configgenerator/filtergen/router.go
@@ -16,7 +16,6 @@ package filtergen
 
 import (
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/options"
-	"github.com/GoogleCloudPlatform/esp-v2/src/go/util/httppattern"
 	routerpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
 	servicepb "google.golang.org/genproto/googleapis/api/serviceconfig"
 	"google.golang.org/protobuf/proto"
@@ -30,6 +29,8 @@ const (
 type RouterGenerator struct {
 	SuppressEnvoyHeaders bool
 	StartChildSpan       bool
+
+	NoopFilterGenerator
 }
 
 // NewRouterFilterGensFromOPConfig creates a RouterGenerator from
@@ -52,8 +53,4 @@ func (g *RouterGenerator) GenFilterConfig() (proto.Message, error) {
 		SuppressEnvoyHeaders: g.SuppressEnvoyHeaders,
 		StartChildSpan:       g.StartChildSpan,
 	}, nil
-}
-
-func (g *RouterGenerator) GenPerRouteConfig(selector string, httpRule *httppattern.Pattern) (proto.Message, error) {
-	return nil, nil
 }

--- a/src/go/configgenerator/filtergen/service_control.go
+++ b/src/go/configgenerator/filtergen/service_control.go
@@ -77,6 +77,8 @@ type ServiceControlGenerator struct {
 	MethodRequirements []*scpb.Requirement
 	CallingConfig      *scpb.ServiceControlCallingConfig
 	GCPAttributes      *scpb.GcpAttributes
+
+	NoopFilterGenerator
 }
 
 // ServiceControlOPFactoryParams are extra params that don't fit within OP

--- a/src/go/configgenerator/route_generator.go
+++ b/src/go/configgenerator/route_generator.go
@@ -32,17 +32,13 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
-	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 const (
 	routeName       = "local_route"
 	virtualHostName = "backend"
 )
-
-// perResourceCallback is a callback to generate per-resource config for a
-// specific FilterGenerator.
-type perResourceCallback func(gen filtergen.FilterGenerator) (proto.Message, error)
 
 func makeRouteConfig(serviceInfo *configinfo.ServiceInfo, filterGenerators []filtergen.FilterGenerator) (*routepb.RouteConfiguration, error) {
 	var virtualHosts []*routepb.VirtualHost


### PR DESCRIPTION
Started working on the refactor of `route_generator.go` so we can remove `ServiceInfo`. There are many items to clean up, expect quite a few PRs to finish up refactor work.

This PR:
1) Moves some logic from `route_generator.go` to each `FilterGenerator`, allowing route generation to be generic.
2) Introduces `NoopFilterGenerator` to reduce code duplication of optional methods.