### PR TITLE
Update the Bootstrap proto link in Envoy Filters README.md

### DIFF
--- a/src/envoy/README.md
+++ b/src/envoy/README.md
@@ -26,7 +26,7 @@ filter_chains:
 See the
 [Config Manager documentation][Config Manager] for more details.
 
-[bootstrap]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/bootstrap/v2/bootstrap.proto#config-bootstrap-v2-bootstrap
+[bootstrap]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/bootstrap/v3/bootstrap.proto#config-bootstrap-v2-bootstrap
 [Config Manager]: ../go/README.md
 [Envoy filter example]: https://github.com/envoyproxy/envoy-filter-example
 [Envoy Home]: https://www.envoyproxy.io/


### PR DESCRIPTION
The old link to the Bootstrap config is no longer valid, change it to the current link.