### PR TITLE
Update googleapi version to latest

### DIFF
--- a/bazel/googleapis.bzl
+++ b/bazel/googleapis.bzl
@@ -17,9 +17,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def googleapis_repositories(bind = True):
     http_archive(
         name = "com_github_googleapis_googleapis",
-        strip_prefix = "googleapis-736857e7a655eea72322e078b1988bd0d25aae0f",  # 10/19/2022
-        url = "https://github.com/googleapis/googleapis/archive/736857e7a655eea72322e078b1988bd0d25aae0f.tar.gz",
-        sha256 = "b165b0f397f143d2e09d22c51aa90028d24ac3b755a103688e7a49090993155f",
+        strip_prefix = "googleapis-792dacbd24643d8650fbf705b3f745532012ea34",  # 03/05/2024
+        url = "https://github.com/googleapis/googleapis/archive/792dacbd24643d8650fbf705b3f745532012ea34.tar.gz",
+        sha256 = "7546ed2126b3cb08cc71ca22766cbb3e6ea425e6491dfafccac47500637b91ba",
     )
 
     if bind:

--- a/tests/env/components/stats_verifier.go
+++ b/tests/env/components/stats_verifier.go
@@ -54,7 +54,7 @@ func (sv StatsVerifier) CheckExpectedCounters(wantCounters utils.StatCounters) e
 		if getCountVal, ok := counters[wantCounter]; !ok {
 			return fmt.Errorf("expected counter %v not in the got counters: %v", wantCounter, counters)
 		} else if getCountVal != wantCounterVal {
-			return fmt.Errorf("for counter %v, expected value %v:, got value: %v ", wantCounter, wantCounterVal, getCountVal)
+			return fmt.Errorf("for counter %v, expected value: %v, got value: %v ", wantCounter, wantCounterVal, getCountVal)
 		}
 	}
 

--- a/tests/integration_test/statistics_test/statistics_test.go
+++ b/tests/integration_test/statistics_test/statistics_test.go
@@ -138,7 +138,7 @@ func TestStatisticsServiceControlCallStatus(t *testing.T) {
 			quotaRespCode: 403,
 			wantCounters: utils.StatCounters{
 				"http.ingress_http.service_control.check.OK":                         1,
-				"http.ingress_http.service_control.allocate_quota.PERMISSION_DENIED": 2,
+				"http.ingress_http.service_control.allocate_quota.PERMISSION_DENIED": 3,
 			},
 		},
 	}

--- a/tests/integration_test/statistics_test/statistics_test.go
+++ b/tests/integration_test/statistics_test/statistics_test.go
@@ -138,7 +138,7 @@ func TestStatisticsServiceControlCallStatus(t *testing.T) {
 			quotaRespCode: 403,
 			wantCounters: utils.StatCounters{
 				"http.ingress_http.service_control.check.OK":                         1,
-				"http.ingress_http.service_control.allocate_quota.PERMISSION_DENIED": 3,
+				"http.ingress_http.service_control.allocate_quota.PERMISSION_DENIED": 2,
 			},
 		},
 	}


### PR DESCRIPTION
Update googleapi version to include the newly added field `api_key_uid` in https://github.com/googleapis/googleapis/blob/cff4df02d7f68e7d131357815a4faf2d26b87957/google/api/servicecontrol/v1/service_controller.proto#L128