### PR TITLE
Update alpine base image to 3.22 (for setuptools 78+)

### DIFF
--- a/docker/Dockerfile-envoy
+++ b/docker/Dockerfile-envoy
@@ -14,7 +14,7 @@
 
 # Folloing portion is copied from https://github.com/Docker-Hub-frolvlad/docker-alpine-glibc/blob/master/Dockerfile
 ################################################################################################################
-FROM alpine:3.20
+FROM alpine:3.22
 
 ENV LANG=C.UTF-8
 


### PR DESCRIPTION
setuptools in alpine 3.20, 3.21 have vulnerabilities. Upgrading to alpine 3.22 to resolve them.