### PR TITLE
Allow rewrite of host header for http backend

### DIFF
--- a/src/go/configmanager/flags/flags.go
+++ b/src/go/configmanager/flags/flags.go
@@ -87,7 +87,8 @@ var (
          For example --add_response_headers=key1=value1;key2=value2. If a header is already in the response, its value will be replaced with the new one.`)
 	AppendResponseHeaders = flag.String("append_response_headers", defaults.AppendResponseHeaders, `Append HTTP headers to the response before sent to the upstream backend. Multiple headers are separated by ';'.
          For example --append_response_headers=key1=value1;key2=value2. If a header is already in the response, the new value will be append.`)
-	EnableOperationNameHeader = flag.Bool("enable_operation_name_header", defaults.EnableOperationNameHeader, "If enabled, the operation name for the matched route will be sent to the upstream as a request header.")
+	EnableOperationNameHeader      = flag.Bool("enable_operation_name_header", defaults.EnableOperationNameHeader, "If enabled, the operation name for the matched route will be sent to the upstream as a request header.")
+	AllowHostRewriteForHTTPBackend = flag.Bool("allow_host_rewrite_for_http_backend", defaults.AllowHostRewriteForHTTPBackend, "If enabled, the host/:authority header of the upstream request will be rewritten to the hostname of backend http cluster.")
 
 	// Flags for non_gcp deployment.
 	ServiceAccountKey = flag.String("service_account_key", defaults.ServiceAccountKey, `Use the service account key JSON file to access the service control and the
@@ -269,6 +270,7 @@ func EnvoyConfigOptionsFromFlags() options.ConfigGeneratorOptions {
 		AddResponseHeaders:                            *AddResponseHeaders,
 		AppendResponseHeaders:                         *AppendResponseHeaders,
 		EnableOperationNameHeader:                     *EnableOperationNameHeader,
+		AllowHostRewriteForHTTPBackend:                *AllowHostRewriteForHTTPBackend,
 		ServiceAccountKey:                             *ServiceAccountKey,
 		TokenAgentPort:                                *TokenAgentPort,
 		EnableApplicationDefaultCredentials:           *EnableApplicationDefaultCredentials,

--- a/src/go/options/configgenerator.go
+++ b/src/go/options/configgenerator.go
@@ -78,11 +78,12 @@ type ConfigGeneratorOptions struct {
 	DnsResolverAddresses             string
 
 	// Headers manipulation:
-	AddRequestHeaders         string
-	AppendRequestHeaders      string
-	AddResponseHeaders        string
-	AppendResponseHeaders     string
-	EnableOperationNameHeader bool
+	AddRequestHeaders              string
+	AppendRequestHeaders           string
+	AddResponseHeaders             string
+	AppendResponseHeaders          string
+	EnableOperationNameHeader      bool
+	AllowHostRewriteForHTTPBackend bool
 
 	// Flags for non_gcp deployment.
 	ServiceAccountKey                   string


### PR DESCRIPTION
The configgenerator would by default allow rewrite of host/:authority header even for the http backends, but this behavior was changed in [this](https://github.com/GoogleCloudPlatform/esp-v2/commit/13569ad6647ca45cc272c314a09b2c61ab4a220e) commit. This PR restores the old behavior behind a flag, while [this](https://github.com/GoogleCloudPlatform/esp-v2/commit/13569ad6647ca45cc272c314a09b2c61ab4a220e) behavior continues to be the default.