### PR TITLE
guard long cast of numeric jwt claim in extractJwtPayload

### DIFF
--- a/src/envoy/http/service_control/handler_utils.cc
+++ b/src/envoy/http/service_control/handler_utils.cc
@@ -14,6 +14,8 @@
 
 #include "src/envoy/http/service_control/handler_utils.h"
 
+#include <cmath>
+#include <limits>
 #include <sstream>
 #include <vector>
 
@@ -114,11 +116,23 @@ void extractJwtPayload(const Envoy::ProtobufWkt::Value& value,
     case ::google::protobuf::Value::kNullValue:
       absl::StrAppend(&info_jwt_payloads, jwt_payload_path, "=;");
       return;
-    case ::google::protobuf::Value::kNumberValue:
-      absl::StrAppend(&info_jwt_payloads, jwt_payload_path, "=",
-                      std::to_string(static_cast<long>(value.number_value())),
-                      ";");
+    case ::google::protobuf::Value::kNumberValue: {
+      // The JWT number claim is parsed into a double. Casting to long is
+      // undefined when it is non-finite or outside long's range, so guard the
+      // narrowing (same as JsonStruct::getInteger) and render the raw value in
+      // that case.
+      const double number = value.number_value();
+      if (std::isfinite(number) &&
+          number >= static_cast<double>(std::numeric_limits<long>::min()) &&
+          number < 9223372036854775808.0 /* 2^63 */) {
+        absl::StrAppend(&info_jwt_payloads, jwt_payload_path, "=",
+                        std::to_string(static_cast<long>(number)), ";");
+      } else {
+        absl::StrAppend(&info_jwt_payloads, jwt_payload_path, "=",
+                        absl::StrCat(number), ";");
+      }
       return;
+    }
     case ::google::protobuf::Value::kBoolValue:
       absl::StrAppend(&info_jwt_payloads, jwt_payload_path, "=",
                       value.bool_value() ? "true" : "false", ";");


### PR DESCRIPTION
extractJwtPayload renders a numeric JWT claim via static_cast<long>(value.number_value()), but that cast is undefined when the claim is non-finite or outside long's range. A token whose logged number claim is e.g. 1e19 (> LONG_MAX) trips it; under UBSan: "1e+19 is outside the range of representable values of type 'long'". The number comes straight from the client JWT. Guard the narrowing the way JsonStruct::getInteger already does and render the raw value otherwise.