### PR TITLE
fix out-of-bounds read in extractIPFromForwardedHeader on empty for= token

### DIFF
--- a/src/envoy/http/service_control/handler_utils.cc
+++ b/src/envoy/http/service_control/handler_utils.cc
@@ -400,11 +400,11 @@ absl::StatusOr<std::string> extractIPFromForwardedHeader(
 
       // IPv2 address is wrapped with \"[]\".
       // Remove double quote.
-      if (ip[0] == '"' && ip[ip.size() - 1] == '"') {
+      if (ip.size() >= 2 && ip.front() == '"' && ip.back() == '"') {
         ip = ip.substr(1, ip.size() - 2);
       }
       // Remove [].
-      if (ip[0] == '[' && ip[ip.size() - 1] == ']') {
+      if (ip.size() >= 2 && ip.front() == '[' && ip.back() == ']') {
         ip = ip.substr(1, ip.size() - 2);
       }
       std::string ip_str(ip);

--- a/src/envoy/http/service_control/handler_utils_test.cc
+++ b/src/envoy/http/service_control/handler_utils_test.cc
@@ -489,6 +489,16 @@ TEST(TestExtractIPFromForwardedHeader, WrongIpv4) {
   EXPECT_FALSE(extractIPFromForwardedHeader(headers).ok());
 }
 
+TEST(TestExtractIPFromForwardedHeader, EmptyForToken) {
+  Envoy::Http::TestRequestHeaderMapImpl headers{{"forwarded", "for="}};
+  EXPECT_FALSE(extractIPFromForwardedHeader(headers).ok());
+}
+
+TEST(TestExtractIPFromForwardedHeader, EmptyQuotedForToken) {
+  Envoy::Http::TestRequestHeaderMapImpl headers{{"forwarded", "for=\"\""}};
+  EXPECT_FALSE(extractIPFromForwardedHeader(headers).ok());
+}
+
 TEST(TestExtractIPFromForwardedHeader, WrongIpv6) {
   Envoy::Http::TestRequestHeaderMapImpl headers{
       {"forwarded", "for=\"[fe80::1%]\""}};


### PR DESCRIPTION
When the `Forwarded` header arrives as `for=` (or `for=""`), `ip` becomes an empty `absl::string_view` and `ip[0]` / `ip[ip.size() - 1]` in handler_utils.cc:403-408 read out of bounds. Gate the unquote/unbracket steps on `ip.size() >= 2` so the strip only runs when there is something to strip.