### PR TITLE
Propagate Api Key UID when it is returned by the service controller.

### DIFF
--- a/src/api_proxy/service_control/check_response_convert_utils.cc
+++ b/src/api_proxy/service_control/check_response_convert_utils.cc
@@ -50,6 +50,8 @@ Status ConvertCheckResponse(const CheckResponse& check_response,
             check_response.check_info().consumer_info().type());
   }
 
+  check_response_info->api_key_uid = check_response.check_info().api_key_uid();
+
   if (check_response.check_errors().empty()) {
     return OkStatus();
   }

--- a/src/api_proxy/service_control/check_response_convert_utils_test.cc
+++ b/src/api_proxy/service_control/check_response_convert_utils_test.cc
@@ -191,6 +191,18 @@ TEST_F(CheckResponseConverterTest, ConvertConsumerInfo) {
   EXPECT_EQ(info.consumer_number, std::to_string(consumer_number));
 }
 
+TEST_F(CheckResponseConverterTest,
+       ApiKeyUidCarriedInCheckResponseInfo) {
+  CheckResponseInfo info;
+  CheckResponse response;
+  response.mutable_check_info()->set_api_key_uid("fake_api_key_uid");
+
+  Status result = ConvertCheckResponse(response, "api_xxxx", &info);
+
+  EXPECT_EQ(StatusCode::kOk, result.code());
+  EXPECT_EQ(info.api_key_uid, "fake_api_key_uid");
+}
+
 }  // namespace
 }  // namespace service_control
 }  // namespace api_proxy

--- a/src/api_proxy/service_control/request_builder.cc
+++ b/src/api_proxy/service_control/request_builder.cc
@@ -383,7 +383,9 @@ Status set_credential_id(const SupportedLabel& l, const ReportRequestInfo& info,
     ASSERT(!info.api_key.empty(),
            "API Key must be set, otherwise consumer would not be verified.");
     std::string credential_id("apikey:");
-    credential_id += info.api_key;
+    credential_id = credential_id
+           + (info.check_response_info.api_key_uid.empty() ? info.api_key
+                      : info.check_response_info.api_key_uid);
     (*labels)[l.name] = credential_id;
   } else if (!info.auth_issuer.empty()) {
     std::string base64_issuer = Envoy::Base64Url::encode(

--- a/src/api_proxy/service_control/request_builder.cc
+++ b/src/api_proxy/service_control/request_builder.cc
@@ -347,6 +347,8 @@ constexpr char kServiceControlBackendProtocol[] =
     "servicecontrol.googleapis.com/backend_protocol";
 constexpr char kServiceControlConsumerProject[] =
     "serviceruntime.googleapis.com/consumer_project";
+constexpr char kApiKeyPrefix[] = "apikey:";
+    
 
 // User agent label value
 // The value for kUserAgent should be configured at service control server.
@@ -382,8 +384,7 @@ Status set_credential_id(const SupportedLabel& l, const ReportRequestInfo& info,
       api_key::ApiKeyState::VERIFIED) {
     ASSERT(!info.api_key.empty(),
            "API Key must be set, otherwise consumer would not be verified.");
-    const char* kCredentialIdPrefix = "apikey:";
-    (*labels)[l.name] = absl::StrCat(kCredentialIdPrefix, info.check_response_info.api_key_uid.empty() ? info.api_key
+    (*labels)[l.name] = absl::StrCat(kApiKeyPrefix, info.check_response_info.api_key_uid.empty() ? info.api_key
                       : info.check_response_info.api_key_uid);
   } else if (!info.auth_issuer.empty()) {
     std::string base64_issuer = Envoy::Base64Url::encode(

--- a/src/api_proxy/service_control/request_builder.cc
+++ b/src/api_proxy/service_control/request_builder.cc
@@ -382,11 +382,9 @@ Status set_credential_id(const SupportedLabel& l, const ReportRequestInfo& info,
       api_key::ApiKeyState::VERIFIED) {
     ASSERT(!info.api_key.empty(),
            "API Key must be set, otherwise consumer would not be verified.");
-    std::string credential_id("apikey:");
-    credential_id = credential_id
-           + (info.check_response_info.api_key_uid.empty() ? info.api_key
+    const char* kCredentialIdPrefix = "apikey:";
+    (*labels)[l.name] = absl::StrCat(kCredentialIdPrefix, info.check_response_info.api_key_uid.empty() ? info.api_key
                       : info.check_response_info.api_key_uid);
-    (*labels)[l.name] = credential_id;
   } else if (!info.auth_issuer.empty()) {
     std::string base64_issuer = Envoy::Base64Url::encode(
         info.auth_issuer.data(), info.auth_issuer.size());

--- a/src/api_proxy/service_control/request_info.h
+++ b/src/api_proxy/service_control/request_info.h
@@ -176,6 +176,7 @@ struct CheckResponseInfo {
   // The trust level of the API Key that was checked.
   api_key::ApiKeyState api_key_state;
 
+  // The API key uid of the request.
   std::string api_key_uid;
 
   CheckResponseInfo() : api_key_state(api_key::ApiKeyState::NOT_CHECKED) {}

--- a/src/api_proxy/service_control/request_info.h
+++ b/src/api_proxy/service_control/request_info.h
@@ -176,6 +176,8 @@ struct CheckResponseInfo {
   // The trust level of the API Key that was checked.
   api_key::ApiKeyState api_key_state;
 
+  std::string api_key_uid;
+
   CheckResponseInfo() : api_key_state(api_key::ApiKeyState::NOT_CHECKED) {}
 };
 


### PR DESCRIPTION
Propagates the API key UID if it is returned in the service controller CheckResponse.

If it is not returned by the CheckResponse, we will still use the api_key as it is.
