### PR TITLE
fix use-after-free in extractHeader for multi-value headers

### DIFF
--- a/src/envoy/utils/http_header_utils.cc
+++ b/src/envoy/utils/http_header_utils.cc
@@ -37,14 +37,17 @@ absl::string_view readHeaderEntry(const Envoy::Http::HeaderEntry* entry) {
   return Envoy::EMPTY_STRING;
 }
 
-absl::string_view extractHeader(const Envoy::Http::HeaderMap& headers,
-                                const Envoy::Http::LowerCaseString& header) {
+std::string extractHeader(const Envoy::Http::HeaderMap& headers,
+                          const Envoy::Http::LowerCaseString& header) {
   const auto result =
       Envoy::Http::HeaderUtility::getAllOfHeaderAsString(headers, header);
   if (!result.result().has_value()) {
     return Envoy::EMPTY_STRING;
   }
-  return result.result().value();
+  // When the header has multiple values, result().value() points into the
+  // local result's backing string, so it must be copied out before result
+  // goes out of scope.
+  return std::string(result.result().value());
 }
 
 bool handleHttpMethodOverride(Envoy::Http::RequestHeaderMap& headers) {

--- a/src/envoy/utils/http_header_utils.h
+++ b/src/envoy/utils/http_header_utils.h
@@ -31,8 +31,8 @@ absl::string_view readHeaderEntry(const Envoy::Http::HeaderEntry* entry);
 // better performance.
 // For details, see
 // https://github.com/envoyproxy/envoy/blob/c5f4302325223765b660f0f366ce25bf8570e7a5/include/envoy/http/header_map.h#L271
-absl::string_view extractHeader(const Envoy::Http::HeaderMap& headers,
-                                const Envoy::Http::LowerCaseString& header);
+std::string extractHeader(const Envoy::Http::HeaderMap& headers,
+                          const Envoy::Http::LowerCaseString& header);
 
 // Get the HTTP method to be used for the request. This method understands the
 // x-http-method-override header. If present, it will override the method


### PR DESCRIPTION
extractHeader returns a string_view into the local GetAllOfHeaderAsStringResult. For a header sent with more than one value, getAllOfHeaderAsString joins the values into that result's backing string, so the returned view dangles once extractHeader returns and the result is destroyed. The callers in handler_impl.cc copy attacker-controlled headers like x-android-cert through it, reading freed heap memory. Return std::string so the bytes are copied while the backing string is still alive.