### PR TITLE
Allow internal callers to inject RouteGenerator

### DIFF
--- a/src/go/configgenerator/listener_generator.go
+++ b/src/go/configgenerator/listener_generator.go
@@ -20,6 +20,7 @@ import (
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/configgenerator/filtergen"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/configgenerator/routegen"
 	sc "github.com/GoogleCloudPlatform/esp-v2/src/go/configinfo"
+	"github.com/GoogleCloudPlatform/esp-v2/src/go/options"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
@@ -47,7 +48,7 @@ func MakeListeners(serviceInfo *sc.ServiceInfo, scParams filtergen.ServiceContro
 		return nil, err
 	}
 
-	listener, err := MakeListener(serviceInfo, filterGens, connectionManager, routeGens)
+	listener, err := MakeListener(serviceInfo.Options, filterGens, connectionManager, routeGens)
 	if err != nil {
 		return nil, err
 	}
@@ -87,13 +88,13 @@ func MakeHttpFilterConfigs(filterGenerators []filtergen.FilterGenerator) ([]*hcm
 // MakeListener provides a dynamic listener for Envoy.
 // Allows dependency injection of FilterGenerator and RouteGenerator for
 // internal use.
-func MakeListener(serviceInfo *sc.ServiceInfo, httpFilterGenerators []filtergen.FilterGenerator, connectionManagerGen filtergen.FilterGenerator, routeGenerators []routegen.RouteGenerator) (*listenerpb.Listener, error) {
+func MakeListener(opts options.ConfigGeneratorOptions, httpFilterGenerators []filtergen.FilterGenerator, connectionManagerGen filtergen.FilterGenerator, routeGenerators []routegen.RouteGenerator) (*listenerpb.Listener, error) {
 	httpFilterConfigs, err := MakeHttpFilterConfigs(httpFilterGenerators)
 	if err != nil {
 		return nil, err
 	}
 
-	routeConfig, err := MakeRouteConfig(serviceInfo.Options, httpFilterGenerators, routeGenerators)
+	routeConfig, err := MakeRouteConfig(opts, httpFilterGenerators, routeGenerators)
 	if err != nil {
 		return nil, fmt.Errorf("makeHttpConnectionManagerRouteConfig got err: %s", err)
 	}
@@ -125,13 +126,13 @@ func MakeListener(serviceInfo *sc.ServiceInfo, httpFilterGenerators []filtergen.
 		},
 	}
 
-	if serviceInfo.Options.SslServerCertPath != "" {
+	if opts.SslServerCertPath != "" {
 		transportSocket, err := util.CreateDownstreamTransportSocket(
-			serviceInfo.Options.SslServerCertPath,
-			serviceInfo.Options.SslServerRootCertPath,
-			serviceInfo.Options.SslMinimumProtocol,
-			serviceInfo.Options.SslMaximumProtocol,
-			serviceInfo.Options.SslServerCipherSuites,
+			opts.SslServerCertPath,
+			opts.SslServerRootCertPath,
+			opts.SslMinimumProtocol,
+			opts.SslMaximumProtocol,
+			opts.SslServerCipherSuites,
 		)
 		if err != nil {
 			return nil, err
@@ -144,9 +145,9 @@ func MakeListener(serviceInfo *sc.ServiceInfo, httpFilterGenerators []filtergen.
 		Address: &corepb.Address{
 			Address: &corepb.Address_SocketAddress{
 				SocketAddress: &corepb.SocketAddress{
-					Address: serviceInfo.Options.ListenerAddress,
+					Address: opts.ListenerAddress,
 					PortSpecifier: &corepb.SocketAddress_PortValue{
-						PortValue: uint32(serviceInfo.Options.ListenerPort),
+						PortValue: uint32(opts.ListenerPort),
 					},
 				},
 			},
@@ -154,9 +155,9 @@ func MakeListener(serviceInfo *sc.ServiceInfo, httpFilterGenerators []filtergen.
 		FilterChains: []*listenerpb.FilterChain{filterChain},
 	}
 
-	if serviceInfo.Options.ConnectionBufferLimitBytes >= 0 {
+	if opts.ConnectionBufferLimitBytes >= 0 {
 		listener.PerConnectionBufferLimitBytes = &wrapperspb.UInt32Value{
-			Value: uint32(serviceInfo.Options.ConnectionBufferLimitBytes),
+			Value: uint32(opts.ConnectionBufferLimitBytes),
 		}
 	}
 

--- a/src/go/configgenerator/route_generator.go
+++ b/src/go/configgenerator/route_generator.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/configgenerator/filtergen"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/configgenerator/routegen"
-	"github.com/GoogleCloudPlatform/esp-v2/src/go/configinfo"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/options"
 	"github.com/GoogleCloudPlatform/esp-v2/src/go/util"
 	corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -55,22 +54,7 @@ func MakeRouteGenFactories() []routegen.RouteGeneratorOPFactory {
 
 // MakeRouteConfig creates the virtual host and route table with the default
 // route generators for ESPv2.
-func MakeRouteConfig(serviceInfo *configinfo.ServiceInfo, filterGenerators []filtergen.FilterGenerator) (*routepb.RouteConfiguration, error) {
-	routeGenFactories := MakeRouteGenFactories()
-
-	routeGens, err := routegen.NewRouteGeneratorsFromOPConfig(serviceInfo.ServiceConfig(), serviceInfo.Options, routeGenFactories)
-	if err != nil {
-		return nil, err
-	}
-
-	return MakeRouteConfigWithGens(serviceInfo.Options, filterGenerators, routeGens)
-}
-
-// MakeRouteConfigWithGens is a version of MakeRouteConfig that allows injection
-// of different route generators that are not the default.
-//
-// Useful when extending the config generator internally.
-func MakeRouteConfigWithGens(opts options.ConfigGeneratorOptions, filterGenerators []filtergen.FilterGenerator, routeGenerators []routegen.RouteGenerator) (*routepb.RouteConfiguration, error) {
+func MakeRouteConfig(opts options.ConfigGeneratorOptions, filterGenerators []filtergen.FilterGenerator, routeGenerators []routegen.RouteGenerator) (*routepb.RouteConfiguration, error) {
 	host := &routepb.VirtualHost{
 		Name:    virtualHostName,
 		Domains: []string{"*"},


### PR DESCRIPTION
Bubble up `routeGens` parameter to `MakeListener`, which we call internally.

Also allows us to remove `ServiceInfo` from `MakeListener` 💯  In follow-up CL, I will completely delete `ServiceInfo`.