### PR TITLE
Disable keepalive for local ADS cluster

### DIFF
--- a/src/go/bootstrap/ads/bootstrap.go
+++ b/src/go/bootstrap/ads/bootstrap.go
@@ -74,13 +74,14 @@ func CreateBootstrapConfig(opts options.AdsBootstrapperOptions) (string, error) 
 		StaticResources: &bootstrappb.Bootstrap_StaticResources{
 			Clusters: []*clusterpb.Cluster{
 				{
+					// Config Manager enforces grpc-go's default minimum interval for client keepalive pings.
 					Name:           opts.AdsNamedPipe,
 					LbPolicy:       clusterpb.Cluster_ROUND_ROBIN,
 					ConnectTimeout: connectTimeoutProto,
 					ClusterDiscoveryType: &clusterpb.Cluster_Type{
 						Type: clusterpb.Cluster_STATIC,
 					},
-					TypedExtensionProtocolOptions: util.CreateUpstreamProtocolOptions(),
+					TypedExtensionProtocolOptions: util.CreateUpstreamProtocolOptionsWithoutKeepalive(),
 					LoadAssignment:                util.CreateUdsLoadAssignment(opts.AdsNamedPipe),
 				},
 			},

--- a/src/go/bootstrap/ads/bootstrap_test.go
+++ b/src/go/bootstrap/ads/bootstrap_test.go
@@ -89,10 +89,6 @@ func TestCreateBootstrapConfig(t *testing.T) {
                   "@type":"type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
                   "explicitHttpConfig":{
                      "http2ProtocolOptions":{
-                       "connectionKeepalive":{
-                         "interval":"30s",
-                         "timeout":"10s"
-                       }
                      }
                   }
                }
@@ -190,10 +186,6 @@ func TestCreateBootstrapConfig(t *testing.T) {
                   "@type":"type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
                   "explicitHttpConfig":{
                      "http2ProtocolOptions":{
-                       "connectionKeepalive":{
-                         "interval":"30s",
-                         "timeout":"10s"
-                       }
                      }
                   }
                }

--- a/src/go/util/load_assignment.go
+++ b/src/go/util/load_assignment.go
@@ -31,15 +31,24 @@ const (
 
 // CreateUpstreamProtocolOptions creates a http2 protocol option as a typed upstream extension.
 func CreateUpstreamProtocolOptions() map[string]*anypb.Any {
+	return createUpstreamProtocolOptions(&corepb.KeepaliveSettings{
+		Interval: durationpb.New(Http2KeepaliveInterval),
+		Timeout:  durationpb.New(Http2KeepaliveTimeout),
+	})
+}
+
+// CreateUpstreamProtocolOptionsWithoutKeepalive creates HTTP/2 protocol options without connection keepalive.
+func CreateUpstreamProtocolOptionsWithoutKeepalive() map[string]*anypb.Any {
+	return createUpstreamProtocolOptions(nil)
+}
+
+func createUpstreamProtocolOptions(connectionKeepalive *corepb.KeepaliveSettings) map[string]*anypb.Any {
 	o := &httppb.HttpProtocolOptions{
 		UpstreamProtocolOptions: &httppb.HttpProtocolOptions_ExplicitHttpConfig_{
 			ExplicitHttpConfig: &httppb.HttpProtocolOptions_ExplicitHttpConfig{
 				ProtocolConfig: &httppb.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{
 					Http2ProtocolOptions: &corepb.Http2ProtocolOptions{
-						ConnectionKeepalive: &corepb.KeepaliveSettings{
-							Interval: durationpb.New(Http2KeepaliveInterval),
-							Timeout:  durationpb.New(Http2KeepaliveTimeout),
-						},
+						ConnectionKeepalive: connectionKeepalive,
 					},
 				},
 			},

--- a/src/go/util/load_assignment_test.go
+++ b/src/go/util/load_assignment_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
+)
+
+func TestCreateUpstreamProtocolOptionsIncludesKeepalive(t *testing.T) {
+	options, ok := CreateUpstreamProtocolOptions()[UpstreamProtocolOptions]
+	if !ok {
+		t.Fatalf("CreateUpstreamProtocolOptions() did not return %q", UpstreamProtocolOptions)
+	}
+
+	httpOptions := &httppb.HttpProtocolOptions{}
+	if err := options.UnmarshalTo(httpOptions); err != nil {
+		t.Fatalf("options.UnmarshalTo(%T) failed: %v", httpOptions, err)
+	}
+
+	keepalive := httpOptions.GetExplicitHttpConfig().GetHttp2ProtocolOptions().GetConnectionKeepalive()
+	if keepalive == nil {
+		t.Fatal("CreateUpstreamProtocolOptions() did not configure connection keepalive")
+	}
+	if got := keepalive.GetInterval().AsDuration(); got != Http2KeepaliveInterval {
+		t.Errorf("keepalive interval = %v, want %v", got, Http2KeepaliveInterval)
+	}
+	if got := keepalive.GetTimeout().AsDuration(); got != Http2KeepaliveTimeout {
+		t.Errorf("keepalive timeout = %v, want %v", got, Http2KeepaliveTimeout)
+	}
+}

--- a/src/go/util/load_assignment_test.go
+++ b/src/go/util/load_assignment_test.go
@@ -42,3 +42,23 @@ func TestCreateUpstreamProtocolOptionsIncludesKeepalive(t *testing.T) {
 		t.Errorf("keepalive timeout = %v, want %v", got, Http2KeepaliveTimeout)
 	}
 }
+
+func TestCreateUpstreamProtocolOptionsWithoutKeepalive(t *testing.T) {
+	options, ok := CreateUpstreamProtocolOptionsWithoutKeepalive()[UpstreamProtocolOptions]
+	if !ok {
+		t.Fatalf("CreateUpstreamProtocolOptionsWithoutKeepalive() did not return %q", UpstreamProtocolOptions)
+	}
+
+	httpOptions := &httppb.HttpProtocolOptions{}
+	if err := options.UnmarshalTo(httpOptions); err != nil {
+		t.Fatalf("options.UnmarshalTo(%T) failed: %v", httpOptions, err)
+	}
+
+	http2Options := httpOptions.GetExplicitHttpConfig().GetHttp2ProtocolOptions()
+	if http2Options == nil {
+		t.Fatal("CreateUpstreamProtocolOptionsWithoutKeepalive() did not configure HTTP/2")
+	}
+	if keepalive := http2Options.GetConnectionKeepalive(); keepalive != nil {
+		t.Errorf("connection keepalive = %v, want nil", keepalive)
+	}
+}


### PR DESCRIPTION
## Summary

Remove connection keepalive from the local ADS Unix socket cluster. Preserve HTTP/2 and connection keepalive for upstream backend clusters.

Config Manager uses the grpc-go default minimum interval of five minutes. Envoy sends keepalive pings every 30 seconds. The server closes the ADS stream after the client exceeds the allowed ping strikes.

This change stops the recurring ADS disconnects without changing backend keepalive behavior.

Fixes #1030.
Addresses #791.

## Tests

- `go test ./src/go/...`
- `go test -race -count=1 ./src/go/bootstrap/ads ./src/go/util`
- `go vet ./src/go/bootstrap/ads ./src/go/util`
- `goimports` on the changed Go files
- `misspell` v0.3.4 on the changed files

The repository's pinned macOS `misspell` binary exited with `SIGSEGV` on arm64. The same v0.3.4 source passed with the current Go toolchain.
