### PR TITLE
change glibc version to 1.26.4

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -40,6 +40,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Try to match it with the one in source/extensions and comment out unneeded extensions.
 
 ENVOY_SHA1 = "349011c2ebd40f070510e34f4605bff1da64fb0e"  # v1.30.7
+
 ENVOY_SHA256 = "fee4d8c1005cac9a241e29d51a903b1b369515a8a77e5b7fe320520ae7c7b855"
 
 http_archive(

--- a/docker/Dockerfile-prow-env
+++ b/docker/Dockerfile-prow-env
@@ -51,7 +51,7 @@ ENV GOPATH /go
 ENV PATH /usr/local/go/bin:$PATH
 ENV PATH $GOPATH/bin:$PATH
 
-ENV GO_TARBALL "go1.26.3.linux-amd64.tar.gz"
+ENV GO_TARBALL "go1.26.4.linux-amd64.tar.gz"
 RUN wget -q "https://go.dev/dl/${GO_TARBALL}" && \
     tar xzf "${GO_TARBALL}" -C /usr/local && \
     rm "${GO_TARBALL}"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/esp-v2
 
-go 1.26.3
+go 1.26.4
 
 require (
 	cloud.google.com/go/storage v1.28.1

--- a/prow/gcpproxy-e2e.sh
+++ b/prow/gcpproxy-e2e.sh
@@ -20,8 +20,8 @@ set -eo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PROJECT_ID="api_proxy_e2e_test"
 
-# Install Go 1.26.3 to support go 1.26.3 in go.mod
-GO_VERSION="1.26.3"
+# Install Go 1.26.4 to support go 1.26.4 in go.mod
+GO_VERSION="1.26.4"
 GO_TARBALL="go${GO_VERSION}.linux-amd64.tar.gz"
 INSTALL_DIR="${ROOT}/test_go_env"
 


### PR DESCRIPTION
Bump up go version to 1.26.4 to address security updates.