### PR TITLE
chore: enable dependabot for the Docker ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directories:
+      - "/docker/*"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
To avoid running into issues like #957 #959, I think it would be useful to enable Dependabot in the repository settings, and configure like it is configured in this PR.

This will allow Dependabot to create a new PR like in the attached screenshot.

Thanks

<img width="1050" height="377" alt="image" src="https://github.com/user-attachments/assets/2a2e0056-6662-4bc6-8028-55a1abe23c09" />
 