### PR TITLE
Enable deterministic Go Protobuf marshaling (encoding)

### DIFF
--- a/src/go/configgenerator/filtergen/grpc_transcoder.go
+++ b/src/go/configgenerator/filtergen/grpc_transcoder.go
@@ -257,7 +257,7 @@ func UpdateProtoDescriptorFromOPConfig(serviceConfig *confpb.Service, opts optio
 		}
 	}
 
-	newData, err := protov2.Marshal(fds)
+	newData, err := protov2.MarshalOptions{Deterministic: true}.Marshal(fds)
 	if err != nil {
 		glog.Error("failed to marshal proto descriptor, error: ", err)
 		return nil, fmt.Errorf("failed to marshal proto descriptor, error: %v", err)


### PR DESCRIPTION
While developing Go Protobuf, we found this line to be responsible for a test failure when enabling fully lazy extensions (Google-internal bug reference: b/328746084).

Your test seems to compare Protobuf-encoded data. As explained on go/go-proto-stability, you should not rely on the Protobuf wire encoding being stable across different versions of your program.

go/go-proto-stability lists a couple of strategies you could pursue for a more reliable test, but for now, to unblock our optimization, enabling deterministic marshaling side-steps many vectors for change.