### PR TITLE
Delete removed guard

### DIFF
--- a/examples/auth/envoy_config.json
+++ b/examples/auth/envoy_config.json
@@ -4,8 +4,7 @@
     "layers": [
       {
         "name": "static-runtime",
-        "staticLayer": {
-          "envoy.reloadable_features.prohibit_route_refresh_after_response_headers_sent": false,
+        "staticLayer": {0
           "http.max_requests_per_io_cycle": 1,
           "re2.max_program_size.error_level": 1000
         }

--- a/examples/auth/envoy_config.json
+++ b/examples/auth/envoy_config.json
@@ -4,7 +4,7 @@
     "layers": [
       {
         "name": "static-runtime",
-        "staticLayer": {0
+        "staticLayer": {
           "http.max_requests_per_io_cycle": 1,
           "re2.max_program_size.error_level": 1000
         }

--- a/examples/dynamic_routing/envoy_config.json
+++ b/examples/dynamic_routing/envoy_config.json
@@ -5,7 +5,6 @@
       {
         "name": "static-runtime",
         "staticLayer": {
-          "envoy.reloadable_features.prohibit_route_refresh_after_response_headers_sent": false,
           "http.max_requests_per_io_cycle": 1,
           "re2.max_program_size.error_level": 1000
         }

--- a/examples/grpc_dynamic_routing/envoy_config.json
+++ b/examples/grpc_dynamic_routing/envoy_config.json
@@ -5,7 +5,6 @@
       {
         "name": "static-runtime",
         "staticLayer": {
-          "envoy.reloadable_features.prohibit_route_refresh_after_response_headers_sent": false,
           "http.max_requests_per_io_cycle": 1,
           "re2.max_program_size.error_level": 1000
         }

--- a/examples/service_control/envoy_config.json
+++ b/examples/service_control/envoy_config.json
@@ -5,7 +5,6 @@
       {
         "name": "static-runtime",
         "staticLayer": {
-          "envoy.reloadable_features.prohibit_route_refresh_after_response_headers_sent": false,
           "http.max_requests_per_io_cycle": 1,
           "re2.max_program_size.error_level": 1000
         }

--- a/examples/testdata/route_match/envoy_config.json
+++ b/examples/testdata/route_match/envoy_config.json
@@ -5,7 +5,6 @@
       {
         "name": "static-runtime",
         "staticLayer": {
-          "envoy.reloadable_features.prohibit_route_refresh_after_response_headers_sent": false,
           "http.max_requests_per_io_cycle": 1,
           "re2.max_program_size.error_level": 1000
         }

--- a/examples/testdata/sidecar_backend/envoy_config.json
+++ b/examples/testdata/sidecar_backend/envoy_config.json
@@ -5,7 +5,6 @@
       {
         "name": "static-runtime",
         "staticLayer": {
-          "envoy.reloadable_features.prohibit_route_refresh_after_response_headers_sent": false,
           "http.max_requests_per_io_cycle": 1,
           "re2.max_program_size.error_level": 1000
         }

--- a/src/go/bootstrap/ads/bootstrap_test.go
+++ b/src/go/bootstrap/ads/bootstrap_test.go
@@ -70,7 +70,6 @@ func TestCreateBootstrapConfig(t *testing.T) {
          {
             "name": "static-runtime",
             "staticLayer": {
-              "envoy.reloadable_features.prohibit_route_refresh_after_response_headers_sent": false,
           "http.max_requests_per_io_cycle":1,
               "re2.max_program_size.error_level":1000
             }
@@ -172,7 +171,6 @@ func TestCreateBootstrapConfig(t *testing.T) {
          {
             "name": "static-runtime",
             "staticLayer": {
-              "envoy.reloadable_features.prohibit_route_refresh_after_response_headers_sent": false,
           "http.max_requests_per_io_cycle":1,
               "re2.max_program_size.error_level":1000
             }

--- a/src/go/bootstrap/layer_runtime.go
+++ b/src/go/bootstrap/layer_runtime.go
@@ -35,15 +35,6 @@ func CreateLayeredRuntime() *bootstrappb.LayeredRuntime {
 									NumberValue: 1000,
 								},
 							},
-							// Our service control filter may call route() in log time
-							// but it is possible that the route isn't set with early local reply,
-							// which triggers an ENVOY_BUG, so we use this flag to workaround.
-							// For more context, see https://github.com/envoyproxy/envoy/issues/28626.
-							"envoy.reloadable_features.prohibit_route_refresh_after_response_headers_sent": {
-								Kind: &structpb.Value_BoolValue{
-									BoolValue: false,
-								},
-							},
 							// Enable an Envoy vulnerability mitigation. For details, please see b/299661830.
 							"http.max_requests_per_io_cycle": {
 								Kind: &structpb.Value_NumberValue{


### PR DESCRIPTION
Get rid of log error message

> [24][envoy_bug]envoy bug failure: false. Details: Using a removed guard envoy.reloadable_features.prohibit_route_refresh_after_response_headers_sent. In future version of Envoy this will be treated as invalid configuration

+ what seems to be a stacktrace.